### PR TITLE
設定画面をナビゲーションバーから遷移するようにする

### DIFF
--- a/homete/Views/HomeView/HomeNavigationPath.swift
+++ b/homete/Views/HomeView/HomeNavigationPath.swift
@@ -1,0 +1,25 @@
+//
+//  HomeNavigationPath.swift
+//  homete
+//
+//  Created by 佐藤汰一 on 2025/09/13.
+//
+
+import SwiftUI
+
+enum HomeNavigationPathElement {
+    
+    case settings
+    
+    @ViewBuilder
+    func destination() -> some View {
+        switch self {
+        case .settings: SettingView()
+        }
+    }
+}
+
+extension EnvironmentValues {
+    
+    @Entry var homeNavigationPath = CustomNavigationPath<HomeNavigationPathElement>(path: [])
+}

--- a/homete/Views/HomeView/HomeView.swift
+++ b/homete/Views/HomeView/HomeView.swift
@@ -11,13 +11,28 @@ struct HomeView: View {
         
     @AppStorage(key: .cohabitantId) var cohabitantId = ""
     
+    @State var navigationPath = CustomNavigationPath<HomeNavigationPathElement>(path: [])
+    
     var body: some View {
-        ZStack {
-            if cohabitantId.isEmpty {
-                NotRegisteredContent()
+        NavigationStack(path: $navigationPath.path) {
+            ZStack {
+                if cohabitantId.isEmpty {
+                    NotRegisteredContent()
+                }
+                else {
+                    RegisteredContent()
+                }
             }
-            else {
-                RegisteredContent()
+            .environment(\.homeNavigationPath, navigationPath)
+            .navigationDestination(for: HomeNavigationPathElement.self) { element in
+                element.destination()
+            }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationBarButton(label: .settings) {
+                        navigationPath.push(.settings)
+                    }
+                }
             }
         }
     }

--- a/homete/Views/HouseworkBoardView/HouseworkBoardNavigationPath.swift
+++ b/homete/Views/HouseworkBoardView/HouseworkBoardNavigationPath.swift
@@ -1,0 +1,27 @@
+//
+//  HouseworkBoardNavigationPath.swift
+//  homete
+//
+//  Created by 佐藤汰一 on 2025/09/13.
+//
+
+import SwiftUI
+
+enum HouseworkBoardNavigationPathElement {
+    
+    case settings
+    
+    @ViewBuilder
+    func destination() -> some View {
+        switch self {
+        case .settings: SettingView()
+        }
+    }
+}
+
+extension EnvironmentValues {
+    
+    @Entry var houseworkBoardNavigationPath = CustomNavigationPath<
+        HouseworkBoardNavigationPathElement
+    >(path: [])
+}

--- a/homete/Views/HouseworkBoardView/HouseworkBoardView.swift
+++ b/homete/Views/HouseworkBoardView/HouseworkBoardView.swift
@@ -11,29 +11,42 @@ struct HouseworkBoardView: View {
     
     @Environment(\.calendar) var calendar
     
+    @State var navigationPath = CustomNavigationPath<HouseworkBoardNavigationPathElement>(path: [])
     @State var selectedHouseworkState = HouseworkState.incomplete
     @State var houseworkBoardList = HouseworkBoardList(items: [])
     @State var selectedDate = Date.now
     @State var isPresentingAddHouseworkView = false
     
     var body: some View {
-        ZStack {
-            VStack(spacing: DesignSystem.Space.space16) {
-                HouseworkDateHeaderContent(selectedDate: $selectedDate)
-                HouseworkBoardSegmentedControl(selectedHouseworkState: $selectedHouseworkState)
-                HouseworkBoardListContent(
-                    selectedHouseworkState: selectedHouseworkState,
-                    houseworkBoardList: $houseworkBoardList
-                )
-                Spacer()
+        NavigationStack(path: $navigationPath.path) {
+            ZStack {
+                VStack(spacing: DesignSystem.Space.space16) {
+                    HouseworkDateHeaderContent(selectedDate: $selectedDate)
+                    HouseworkBoardSegmentedControl(selectedHouseworkState: $selectedHouseworkState)
+                    HouseworkBoardListContent(
+                        selectedHouseworkState: selectedHouseworkState,
+                        houseworkBoardList: $houseworkBoardList
+                    )
+                    Spacer()
+                }
+                .padding(.horizontal, DesignSystem.Space.space16)
+                addHouseworkButton {
+                    isPresentingAddHouseworkView = true
+                }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                .padding(.trailing, DesignSystem.Space.space24)
+                .padding(.bottom, DesignSystem.Space.space24)
             }
-            .padding(.horizontal, DesignSystem.Space.space16)
-            addHouseworkButton {
-                isPresentingAddHouseworkView = true
+            .navigationDestination(for: HouseworkBoardNavigationPathElement.self) { element in
+                element.destination()
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-            .padding(.trailing, DesignSystem.Space.space24)
-            .padding(.bottom, DesignSystem.Space.space24)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    NavigationBarButton(label: .settings) {
+                        navigationPath.push(.settings)
+                    }
+                }
+            }
         }
         .sheet(isPresented: $isPresentingAddHouseworkView) {
             RegisterHouseworkView(

--- a/homete/Views/TabView/AppTabView.swift
+++ b/homete/Views/TabView/AppTabView.swift
@@ -20,9 +20,6 @@ struct AppTabView: View {
                 Tab("家事", systemImage: "person.2.arrow.trianglehead.counterclockwise", value: .dashboard) {
                     HouseworkBoardView()
                 }
-                Tab("設定", systemImage: "gear", value: .dashboard) {
-                    SettingView()
-                }
             }
         } else {
             TabView(selection: $type) {
@@ -39,11 +36,6 @@ struct AppTabView: View {
                             systemImage: "person.2.arrow.trianglehead.counterclockwise"
                         )
                     }
-                SettingView()
-                    .tag(TabType.settings)
-                    .tabItem {
-                        Label("設定", systemImage: "gear")
-                    }
             }
         }
     }
@@ -55,7 +47,6 @@ extension AppTabView {
         
         case dashboard
         case homework
-        case settings
     }
 }
 

--- a/homete/Views/ViewUtilities/CustomNavigationPath.swift
+++ b/homete/Views/ViewUtilities/CustomNavigationPath.swift
@@ -25,4 +25,9 @@ final class CustomNavigationPath<Element: Hashable> {
         
         _ = path.popLast()
     }
+    
+    func push(_ element: Element) {
+        
+        path.append(element)
+    }
 }


### PR DESCRIPTION
## 経緯

<!-- PRを作成するに至った経緯や関連のIssueのリンクを記載する -->
設定画面はメインの機能ではないのでタブバーではなくナビゲーションバーにある方が適切と感じたため、導線を変更する修正を行います。

## 実装内容

<!-- なぜそのような実装を行なったかがわかるように、理由に重きを置いて記載する -->
各タブの画面ごとにNavigationStackを実装しました。
その理由として、現在はNavigationの内容が各タブで一致しているのは偶然であり、今後各タブごとに変わる可能性が高いので保守性の観点から分けています。

## 確認内容

<!-- 修正した内容が正しく動作していることを確認する方法とその内容を記載する -->
 - [x] シミュレーターで設定画面がナビゲーションバーのボタンから遷移できることを確認
