### PR TITLE
feat: HouseworkClientに一括フェッチメソッドを追加

### DIFF
--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkIndexedDate.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkIndexedDate.swift
@@ -19,18 +19,18 @@ public struct HouseworkIndexedDate: Equatable, Codable, Hashable, Sendable {
         anchorDate: Date,
         offsetDays: Int,
         calendar: Calendar
-    ) -> [[String: String]] {
+    ) -> [String] {
 
         let base = calendar.startOfDay(for: anchorDate)
         guard offsetDays >= 0 else {
 
-            return [["value": HouseworkIndexedDate(base, calendar: calendar).value]]
+            return [HouseworkIndexedDate(base, calendar: calendar).value]
         }
         // -offset ... +offset の範囲を列挙
         return (-offsetDays...offsetDays).compactMap { delta in
 
             guard let date = calendar.date(byAdding: .day, value: delta, to: base) else { return nil }
-            return ["value": HouseworkIndexedDate(date, calendar: calendar).value]
+            return HouseworkIndexedDate(date, calendar: calendar).value
         }
     }
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkClient.swift
@@ -18,6 +18,11 @@ public struct HouseworkClient: Sendable {
         _ offset: Int
     ) async -> AsyncStream<[HouseworkItem]>
     public let removeListener: @Sendable (_ id: String) async -> Void
+    public let fetchItems: @Sendable (
+        _ cohabitantId: String,
+        _ from: Date,
+        _ to: Date
+    ) async throws -> [HouseworkItem]
 }
 
 public extension HouseworkClient {
@@ -37,13 +42,19 @@ public extension HouseworkClient {
             _ anchorDate: Date,
             _ offset: Int
         ) async -> AsyncStream<[HouseworkItem]> = { _, _, _, _ in .makeStream().stream },
-        removeListenerHandler: @escaping @Sendable (_ id: String) async -> Void = { _ in }
+        removeListenerHandler: @escaping @Sendable (_ id: String) async -> Void = { _ in },
+        fetchItemsHandler: @escaping @Sendable (
+            _ cohabitantId: String,
+            _ from: Date,
+            _ to: Date
+        ) async throws -> [HouseworkItem] = { _, _, _ in [] }
     ) {
 
         insertOrUpdateItem = insertOrUpdateItemHandler
         removeItem = removeItemHandler
         snapshotListener = snapshotListenerHandler
         removeListener = removeListenerHandler
+        fetchItems = fetchItemsHandler
     }
 
     static let previewValue = HouseworkClient()

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplHouseworkClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplHouseworkClient.swift
@@ -34,10 +34,21 @@ extension HouseworkClient {
         return await FirestoreService.shared.addSnapshotListener(id: id) {
 
             return $0.houseworkListRef(id: cohabitantId)
-                .whereField("indexedDate", in: targetDateList)
+                .whereField("indexedDate.value", in: targetDateList)
         }
     } removeListenerHandler: { id in
 
         await FirestoreService.shared.removeSnapshotListener(id: id)
+    } fetchItemsHandler: { cohabitantId, from, to in
+
+        let calendar = Calendar.autoupdatingCurrent
+        let fromString = HouseworkIndexedDate(from, calendar: calendar).value
+        let toString = HouseworkIndexedDate(to, calendar: calendar).value
+
+        return try await FirestoreService.shared.fetch {
+            $0.houseworkListRef(id: cohabitantId)
+                .whereField("indexedDate.value", isGreaterThanOrEqualTo: fromString)
+                .whereField("indexedDate.value", isLessThanOrEqualTo: toString)
+        }
     }
 }

--- a/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkIndexedDate.swift
+++ b/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkIndexedDate.swift
@@ -58,15 +58,15 @@ extension HouseworkIndexedDateTest.CalcTargetPeriodCase {
 
         // Assert
         let expected = [
-            ["value": "2026/01/30"],
-            ["value": "2026/01/31"],
-            ["value": "2026/02/01"],
-            ["value": "2026/02/02"],
-            ["value": "2026/02/03"]
+            "2026/01/30",
+            "2026/01/31",
+            "2026/02/01",
+            "2026/02/02",
+            "2026/02/03"
         ]
         #expect(result == expected)
     }
-    
+
     @Test("指定の期間が0以下の場合、基準日付のみ返す")
     func calcTargetPeriod_zero_offset() {
 
@@ -81,7 +81,7 @@ extension HouseworkIndexedDateTest.CalcTargetPeriodCase {
         )
 
         // Assert
-        let expected = [["value": "2026/01/15"]]
+        let expected = ["2026/01/15"]
         #expect(result == expected)
     }
 }


### PR DESCRIPTION
## 経緯

家事ポイント可視化機能（#66）の実装 Phase 1。
HouseworkManager が起動時に直近1年分の家事をワンショット取得するために、事前に `HouseworkClient` へのフェッチメソッド追加が必要だった（#100）。

## 実装内容

### HouseworkClientにfetchItemsを追加

`indexedDate.value` の範囲クエリ（`isGreaterThanOrEqualTo` / `isLessThanOrEqualTo`）でワンショット取得するクロージャを追加した。
既存の `snapshotListener` は `in:` クエリでオブジェクト配列と比較していたが、直近1年分（最大365日）を `in:` で渡すのは現実的でないため、範囲クエリ方式を採用した。

### calcTargetPeriodの戻り値変更

`snapshotListener` のクエリを `whereField("indexedDate.value", in:)` に変更したことに合わせ、`calcTargetPeriod` の戻り値を `[[String: String]]`（オブジェクト配列）から `[String]`（文字列配列）に変更した。
フィールドパスをネストオブジェクト全体ではなく `indexedDate.value` に絞ることで、クエリの意図が明確になる。

## 確認内容

- [x] ビルド成功（警告のみ）
- [x] ユニットテスト全64件通過
- [x] `calcTargetPeriod` のテストを戻り値の型変更に合わせて更新済み