### PR TITLE
ローディング状態管理のリファクタリングと家族グループメンバー管理機能の追加

### DIFF
--- a/homete/Model/Domain/Authentification/AccountAuthStore.swift
+++ b/homete/Model/Domain/Authentification/AccountAuthStore.swift
@@ -55,11 +55,12 @@ final class AccountAuthStore {
     
     func logOut() {
         
+        currentAuth = .init(result: nil, alreadyLoadedAtInitiate: true)
+        analyticsClient.log(.logout())
+        
         do {
             
-            currentAuth = .init(result: nil, alreadyLoadedAtInitiate: true)
             try accountAuthClient.signOut()
-            analyticsClient.log(.logout())
         }
         catch {
             

--- a/homete/Views/Auth/Login/LoginView.swift
+++ b/homete/Views/Auth/Login/LoginView.swift
@@ -11,7 +11,7 @@ struct LoginView: View {
     
     @Environment(AccountAuthStore.self) var accountAuthStore
     @CommonError var commonErrorContent
-    @State var isLoading = false
+    @LoadingState var loadingState
     
     var body: some View {
         VStack(spacing: .space16) {
@@ -21,9 +21,10 @@ struct LoginView: View {
                 .font(with: .headLineL)
             Text("サービスを利用するには、Appleアカウントでサインインする必要があります。")
                 .font(with: .body)
-            SignInUpWithAppleButton {
-                isLoading = true
-                await onSignInWithApple($0)
+            SignInUpWithAppleButton { result in
+                loadingState.task {
+                    await onSignInWithApple(result)
+                }
             }
             .frame(height: .space48)
             .clipShape(RoundedRectangle(cornerRadius: .space16 / 2))
@@ -36,7 +37,7 @@ struct LoginView: View {
         }
         .padding(.horizontal, .space16)
         .ignoresSafeArea(edges: [.bottom])
-        .fullScreenLoadingIndicator(isLoading)
+        .fullScreenLoadingIndicator(loadingState)
         .commonError(content: $commonErrorContent)
     }
 }

--- a/homete/Views/Auth/RegistrationAccount/RegistrationAccountView.swift
+++ b/homete/Views/Auth/RegistrationAccount/RegistrationAccountView.swift
@@ -10,9 +10,9 @@ import SwiftUI
 struct RegistrationAccountView: View {
     @Environment(AccountStore.self) var accountStore
     @Environment(\.launchStateProxy) var launchStateProxy
+    @LoadingState var loadingState
     
     @State var inputUserName = UserName()
-    @State var isLoading = false
     let authInfo: AccountAuthResult
     
     var body: some View {
@@ -34,8 +34,7 @@ struct RegistrationAccountView: View {
                 }
                 Spacer(minLength: .space24)
                 Button {
-                    Task {
-                        isLoading = true
+                    loadingState.task {
                         await tappedRegistrationButton()
                     }
                 } label: {
@@ -52,7 +51,7 @@ struct RegistrationAccountView: View {
             .navigationTitle("アカウント登録")
             .navigationBarTitleDisplayMode(.inline)
         }
-        .fullScreenLoadingIndicator(isLoading)
+        .fullScreenLoadingIndicator(loadingState)
     }
 }
 
@@ -83,8 +82,6 @@ private extension RegistrationAccountView {
             
             print("occurred error: \(error)")
         }
-        
-        isLoading = false
     }
 }
 
@@ -95,7 +92,7 @@ private extension RegistrationAccountView {
 
 #Preview("RegistrationAccountView_入力済み") {
     RegistrationAccountView(
-        isLoading: true,
+        loadingState: .init(store: .init(isLoading: true)),
         authInfo: .init(id: "Test")
     )
     .environment(AccountStore(appDependencies: .previewValue))

--- a/homete/Views/Components/Indicator/LoadingIndicator.swift
+++ b/homete/Views/Components/Indicator/LoadingIndicator.swift
@@ -20,10 +20,10 @@ struct LoadingIndicator: View {
 }
 
 extension View {
-    func fullScreenLoadingIndicator(_ isLoading: Bool) -> some View {
+    func fullScreenLoadingIndicator(_ loadingState: LoadingStateStore) -> some View {
         ZStack {
             self
-            if isLoading {
+            if loadingState.isLoading {
                 LoadingIndicator()
             }
         }

--- a/homete/Views/Components/Indicator/LoadingState.swift
+++ b/homete/Views/Components/Indicator/LoadingState.swift
@@ -15,12 +15,21 @@ struct LoadingState: DynamicProperty {
     var wrappedValue: LoadingStateStore {
         return store
     }
+    
+    var projectedValue: Binding<LoadingStateStore> {
+        return $store
+    }
 }
 
 @MainActor
 @Observable
 final class LoadingStateStore {
-    var isLoading = false
+    var isLoading: Bool
+    
+    init(isLoading: Bool = false) {
+        
+        self.isLoading = isLoading
+    }
     
     func task(_ operation: @MainActor @escaping () async -> Void) {
         

--- a/homete/Views/HouseworkDetailView/HouseworkDetailView.swift
+++ b/homete/Views/HouseworkDetailView/HouseworkDetailView.swift
@@ -13,8 +13,8 @@ struct HouseworkDetailView: View {
     @Environment(\.loginContext.account) var account
     @Environment(HouseworkListStore.self) var houseworkListStore
     @Environment(CohabitantStore.self) var cohabitantStore
+    @LoadingState var loadingState
     
-    @State var isLoading = false
     @State var item: HouseworkItem
     
     @CommonError var commonErrorContent
@@ -23,7 +23,7 @@ struct HouseworkDetailView: View {
         mainContent()
             .padding(.horizontal, .space16)
             .padding(.bottom, .space24)
-            .fullScreenLoadingIndicator(isLoading)
+            .fullScreenLoadingIndicator(loadingState)
             .navigationTitle(item.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -46,7 +46,7 @@ private extension HouseworkDetailView {
             )
             Spacer()
             HouseworkDetailActionContent(
-                isLoading: $isLoading,
+                isLoading: $loadingState.isLoading,
                 commonErrorContent: $commonErrorContent,
                 account: account,
                 item: item
@@ -111,7 +111,7 @@ private extension HouseworkDetailView {
 #Preview("HouseworkDetailView_通信中") {
     NavigationStack {
         HouseworkDetailView(
-            isLoading: true,
+            loadingState: .init(store: .init(isLoading: true)),
             item: .init(
                 id: "",
                 title: "洗濯",

--- a/homete/Views/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationPeersListView.swift
+++ b/homete/Views/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationPeersListView.swift
@@ -45,7 +45,6 @@ struct CohabitantRegistrationPeersListView: View {
                 .frame(height: .space24)
         }
         .padding(.horizontal, .space16)
-        .fullScreenLoadingIndicator(isConfirmedReadyRegistration)
         .alert("表示されているメンバーで登録を開始しますか？", isPresented: $isPresentingConfirmReadyRegistrationAlert) {
             Button {
                 tappedConfirmAlertCancelButton()
@@ -111,13 +110,6 @@ private extension CohabitantRegistrationPeersListView {
     CohabitantRegistrationPeersListView(
         isPresentingConfirmReadyRegistrationAlert: true,
         isConfirmedReadyRegistration: .constant(false)
-    )
-    .environment(\.connectedPeers, [.init(displayName: "Test_UUID")])
-}
-
-#Preview("CohabitantRegistrationPeersListView_登録開始待ちケース") {
-    CohabitantRegistrationPeersListView(
-        isConfirmedReadyRegistration: .constant(true)
     )
     .environment(\.connectedPeers, [.init(displayName: "Test_UUID")])
 }

--- a/homete/Views/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationScanningStateView.swift
+++ b/homete/Views/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationScanningStateView.swift
@@ -13,6 +13,7 @@ struct CohabitantRegistrationScanningStateView: View {
     @Environment(\.myPeerID) var myPeerID
     @Environment(\.connectedPeers) var connectedPeers
     @Environment(\.p2pSessionReceiveData) var receiveData
+    @LoadingState var loadingState
     
     @State var isConfirmedReadyRegistration = false
     @State var isPresentingRejectRegistrationAlert = false
@@ -38,6 +39,7 @@ struct CohabitantRegistrationScanningStateView: View {
             }
         }
         .animation(.spring, value: connectedPeers.isEmpty)
+        .fullScreenLoadingIndicator(loadingState)
         .alert(
             "通信中のメンバーがキャンセルしました",
             isPresented: $isPresentingRejectRegistrationAlert
@@ -87,6 +89,8 @@ private extension CohabitantRegistrationScanningStateView {
     }
     
     func transitionToProcessingStateIfNeeded() {
+        
+        loadingState.isLoading = true
         
         // 自分が登録ボタンタップ済みで、かつ全てのメンバーが登録ボタンタップ済みの場合に、
         // 登録処理に移行する

--- a/homete/Views/RegisterHouseworkView/RegisterHouseworkView.swift
+++ b/homete/Views/RegisterHouseworkView/RegisterHouseworkView.swift
@@ -13,11 +13,11 @@ struct RegisterHouseworkView: View {
     
     @Environment(\.dismiss) var dismiss
     @Environment(HouseworkListStore.self) var houseworkListStore
+    @LoadingState var loadingState
     
     @State var houseworkTitle = ""
     @State var completePoint = 10.0
     @State var isPresentingDuplicationAlert = false
-    @State var isLoading = false
     
     @FocusState var isShowingKeyboard: Bool
     @CommonError var commonErrorContent
@@ -49,7 +49,7 @@ struct RegisterHouseworkView: View {
                     }
             }
             Button("登録する") {
-                Task {
+                loadingState.task {
                     await tappedRegisterButton()
                 }
             }
@@ -59,7 +59,7 @@ struct RegisterHouseworkView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
             .padding([.trailing, .bottom], .space24)
         }
-        .fullScreenLoadingIndicator(isLoading)
+        .fullScreenLoadingIndicator(loadingState)
         .commonError(content: $commonErrorContent)
         .alert("登録できません", isPresented: $isPresentingDuplicationAlert) {
             Button(
@@ -152,19 +152,6 @@ private extension RegisterHouseworkView {
     
     func tappedRegisterButton() async {
         
-        withAnimation {
-            
-            isLoading = true
-        }
-        
-        defer {
-            
-            withAnimation {
-                
-                isLoading = false
-            }
-        }
-        
         let newItem = HouseworkItem(
             id: UUID().uuidString,
             title: houseworkTitle,
@@ -215,7 +202,7 @@ private extension RegisterHouseworkView {
 
 #Preview("RegisterHouseworkView_通信中") {
     RegisterHouseworkView(
-        isLoading: true,
+        loadingState: .init(store: .init(isLoading: true)),
         dailyHouseworkList: .init(
             items: [],
             metaData: .init(indexedDate: .init(.now), expiredAt: .now)

--- a/homete/Views/SettingView/SettingView.swift
+++ b/homete/Views/SettingView/SettingView.swift
@@ -13,10 +13,10 @@ struct SettingView: View {
     @Environment(AccountAuthStore.self) var accountAuthStore
     @Environment(\.loginContext.account.userName) var userName
     @Environment(\.dismiss) var dismiss
+    @LoadingState var loadingState
     
     @State var isPresentedLogoutConfirmAlert = false
     @State var isPresentedAccountDeletionConfirmAlert = false
-    @State var isLoading = false
     
     var body: some View {
         NavigationStack {
@@ -62,7 +62,7 @@ struct SettingView: View {
                 }
             }
         }
-        .fullScreenLoadingIndicator(isLoading)
+        .fullScreenLoadingIndicator(loadingState)
         .alert("ログアウトしますか？", isPresented: $isPresentedLogoutConfirmAlert) {
             Button("ログアウト", role: .destructive) {
                 tappedLogoutAlertOkButton()
@@ -70,8 +70,7 @@ struct SettingView: View {
         }
         .alert("退会しますか？", isPresented: $isPresentedAccountDeletionConfirmAlert) {
             Button("退会する", role: .destructive) {
-                isLoading = true
-                Task {
+                loadingState.task {
                     await tappedAccountDeletionAlertOkButton()
                 }
             }
@@ -119,8 +118,6 @@ private extension SettingView {
             // TODO: エラーハンドリング
             print("occurred error: \(error)")
         }
-        
-        isLoading = false
     }
 }
 


### PR DESCRIPTION
## Summary
- LoadingStateの導入によるローディングUI管理の改善
- CohabitantStoreによる家族グループメンバー管理機能の追加
- 家事を未完了に戻す機能の実装

## 主な変更内容

### LoadingState導入
- Boolベースのローディング管理を`LoadingStateStore`に移行
- `@LoadingState` property wrapperの追加
- `fullScreenLoadingIndicator`の引数をBoolから`LoadingStateStore`に変更

### CohabitantStore追加
- 家族グループメンバーをリアルタイムで監視・管理する`CohabitantStore`を実装
- `CohabitantMemberList`ドメインモデルの追加
- 家事承認画面、家事詳細画面で実施者名の表示に対応

### 家事を未完了に戻す機能
- `HouseworkItem.updateIncomplete()`メソッドの追加
- `HouseworkListStore.returnToIncomplete()`の実装
- 家事詳細画面の「未完了に戻す」ボタンの実装
- ユニットテストの追加

### その他
- Store関連ファイルをDomain配下に移動してファイル構造を整理
- `removeSnapshotListner` → `removeSnapshotListener`のtypo修正
- 不要なpreviewと`EnvironmentBindableStore`の削除

## Test plan
- [ ] ローディング表示が正しく動作すること
- [ ] 家族グループメンバーが正しく表示されること（家事承認画面、家事詳細画面）
- [ ] 家事を未完了に戻せること
- [ ] ユニットテストが全て通ること
- [ ] スナップショットテストが全て通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)