### PR TITLE
【ログイン画面実装】ログイン後にアカウント情報を登録する処理を追加

### DIFF
--- a/homete.xcodeproj/project.pbxproj
+++ b/homete.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		BC2E372C2E3DE189005BD910 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = BC2E372B2E3DE189005BD910 /* FirebaseAuth */; };
+		BC47E6A62E47240F00308562 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = BC47E6A52E47240F00308562 /* FirebaseFirestore */; };
 		BC7469472DBCBE71007E4222 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = BC7469462DBCBE71007E4222 /* PrivacyInfo.xcprivacy */; };
 		BCB8DAFE2E36FC7200FFB4E1 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = BCB8DAFD2E36FC7200FFB4E1 /* FirebaseAnalytics */; };
 		BCB8DB182E37B3F900FFB4E1 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = BCB8DB172E37B3F900FFB4E1 /* FirebaseCrashlytics */; };
@@ -62,6 +63,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BCB8DAFE2E36FC7200FFB4E1 /* FirebaseAnalytics in Frameworks */,
+				BC47E6A62E47240F00308562 /* FirebaseFirestore in Frameworks */,
 				BC2E372C2E3DE189005BD910 /* FirebaseAuth in Frameworks */,
 				BCB8DB182E37B3F900FFB4E1 /* FirebaseCrashlytics in Frameworks */,
 			);
@@ -138,6 +140,7 @@
 				BCB8DAFD2E36FC7200FFB4E1 /* FirebaseAnalytics */,
 				BCB8DB172E37B3F900FFB4E1 /* FirebaseCrashlytics */,
 				BC2E372B2E3DE189005BD910 /* FirebaseAuth */,
+				BC47E6A52E47240F00308562 /* FirebaseFirestore */,
 			);
 			productName = homete;
 			productReference = BCC853F52DB74BBC00C9A44B /* homete.app */;
@@ -671,6 +674,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = BCB8DAFC2E36FC7100FFB4E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAuth;
+		};
+		BC47E6A52E47240F00308562 /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = BCB8DAFC2E36FC7100FFB4E1 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
 		};
 		BCB8DAFD2E36FC7200FFB4E1 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/homete/Model/AppDependencies.swift
+++ b/homete/Model/AppDependencies.swift
@@ -9,18 +9,21 @@ import SwiftUI
 
 struct AppDependencies {
     let nonceGeneratorClient: NonceGenerationClient
-    let accountClient: AccountClient
+    let accountAuthClient: AccountAuthClient
     let analyticsClient: AnalyticsClient
+    let accountInfoClient: AccountInfoClient
     
     init(
         nonceGeneratorClient: NonceGenerationClient = .previewValue,
-        accountClient: AccountClient = .previewValue,
-        analyticsClient: AnalyticsClient = .previewValue
+        accountAuthClient: AccountAuthClient = .previewValue,
+        analyticsClient: AnalyticsClient = .previewValue,
+        accountInfoClient: AccountInfoClient = .previewValue
     ) {
         
         self.nonceGeneratorClient = nonceGeneratorClient
-        self.accountClient = accountClient
+        self.accountAuthClient = accountAuthClient
         self.analyticsClient = analyticsClient
+        self.accountInfoClient = accountInfoClient
     }
 }
 
@@ -28,8 +31,9 @@ extension EnvironmentValues {
     
     @Entry var appDependencies: AppDependencies = .init(
         nonceGeneratorClient: .liveValue,
-        accountClient: .liveValue,
-        analyticsClient: .liveValue
+        accountAuthClient: .liveValue,
+        analyticsClient: .liveValue,
+        accountInfoClient: .liveValue
     )
 }
 

--- a/homete/Model/Dependencies/AccountInfoClient.swift
+++ b/homete/Model/Dependencies/AccountInfoClient.swift
@@ -1,0 +1,36 @@
+//
+//  AccountInfoClient.swift
+//  homete
+//
+//  Created by 佐藤汰一 on 2025/08/09.
+//
+
+import FirebaseFirestore
+
+struct AccountInfoClient {
+    
+    let insertOrUpdate: @Sendable (Account) async throws -> Void
+    let fetch: @Sendable (String) async throws -> Account?
+}
+
+extension AccountInfoClient: DependencyClient {
+    
+    static let collectionPath = "Account"
+    static let primaryKey = "id"
+    
+    static let liveValue: AccountInfoClient = .init { account in
+        
+        try Firestore.firestore().collection(collectionPath).document(account.id).setData(from: account)
+    } fetch: { id in
+        
+        let snapshots = try await Firestore.firestore()
+            .collection(collectionPath)
+            .whereField(primaryKey, isEqualTo: id)
+            .getDocuments()
+        return try snapshots.documents.first?.data(as: Account.self)
+    }
+    
+    
+    static let previewValue: AccountInfoClient = .init(insertOrUpdate: { _ in },
+                                                       fetch: { _ in .init(id: "", displayName: "") })
+}

