### PR TITLE
Crashlyticsをセットアップ

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -16,6 +16,7 @@ env:
   EXPORT_PATH: Build/app
   SPM_CLONE_PATH: SourcePackages
   SPM_PACKAGE_RESOLVED_FILE_PATH: homete.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+  IS_RELEASE: true
 
 jobs:
   deploy_app_store:

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Setup env for api key path
         run: echo "API_KEY_ABSOLUTE_PATH=$(pwd)/$API_KEY_PATH" >> $GITHUB_ENV
 
+      - name: Decode Firebase Api Key
+        run: echo "${{ secrets.FIREBASE_API_KEY_BASE64 }}" | base64 --decode > homete/GoogleService-Info.plist
+
       # Gemfileの依存ライブラリキャッシュ
       - name: cache bundle directory
         uses: actions/cache@v4.2.2

--- a/.github/workflows/cd_testFlight.yml
+++ b/.github/workflows/cd_testFlight.yml
@@ -74,9 +74,12 @@ jobs:
       - name: Cache Swift Packages
         uses: actions/cache@v4.2.2
         with:
-          path: SourcePackages
+          path: ${{ env.SPM_CLONE_PATH }}
           key: ${{ runner.os }}-spm-${{ hashFiles(env.SPM_PACKAGE_RESOLVED_FILE_PATH) }}
           restore-keys: ${{ runner.os }}-spm-
+
+      - name: Decode Firebase Api Key
+        run: echo "${{ secrets.FIREBASE_API_KEY_BASE64 }}" | base64 --decode > homete/GoogleService-Info.plist
 
       # ビルド番号更新
       - name: Increment build number
@@ -89,7 +92,7 @@ jobs:
           -project "${WORKSPACE_DIR}"
           -scheme "${BUILD_SCHEME}"
           -configuration Release
-          -clonedSourcePackagesDirPath SourcePackages
+          -clonedSourcePackagesDirPath "${SPM_CLONE_PATH}"
           -skipPackagePluginValidation
           -skipMacroValidation
           -scmProvider xcode
@@ -99,7 +102,7 @@ jobs:
       - name: Archive app
         run: set -o pipefail &&
           xcodebuild clean archive
-          -clonedSourcePackagesDirPath $SPM_CLONE_PATH
+          -clonedSourcePackagesDirPath "${SPM_CLONE_PATH}"
           -configuration Release
           -scheme "${BUILD_SCHEME}"
           -project "${WORKSPACE_DIR}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ env:
   WORKSPACE_DIR: homete.xcodeproj
   BUILD_SCHEME: homete
   TEST_PLAN: homete
+  SPM_CLONE_PATH: SourcePackages
+  SPM_PACKAGE_RESOLVED_FILE_PATH: homete.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
 
 jobs:
   build:
@@ -52,14 +54,24 @@ jobs:
       - name: Show Xcode version
         run: xcodebuild -version
 
-      # ビルド
+      # SPMのライブラリのキャッシュ
+      - name: Cache Swift Packages
+        uses: actions/cache@v4.2.2
+        with:
+          path: SourcePackages
+          key: v1-dev-${{ runner.os }}-spm-${{ hashFiles(env.SPM_PACKAGE_RESOLVED_FILE_PATH) }}
+          restore-keys: v1-dev-${{ runner.os }}-spm-
+
+      - name: Decode Firebase Api Key
+        run: echo "${{ secrets.DEV_FIREBASE_API_KEY_BASE64 }}" | base64 --decode > homete/GoogleService-Info-dev.plist
+
       - name: Xcode Resolve Package Dependencies
         run: set -o pipefail &&
           xcodebuild
           -project "${WORKSPACE_DIR}"
           -scheme "${BUILD_SCHEME}"
           -configuration Debug
-          -clonedSourcePackagesDirPath SourcePackages
+          -clonedSourcePackagesDirPath "${SPM_CLONE_PATH}"
           -skipPackagePluginValidation
           -skipMacroValidation
           -scmProvider xcode
