### PR TITLE
feat: expiredAtを1ヶ月から1年に変更

### DIFF
--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/DailyHouseworkMetaData.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/DailyHouseworkMetaData.swift
@@ -23,7 +23,7 @@ public extension DailyHouseworkMetaData {
     init(selectedDate: Date, calendar: Calendar) {
 
         let indexedDate = HouseworkIndexedDate(selectedDate, calendar: calendar)
-        let expiredAt = calendar.date(byAdding: .month, value: 1, to: selectedDate) ?? selectedDate
+        let expiredAt = calendar.date(byAdding: .year, value: 1, to: selectedDate) ?? selectedDate
         self.init(indexedDate: indexedDate, expiredAt: expiredAt)
     }
 }

--- a/LocalPackage/Tests/HometeDomainTests/Housework/DailyHouseworkListTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/Housework/DailyHouseworkListTest.swift
@@ -20,14 +20,14 @@ struct DailyHouseworkListTest {
 
 extension DailyHouseworkListTest.MakeInitialValueCase {
     
-    @Test("一日の家事情報の保持期限は3か月後になる")
+    @Test("一日の家事情報の保持期限は1年後になる")
     func makeInitialValue() throws {
-        
+
         // Arrange
         let calendar = Calendar.japanese
         let selectedDate = Date()
         let expectedIndexedDate = HouseworkIndexedDate(selectedDate, calendar: calendar)
-        let expectedExpiredAt = try #require(calendar.date(byAdding: .month, value: 1, to: selectedDate))
+        let expectedExpiredAt = try #require(calendar.date(byAdding: .year, value: 1, to: selectedDate))
         
         let expectedList = DailyHouseworkList(
             items: [],


### PR DESCRIPTION
## 経緯

HouseworkManager が直近1年分の家事データを保持する設計（#66）に対応するため、Firestore TTL による自動削除が1ヶ月で行われないよう保存期限を延長する。

close #99

## 実装内容

`DailyHouseworkMetaData` の convenience initializer で計算する `expiredAt` を `.month, value: 1` から `.year, value: 1` に変更した。

新規コレクションや集計ロジックを追加せず既存の Houseworks コレクションを単一データソースとして使う設計上、データが1ヶ月で TTL 削除されると直近1年分の保持という前提が崩れる。そのため、アプリ側の保持期間と Firestore TTL を揃える目的で保存期限を1年に延長した。

あわせてテストのテスト名（「3か月後」→「1年後」）と期待値も実態に合わせて修正した。

> **注意:** この変更は新規登録される家事にのみ適用される。変更前に登録済みの家事は元の expiredAt（登録日 + 1ヶ月）のまま自動削除される。

## 確認内容

- [x] ビルドが通ること
- [x] SwiftLint エラーがないこと
- [x] ユニットテスト（64件）が全て通ること