### PR TITLE
feat: 証明書一括削除laneの追加とREADMEへの手順記載

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,36 @@
 # homete_iOS
 
 homete の iOS アプリリポジトリ
+
+## 証明書・プロビジョニングプロファイルの管理
+
+証明書管理には [Fastlane Match](https://docs.fastlane.tools/actions/match/) を使用しています。
+
+### プロファイルの更新
+
+```bash
+# 開発用
+bundle exec fastlane update_profile
+
+# 本番用
+bundle exec fastlane update_profile_prod
+```
+
+### 証明書が Developer Portal と不一致になった場合
+
+以下のエラーが出た場合は証明書が不一致になっています。
+
+```
+Certificate 'XXXXXXXXXX' (stored in your storage) is not available on the Developer Portal
+```
+
+全ての証明書・プロビジョニングプロファイルを一掃してから再生成してください。
+
+```bash
+# 証明書・プロビジョニングプロファイルを全削除
+bundle exec fastlane nuke_certificates
+
+# 削除後に再生成
+bundle exec fastlane update_profile         # 開発用
+bundle exec fastlane update_profile_prod    # 本番用
+```

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -127,6 +127,18 @@ platform :ios do
     )
   end
 
+  desc "全ての証明書・プロビジョニングプロファイルを削除"
+  lane :nuke_certificates do
+    api_key = generate_api_key
+    ["development", "appstore"].each do |type|
+      match_nuke(
+        api_key: api_key,
+        type: type,
+        skip_confirmation: true
+      )
+    end
+  end
+
   private_lane :generate_api_key do
     app_store_connect_api_key(
       key_id: ENV['ASC_KEY_ID'],

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -71,6 +71,14 @@ ipaを生成
 
 本番用のプロビジョニングプロファイルをインストール
 
+### ios nuke_certificates
+
+```sh
+[bundle exec] fastlane ios nuke_certificates
+```
+
+全ての証明書・プロビジョニングプロファイルを削除
+
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.


### PR DESCRIPTION
## Summary

- `nuke_certificates` laneを追加（development/appstoreの証明書・プロビジョニングプロファイルを一括削除）
- READMEに証明書更新手順と、Developer Portalとの不一致エラー発生時の対処手順を追記

## Test plan

- [x] `bundle exec fastlane nuke_certificates` が正常に実行できることを確認
- [x] 削除後に `update_profile` / `update_profile_prod` で再生成できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)