@@ -77,7 +89,7 @@ jobs:
           -skipPackagePluginValidation
           -skipMacroValidation
           -scmProvider xcode
-          -clonedSourcePackagesDirPath SourcePackages
+          -clonedSourcePackagesDirPath "${SPM_CLONE_PATH}"
           clean test |
           xcbeautify --renderer github-actions
 

--- a/.gitignore
+++ b/.gitignore
@@ -68,7 +68,8 @@ fastlane/test_output
 # secret
 
 private_keys/
-GoogleService-Info*.plist
+GoogleService-Info.plist
+GoogleService-Info-dev.plist
 
 # other
 

--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ fastlane/test_output
 # secret
 
 private_keys/
+GoogleService-Info*.plist
 
 # other
 

--- a/homete.xcodeproj/project.pbxproj
+++ b/homete.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BC7469472DBCBE71007E4222 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BC7469462DBCBE71007E4222 /* PrivacyInfo.xcprivacy */; };
+		BCB8DAFE2E36FC7200FFB4E1 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = BCB8DAFD2E36FC7200FFB4E1 /* FirebaseAnalytics */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BCB8DAFE2E36FC7200FFB4E1 /* FirebaseAnalytics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,6 +122,7 @@
 			);
 			name = homete;
 			packageProductDependencies = (
+				BCB8DAFD2E36FC7200FFB4E1 /* FirebaseAnalytics */,
 			);
 			productName = homete;
 			productReference = BCC853F52DB74BBC00C9A44B /* homete.app */;
@@ -203,6 +206,9 @@
 			);
 			mainGroup = BCC853EC2DB74BBC00C9A44B;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				BCB8DAFC2E36FC7100FFB4E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = BCC853F62DB74BBC00C9A44B /* Products */;
 			projectDirPath = "";
@@ -424,7 +430,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0.0;
-				PRODUCT_BUNDLE_IDENTIFIER = taichi.satou.hometekure;
+				PRODUCT_BUNDLE_IDENTIFIER = taichi.satou.hometekure.dev;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -591,6 +597,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		BCB8DAFC2E36FC7100FFB4E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
+			requirement = {
+				kind = exactVersion;
+				version = 12.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		BCB8DAFD2E36FC7200FFB4E1 /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCB8DAFC2E36FC7100FFB4E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = BCC853ED2DB74BBC00C9A44B /* Project object */;
 }

--- a/homete.xcodeproj/project.pbxproj
+++ b/homete.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		BC7469472DBCBE71007E4222 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BC7469462DBCBE71007E4222 /* PrivacyInfo.xcprivacy */; };
 		BCB8DAFE2E36FC7200FFB4E1 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = BCB8DAFD2E36FC7200FFB4E1 /* FirebaseAnalytics */; };
+		BCB8DB182E37B3F900FFB4E1 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = BCB8DB172E37B3F900FFB4E1 /* FirebaseCrashlytics */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +61,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BCB8DAFE2E36FC7200FFB4E1 /* FirebaseAnalytics in Frameworks */,
+				BCB8DB182E37B3F900FFB4E1 /* FirebaseCrashlytics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -80,6 +82,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		BCB8DB162E37B3F900FFB4E1 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		BCC853EC2DB74BBC00C9A44B = {
 			isa = PBXGroup;
 			children = (
@@ -88,6 +97,7 @@
 				BCC853F72DB74BBC00C9A44B /* homete */,
 				BCC854052DB74BBF00C9A44B /* hometeTests */,
 				BCC8540F2DB74BBF00C9A44B /* hometeUITests */,
+				BCB8DB162E37B3F900FFB4E1 /* Frameworks */,
 				BCC853F62DB74BBC00C9A44B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -112,6 +122,7 @@
 				BCC853F12DB74BBC00C9A44B /* Sources */,
 				BCC853F22DB74BBC00C9A44B /* Frameworks */,
 				BCC853F32DB74BBC00C9A44B /* Resources */,
+				BCB8DB192E37B43600FFB4E1 /* Run Upload dSYM */,
 			);
 			buildRules = (
 			);
