### PR TITLE
fix: SwiftGenPluginの検証スキップオプションをgymに追加

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,7 +38,8 @@ platform :ios do
       scheme: "homete",
       output_directory: "Build/app",
       cloned_source_packages_path: "SourcePackages",
-      export_method: "app-store"
+      export_method: "app-store",
+      xcargs: "-skipPackagePluginValidation"
     )
   end
 


### PR DESCRIPTION
## Summary

- Xcode 26環境でSwiftGenPlugin 6.6.2のSPMプラグイン検証が失敗し、TestFlightデプロイのアーカイブビルドが壊れていた問題を修正
- `gym`の`xcargs`に`-skipPackagePluginValidation`を追加し、アーカイブ時のプラグイン検証をスキップ

## 原因

SwiftGenPlugin 6.6.2（`swift-tools-version: 5.6`）がXcode 26（Swift 6.2）のSPMプラグイン検証要件を満たさず、`Validate plug-in "SwiftGenPlugin"` フェーズで失敗していた。

参照: https://github.com/stotic-dev/homete_iOS/actions/runs/23680554241/job/68991619788

## Test plan

- [ ] CIのTestFlightデプロイワークフローが正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)