--- a/homete/Model/Domain/Account/Account.swift
+++ b/homete/Model/Domain/Account/Account.swift
@@ -5,8 +5,18 @@
 //  Created by 佐藤汰一 on 2025/08/03.
 //
 
-struct Account {
+struct Account: Equatable, Codable {
     
     let id: String
-    let displayName: String?
+    let displayName: String
+}
+
+extension Account {
+    
+    static let empty: Self = .init(id: "", displayName: "")
+    
+    static func initial(_ auth: AccountAuthResult) -> Self {
+        
+        return .init(id: auth.id, displayName: auth.displayName ?? "未設定")
+    }
 }

--- a/homete/Model/Domain/Account/AccountAuthResult.swift
+++ b/homete/Model/Domain/Account/AccountAuthResult.swift
@@ -1,0 +1,12 @@
+//
+//  AccountAuthResult.swift
+//  homete
+//
+//  Created by 佐藤汰一 on 2025/08/09.
+//
+
+struct AccountAuthResult: Equatable {
+    
+    let id: String
+    let displayName: String?
+}

--- a/homete/Model/Domain/Account/AccountListenerStream.swift
+++ b/homete/Model/Domain/Account/AccountListenerStream.swift
@@ -9,13 +9,13 @@ import Foundation
 
 struct AccountListenerStream {
     
-    let values: AsyncStream<Account?>
+    let values: AsyncStream<AccountAuthResult?>
     let listenerToken: any NSObjectProtocol
-    private let continuation: AsyncStream<Account?>.Continuation
+    private let continuation: AsyncStream<AccountAuthResult?>.Continuation
     
-    init(values: AsyncStream<Account?>,
+    init(values: AsyncStream<AccountAuthResult?>,
          listenerToken: any NSObjectProtocol,
-         continuation: AsyncStream<Account?>.Continuation) {
+         continuation: AsyncStream<AccountAuthResult?>.Continuation) {
         
         self.values = values
         self.listenerToken = listenerToken

--- a/homete/Model/Domain/AnalyticsLog/AnalyticsEvent.swift
+++ b/homete/Model/Domain/AnalyticsLog/AnalyticsEvent.swift
@@ -20,4 +20,12 @@ extension AnalyticsEvent {
             parameters: ["isSuccess": "\(isSuccess)"]
         )
     }
+    
+    static func logout() -> Self {
+        
+        return .init(
+            name: "logout",
+            parameters: [:]
+        )
+    }
 }

--- a/homete/Model/Service/Firestore/FirestoreService.swift
+++ b/homete/Model/Service/Firestore/FirestoreService.swift
@@ -1,0 +1,27 @@
+//
+//  FirestoreService.swift
+//  homete
+//
+//  Created by 佐藤汰一 on 2025/08/09.
+//
+
+import FirebaseFirestore
+
+final actor FirestoreService {
+    
+    static let shared = FirestoreService()
+    private let db = Firestore.firestore()
+    
+    func fetch<T: Decodable>(predicate: (Firestore) -> Query) async throws -> [T] {
+        
+        return try await predicate(db)
+            .getDocuments()
+            .documents
+            .map { try $0.data(as: T.self) }
+    }
+    
+    func insertOrUpdate<T: Encodable>(data: T, predicate: (Firestore) -> DocumentReference) throws {
+        
+        try predicate(db).setData(from: data, merge: true)
+    }
+}

--- a/homete/Model/Store/AccountAuthStore.swift
+++ b/homete/Model/Store/AccountAuthStore.swift
@@ -1,0 +1,59 @@
+//
+//  AccountAuthStore.swift
+//  homete
+//
+//  Created by 佐藤汰一 on 2025/08/09.
+//
+
+import SwiftUI
+
+@MainActor
+@Observable
+final class AccountAuthStore {
+    
+    var auth: AccountAuthResult?
+    var isLogin: Bool { auth != nil }
+    
+    private let accountAuthClient: AccountAuthClient
+    private let analyticsClient: AnalyticsClient
+    private let listener: AccountListenerStream
+    
+    init(appDependencies: AppDependencies) {
+        
+        accountAuthClient = appDependencies.accountAuthClient
+        analyticsClient = appDependencies.analyticsClient
+        listener = accountAuthClient.makeListener()
+        
+        Task {
+            
+            await listen()
+        }
+    }
+    
+    func login(_ signInResult: SignInWithAppleResult) async throws {
+        
+        do {
+            
+            let authInfo = try await accountAuthClient.signIn(signInResult.tokenId, signInResult.nonce)
+            
+            analyticsClient.setId(authInfo.id)
+            analyticsClient.log(.login(isSuccess: true))
+        }
+        catch {
+            
+            analyticsClient.log(.login(isSuccess: false))
+            throw error
+        }
+    }
+}
+
+private extension AccountAuthStore {
+    
+    func listen() async {
+        
+        for await value in listener.values {
+            
+            auth = value
+        }
+    }
+}

--- a/homete/Model/Store/AccountStore.swift
+++ b/homete/Model/Store/AccountStore.swift
@@ -10,52 +10,51 @@ import SwiftUI
 @MainActor
 @Observable
 final class AccountStore {
-    var account: Account?
     
-    private let accountClient: AccountClient
+    var account: Account = .empty
+    var isLoadingInfo: Bool { account == .empty }
+        
+    private let accountAuthClient: AccountAuthClient
+    private let accountInfoClient: AccountInfoClient
     private let analyticsClient: AnalyticsClient
-    private let listener: AccountListenerStream
     
     init(appDependencies: AppDependencies) {
         
-        accountClient = appDependencies.accountClient
+        accountAuthClient = appDependencies.accountAuthClient
+        accountInfoClient = appDependencies.accountInfoClient
         analyticsClient = appDependencies.analyticsClient
-        listener = accountClient.makeListener()
-        
-        Task {
-            
-            await listen()
-        }
     }
     
-    func login(_ signInResult: SignInWithAppleResult) async throws {
+    func setAccount(_ auth: AccountAuthResult) async {
         
         do {
             
-            let account = try await accountClient.signIn(signInResult.tokenId, signInResult.nonce)
-            analyticsClient.setId(account.id)
-            analyticsClient.log(.login(isSuccess: true))
+            if let account = try await accountInfoClient.fetch(auth.id) {
+                
+                self.account = account
+                return
+            }
+            
+            let newAccount = Account.initial(auth)
+            try await accountInfoClient.insertOrUpdate(newAccount)
+            account = newAccount
         }
         catch {
             
-            analyticsClient.log(.login(isSuccess: false))
-            throw error
+            print("failed to fetch account info: \(error)")
         }
     }
-}
-
-private extension AccountStore {
     
-    func listen() async {
+    func logOut() {
         
-        for await value in listener.values {
+        do {
             
-            account = value
+            try accountAuthClient.signOut()
+            analyticsClient.log(.logout())
+        }
+        catch {
+            
+            print("occurred error: \(error)")
         }
     }
-}
-
-extension EnvironmentValues {
-    
-    @Entry var accountStore: AccountStore?
 }

--- a/homete/Model/Store/AccountStore.swift
+++ b/homete/Model/Store/AccountStore.swift
@@ -12,7 +12,6 @@ import SwiftUI
 final class AccountStore {
     
     var account: Account = .empty
-    var isLoadingInfo: Bool { account == .empty }
         
     private let accountAuthClient: AccountAuthClient
     private let accountInfoClient: AccountInfoClient
@@ -25,7 +24,7 @@ final class AccountStore {
         analyticsClient = appDependencies.analyticsClient
     }
     
-    func setAccount(_ auth: AccountAuthResult) async {
+    func setAccountOnLogin(_ auth: AccountAuthResult) async {
         
         do {
             

--- a/homete/Resouces/Colors.xcassets/loadingBg.colorset/Contents.json
+++ b/homete/Resouces/Colors.xcassets/loadingBg.colorset/Contents.json
@@ -4,7 +4,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.500",
+          "alpha" : "0.300",
           "blue" : "255",
           "green" : "255",
           "red" : "255"
@@ -22,7 +22,7 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "0.500",
+          "alpha" : "0.300",
           "blue" : "255",
           "green" : "255",
           "red" : "255"

--- a/homete/Resouces/Localizable.xcstrings
+++ b/homete/Resouces/Localizable.xcstrings
@@ -4,9 +4,6 @@
     "Debug" : {
 
     },
-    "Hello, world! %lld" : {
-
-    },
     "Homete" : {
       "localizations" : {
         "ja" : {
@@ -19,6 +16,16 @@
     },
     "LogOut" : {
 
+    },
+    "Name: %@: %lld" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Name: %1$@: %2$lld"
+          }
+        }
+      }
     },
     "OK" : {
 

--- a/homete/Views/ContentView.swift
+++ b/homete/Views/ContentView.swift
@@ -30,9 +30,8 @@ struct ContentView: View {
             }
             .padding()
             LoadingIndicator()
-                .opacity(accountStore.isLoadingInfo ? 1 : 0)
+                .opacity(accountStore.account == .empty ? 1 : 0)
         }
-        
     }
 }
 

--- a/homete/Views/ContentView.swift
+++ b/homete/Views/ContentView.swift
@@ -11,28 +11,28 @@ import SwiftUI
 struct ContentView: View {
     
     @Environment(\.rootNavigationPath) var rootNavigationPath
-    @Environment(\.appDependencies.accountClient) var accountClient
+    @Environment(AccountStore.self) var accountStore
     
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world! \(rootNavigationPath.path.count)")
-            Button("Debug") {
-                rootNavigationPath.showContent()
-            }
-            Button("LogOut") {
-                do {
-                    try accountClient.signOut()
+        ZStack {
+            VStack {
+                Image(systemName: "globe")
+                    .imageScale(.large)
+                    .foregroundStyle(.tint)
+                Text("Name: \(accountStore.account.displayName): \(rootNavigationPath.path.count)")
+                Button("Debug") {
+                    rootNavigationPath.showContent()
                 }
-                catch {
-                    print("error: \(error)")
+                Button("LogOut") {
+                    accountStore.logOut()
                 }
+                Spacer()
             }
-            Spacer()
+            .padding()
+            LoadingIndicator()
+                .opacity(accountStore.isLoadingInfo ? 1 : 0)
         }
-        .padding()
+        
     }
 }
 

--- a/homete/Views/LoginView/LoginView.swift
+++ b/homete/Views/LoginView/LoginView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct LoginView: View {
     
-    @Environment(\.accountStore) var accountStore
+    var accountAuthStore: AccountAuthStore
     @State var isPresentedErrorAlert = false
     @State var domainError: DomainError?
     @State var isLoading = false
@@ -52,7 +52,7 @@ private extension LoginView {
         case .success(let success):
             do {
                 
-                try await accountStore?.login(success)
+                try await accountAuthStore.login(success)
             }
             catch {
                 
@@ -72,9 +72,8 @@ private extension LoginView {
 
 #Preview {
     NavigationStack {
-        LoginView()
+        LoginView(accountAuthStore: .init(appDependencies: .previewValue))
             .navigationTitle("Homete")
             .navigationBarTitleDisplayMode(.inline)
     }
-    .environment(\.appDependencies, .previewValue)
 }

--- a/homete/Views/RootView/RootView.swift
+++ b/homete/Views/RootView/RootView.swift
@@ -8,21 +8,29 @@
 import SwiftUI
 
 struct RootView: View {
-    @Environment(\.accountStore) var accountStore
+    @Environment(\.appDependencies) var appDependencies
     @State var navigationPath = CustomNavigationPath(path: [RootNavigationPath]())
+    
+    var accountAuthStore: AccountAuthStore
+    var accountStore: AccountStore
     
     var body: some View {
         NavigationStack(path: $navigationPath.path) {
-            if accountStore?.account == nil {
-                LoginView()
-                    .navigationTitle("Homete")
-                    .navigationBarTitleDisplayMode(.inline)
-            }
-            else {
+            if accountAuthStore.isLogin,
+               let auth = accountAuthStore.auth {
                 ContentView()
                     .navigationDestination(for: RootNavigationPath.self) { path in
                         path.Destination()
                     }
+                    .environment(accountStore)
+                    .task {
+                        await accountStore.setAccount(auth)
+                    }
+            }
+            else {
+                LoginView(accountAuthStore: accountAuthStore)
+                    .navigationTitle("Homete")
+                    .navigationBarTitleDisplayMode(.inline)
             }
         }
         .environment(\.rootNavigationPath, navigationPath)
@@ -30,5 +38,8 @@ struct RootView: View {
 }
 
 #Preview {
-    RootView()
+    RootView(
+        accountAuthStore: .init(appDependencies: .previewValue),
+        accountStore: .init(appDependencies: .previewValue)
+    )
 }

--- a/homete/Views/RootView/RootView.swift
+++ b/homete/Views/RootView/RootView.swift
@@ -24,7 +24,7 @@ struct RootView: View {
                     }
                     .environment(accountStore)
                     .task {
-                        await accountStore.setAccount(auth)
+                        await accountStore.setAccountOnLogin(auth)
                     }
             }
             else {

--- a/homete/Views/hometeApp.swift
+++ b/homete/Views/hometeApp.swift
@@ -33,8 +33,10 @@ struct hometeApp: App {
     
     var body: some Scene {
         WindowGroup {
-            RootView()
-                .environment(\.accountStore, .init(appDependencies: appDependencies))
+            RootView(
+                accountAuthStore: .init(appDependencies: appDependencies),
+                accountStore: .init(appDependencies: appDependencies)
+            )
         }
     }
 }

--- a/hometeTests/Store/AccountAuthStoreTest.swift
+++ b/hometeTests/Store/AccountAuthStoreTest.swift
@@ -1,0 +1,51 @@
+//
+//  AccountAuthStoreTest.swift
+//  hometeTests
+//
+//  Created by 佐藤汰一 on 2025/08/09.
+//
+
+import Testing
+@testable import homete
+
+@MainActor
+struct AccountAuthStoreTest {
+
+    @Test("ログイン処理ではサーバー側でサインイン後、成功したらログを送信する")
+    func test_login() async throws {
+        
+        let inputTokenId = "testId"
+        let inputNonce = "testNonce"
+        let outputAccount = AccountAuthResult(id: "testAccountId", displayName: "testDisplayName")
+        
+        try await confirmation(expectedCount: 4) { confirmation in
+            
+            let store = AccountAuthStore(appDependencies: .init(
+                accountAuthClient: .init(signIn: { tokenId, nonce in
+                    
+                    confirmation()
+                    #expect(tokenId == inputTokenId)
+                    #expect(nonce == inputNonce)
+                    return outputAccount
+                },
+                                     signOut: { confirmation() },
+                                     makeListener: {
+                                         
+                                         confirmation()
+                                         return .defaultValue()
+                                     }),
+                analyticsClient: .init(setId: { id in
+                    
+                    confirmation()
+                    #expect(id == outputAccount.id)
+                }, log: { event in
+                    
+                    confirmation()
+                    #expect(event == .login(isSuccess: true))
+                })
+            ))
+            
+            try await store.login(.init(tokenId: inputTokenId, nonce: inputNonce))
+        }
+    }
+}

--- a/hometeTests/Store/AccountStoreTest.swift
+++ b/hometeTests/Store/AccountStoreTest.swift
@@ -9,19 +9,19 @@ import Testing
 @testable import homete
 
 @MainActor
-struct AccountStoreTest {
+struct AccountAuthStoreTest {
 
     @Test("ログイン処理ではサーバー側でサインイン後、成功したらログを送信する")
     func test_login() async throws {
         
         let inputTokenId = "testId"
         let inputNonce = "testNonce"
-        let outputAccount = Account(id: "testAccountId", displayName: "testDisplayName")
+        let outputAccount = AccountAuthResult(id: "testAccountId", displayName: "testDisplayName")
         
         try await confirmation(expectedCount: 4) { confirmation in
             
-            let store = AccountStore(appDependencies: .init(
-                accountClient: .init(signIn: { tokenId, nonce in
+            let store = AccountAuthStore(appDependencies: .init(
+                accountAuthClient: .init(signIn: { tokenId, nonce in
                     
                     confirmation()
                     #expect(tokenId == inputTokenId)

--- a/hometeTests/TestHelper/AccountListenerStreamCreater.swift
+++ b/hometeTests/TestHelper/AccountListenerStreamCreater.swift
@@ -12,7 +12,7 @@ extension AccountListenerStream {
     
     static func defaultValue() -> Self {
         
-        let (stream, continuation) = AsyncStream<Account?>.makeStream()
+        let (stream, continuation) = AsyncStream<AccountAuthResult?>.makeStream()
         return .init(values: stream, listenerToken: NSObject(), continuation: continuation)
     }
 }


### PR DESCRIPTION
## 経緯

<!-- PRを作成するに至った経緯や関連のIssueのリンクを記載する -->
関連Issue: #11 
ログイン画面の実装にあたって、 #18 をベースにログイン後にアカウント情報を登録する処理を追加しました。

## 実装内容

<!-- なぜそのような実装を行なったかがわかるように、理由に重きを置いて記載する -->
アカウントごとの情報を今後別アカウントや別端末から参照できるように、Firestoreへ登録します。

## 確認内容

<!-- 修正した内容が正しく動作していることを確認する方法とその内容を記載する -->
- [x] ログイン時にFirestoreのアカウント情報が登録されていること
