### PR TITLE
【ログイン画面実装】リリース用にSignInWithAppleのセットアップ

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -87,13 +87,35 @@ platform :ios do
     )
   end
 
-  desc "指定されたipaでTestFlight配信を行う"
+  desc "本番用のプロビジョニングプロファイルを更新"
+  lane :update_profile_prod do |options|
+    api_key = generate_api_key
+    match(
+      api_key: api_key,
+      app_identifier: "taichi.satou.hometekure",
+      type: "appstore",
+      force: true
+    )
+  end
+
+  desc "開発用のプロビジョニングプロファイルをインストール"
   lane :install_dev_profile do |options|
     api_key = generate_api_key
     match(
       api_key: api_key,
       app_identifier: "taichi.satou.hometekure.dev",
       type: "development",
+      readonly: true
+    )
+  end
+
+  desc "本番用のプロビジョニングプロファイルをインストール"
+  lane :install_prod_profile do |options|
+    api_key = generate_api_key
+    match(
+      api_key: api_key,
+      app_identifier: "taichi.satou.hometekure",
+      type: "appstore",
       readonly: true
     )
   end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,13 +47,29 @@ ipaを生成
 
 指定されたipaでTestFlight配信を行う
 
+### ios update_profile_prod
+
+```sh
+[bundle exec] fastlane ios update_profile_prod
+```
+
+本番用のプロビジョニングプロファイルを更新
+
 ### ios install_dev_profile
 
 ```sh
 [bundle exec] fastlane ios install_dev_profile
 ```
 
-指定されたipaでTestFlight配信を行う
+開発用のプロビジョニングプロファイルをインストール
+
+### ios install_prod_profile
+
+```sh
+[bundle exec] fastlane ios install_prod_profile
+```
+
+本番用のプロビジョニングプロファイルをインストール
 
 ----
 

--- a/homete.xcodeproj/project.pbxproj
+++ b/homete.xcodeproj/project.pbxproj
@@ -504,6 +504,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = homete/hometeRelease.entitlements;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Distribution";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;

--- a/homete/hometeRelease.entitlements
+++ b/homete/hometeRelease.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 経緯

<!-- PRを作成するに至った経緯や関連のIssueのリンクを記載する -->
関連Issue: #11 
リリース用にSignInWithAppleのセットアップを行いました。

## 実装内容

<!-- なぜそのような実装を行なったかがわかるように、理由に重きを置いて記載する -->
リリース用のビルドでもSignInWithAppleが使えるようにFirebaseの設定とXcodeのcapabilityの設定を行いました。

## 確認内容

<!-- 修正した内容が正しく動作していることを確認する方法とその内容を記載する -->
