### PR TITLE
リリースノート自動生成のワークフローを追加

### DIFF
--- a/.github/release-drafter.yaml
+++ b/.github/release-drafter.yaml
@@ -1,0 +1,32 @@
+name-template: "v$RESOLVED_VERSION"
+tag-template: "v$RESOLVED_VERSION"
+categories:
+  - title: "🎉 リリース"
+    labels:
+      - "release"
+  - title: "🚀 機能追加"
+    labels:
+      - "feature"
+  - title: "🐛 バグ修正"
+    labels:
+      - "bug"
+  - title: "📝 その他"
+exclude-labels:
+  - "ignore-for-release-note"
+change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - "major"
+  minor:
+    labels:
+      - "minor"
+  default: patch
+template: |
+  $CHANGES
+footer: |
+
+  ## 🌱 すべての変更点
+
+  https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/create-release-note.yaml
+++ b/.github/workflows/create-release-note.yaml
@@ -1,0 +1,19 @@
+name: Create Release Note
+on:
+  push:
+    branches: [main]
+jobs:
+  release-draft:
+    permissions:
+      contents: write
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yaml
+          commitish: main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 経緯

<!-- PRを作成するに至った経緯や関連のIssueのリンクを記載する -->
自動でリリースノートを作れると、今後このバージョンで何をやっているのかなどサッとわかりやすくなると思ったので本PRで自動化のためのワークフローを追加しました。

## 実装内容

<!-- なぜそのような実装を行なったかがわかるように、理由に重きを置いて記載する -->
リリースノート自動生成を以下Github Actionsを用いて実装しました。

https://github.com/release-drafter/release-drafter

## 確認内容

<!-- 修正した内容が正しく動作していることを確認する方法とその内容を記載する -->
なし