@@ -123,6 +134,7 @@
 			name = homete;
 			packageProductDependencies = (
 				BCB8DAFD2E36FC7200FFB4E1 /* FirebaseAnalytics */,
+				BCB8DB172E37B3F900FFB4E1 /* FirebaseCrashlytics */,
 			);
 			productName = homete;
 			productReference = BCC853F52DB74BBC00C9A44B /* homete.app */;
@@ -245,6 +257,33 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		BCB8DB192E37B43600FFB4E1 /* Run Upload dSYM */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Info.plist",
+				"$(TARGET_BUILD_DIR)/$(UNLOCALIZED_RESOURCES_FOLDER_PATH)/GoogleService-Info.plist",
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${PRODUCT_NAME}.debug.dylib",
+			);
+			name = "Run Upload dSYM";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Type a script or drag a script file from your workspace to insert its path.\nif [ \"$CONFIGURATION\" != \"Debug\" ] && [ \"$IS_RELEASE\" ]; then\n    \"${BUILD_DIR%/Build/*}/SourcePackages/checkouts/firebase-ios-sdk/Crashlytics/run\"\nelse\n    echo \"do not upload dsym.\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		BCC853F12DB74BBC00C9A44B /* Sources */ = {
@@ -614,6 +653,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BCB8DAFC2E36FC7100FFB4E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalytics;
+		};
+		BCB8DB172E37B3F900FFB4E1 /* FirebaseCrashlytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCB8DAFC2E36FC7100FFB4E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseCrashlytics;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/homete.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/homete.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,132 @@
+{
+  "originHash" : "a1569f9895aa2be8e24832f98525d5da4eb90b5d158a82691c15b47eb72a13d7",
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk.git",
+      "state" : {
+        "revision" : "4e62da1e5e6baf61674d3f5ae23d6d60c19f9c4a",
+        "version" : "12.0.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "428d8bb138e00f9a3f4f61cc6cd8863607524f65",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "63c18311aac00032f15f5ce431c9e83ada96c386",
+        "version" : "12.0.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "cc0001a0cf963aa40501d9c2b181e7fc9fd8ec71",
+        "version" : "1.69.0"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "fb7f2740b1570d2f7599c6bb9531bf4fad6974b7",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "102a647b573f60f73afdce5613a51d71349fe507",
+        "version" : "1.30.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/homete/hometeApp.swift
+++ b/homete/hometeApp.swift
@@ -6,9 +6,22 @@
 //
 
 import SwiftUI
+import FirebaseCore
+
+final class AppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _ application: UIApplication,
+        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
+    ) -> Bool {
+        
+        FirebaseApp.configure()
+        return true
+    }
+}
 
 @main
 struct hometeApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/homete/hometeApp.swift
+++ b/homete/hometeApp.swift
@@ -14,7 +14,13 @@ final class AppDelegate: NSObject, UIApplicationDelegate {
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil
     ) -> Bool {
         
+        #if DEBUG
+        let devPlistFilePath = (Bundle.main.url(forResource: "GoogleService-Info-dev", withExtension: "plist")?.path())!
+        FirebaseApp.configure(options: .init(contentsOfFile: devPlistFilePath)!)
+        #else
         FirebaseApp.configure()
+        #endif
+        
         return true
     }
 }


### PR DESCRIPTION
## 経緯

<!-- PRを作成するに至った経緯や関連のIssueのリンクを記載する -->
関連Issue: #6 
本番でクラッシュが発生した時に、スムーズにデバッグするために、Crashlyticsでデバッグ情報を監視できるようにする。

## 実装内容

<!-- なぜそのような実装を行なったかがわかるように、理由に重きを置いて記載する -->
基本的に本番環境のクラッシュ情報だけが欲しいので、リリース時にCrashlytics用のdSYMをアップロードするようにRun Scriptを追加しています。

## 確認内容

<!-- 修正した内容が正しく動作していることを確認する方法とその内容を記載する -->
- [x] ビルドできること
