### PR TITLE
fix: HouseworkListStoreをAppTabViewで管理するように修正

### DIFF
--- a/LocalPackage/Sources/AppRoot/AppTabView.swift
+++ b/LocalPackage/Sources/AppRoot/AppTabView.swift
@@ -18,6 +18,7 @@ struct AppTabView: View {
 
     @State var cohabitantStore: CohabitantStore?
     @State var contributionStore: ContributionStore?
+    @State var houseworkListStore: HouseworkListStore?
     @State var type: TabType = .dashboard
 
     var body: some View {
@@ -58,7 +59,7 @@ private extension AppTabView {
                         systemImage: "person.2.arrow.trianglehead.counterclockwise",
                         value: .homework
                     ) {
-                        HouseworkBoardView.instantiate()
+                        HouseworkBoardScreen.make(houseworkListStore: houseworkListStore)
                     }
                 }
             } else {
@@ -74,7 +75,7 @@ private extension AppTabView {
                             systemImage: "list.bullet.clipboard.fill"
                         )
                     }
-                    HouseworkBoardView.instantiate()
+                    HouseworkBoardScreen.make(houseworkListStore: houseworkListStore)
                         .tag(TabType.homework)
                         .tabItem {
                             Label(
@@ -139,6 +140,11 @@ private extension AppTabView {
         contributionStore = .init(
             houseworkManager: appDependencies.houseworkManager,
             calendar: calendar
+        )
+        houseworkListStore = .init(
+            houseworkClient: appDependencies.houseworkClient,
+            cohabitantPushNotificationClient: appDependencies.cohabitantPushNotificationClient,
+            houseworkManager: appDependencies.houseworkManager
         )
     }
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
@@ -1,0 +1,51 @@
+//
+//  HouseworkBoardScreen.swift
+//  LocalPackage
+//
+//  Created by Taichi Sato on 2026/05/09.
+//
+
+import SwiftUI
+
+public struct HouseworkBoardScreen: View {
+    @State var houseworkListStore: HouseworkListStore?
+    @State var houseworkBoardList: HouseworkBoardList = .init(items: [])
+    @State var dateList = HouseworkDateList()
+    
+    public static func make(houseworkListStore: HouseworkListStore?) -> some View {
+        HouseworkBoardScreen(houseworkListStore: houseworkListStore)
+    }
+    
+    public var body: some View {
+        if let houseworkListStore {
+            HouseworkBoardView(
+                houseworkBoardList: $houseworkBoardList,
+                dateList: $dateList
+            )
+            .environment(houseworkListStore)
+            .onAppear {
+                withAnimation {
+                    onAppeare(with: houseworkListStore)
+                }
+            }
+        } else {
+            // TODO: グループ登録前は利用できない旨の空表示を出す
+            ContentUnavailableView(
+                "グループの登録または参加を行うと、家事の管理ができるようになります。",
+                systemImage: ""
+            )
+        }
+    }
+}
+
+// MARK: - プレゼンテーションロジック
+
+private extension HouseworkBoardScreen {
+    
+    func onAppeare(with store: HouseworkListStore) {
+        houseworkBoardList = .init(
+            dailyList: store.items.value,
+            selectedDate: dateList.selectedDate
+        )
+    }
+}

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
@@ -9,27 +9,37 @@ import HometeDomain
 import HometeUI
 import SwiftUI
 
-public struct HouseworkBoardView: View {
+public struct HouseworkBoardScreen: View {
+    @State var houseworkListStore: HouseworkListStore?
+    
+    public static func make(houseworkListStore: HouseworkListStore?) -> some View {
+        HouseworkBoardScreen(houseworkListStore: houseworkListStore)
+    }
+    
+    public var body: some View {
+        if let houseworkListStore {
+            HouseworkBoardView()
+                .environment(houseworkListStore)
+        } else {
+            // TODO: グループ登録前は利用できない旨の空表示を出す
+            ContentUnavailableView(
+                "グループの登録または参加を行うと、家事の管理ができるようになります。",
+                systemImage: ""
+            )
+        }
+    }
+}
+
+struct HouseworkBoardView: View {
     @Environment(\.calendar) var calendar
     @Environment(\.now) var anchorDate
     @Environment(HouseworkListStore.self) var houseworkListStore
-
+    
     @State var navigationPath = AppNavigationPath<HouseworkBoardRoute>()
     @State var dateList = HouseworkDateList()
     @State var selectedHouseworkState = HouseworkState.incomplete
     @State var houseworkBoardList = HouseworkBoardList(items: [])
     @State var isPresentingAddHouseworkView = false
-    
-    public static func instantiate() -> some View {
-        DependenciesInjectLayer {
-            HouseworkBoardView()
-                .environment(HouseworkListStore(
-                    houseworkClient: $0.houseworkClient,
-                    cohabitantPushNotificationClient: $0.cohabitantPushNotificationClient,
-                    houseworkManager: $0.houseworkManager
-                ))
-        }
-    }
 
     public var body: some View {
         NavigationStack(path: $navigationPath.path) {
@@ -150,20 +160,7 @@ private extension HouseworkBoardView {
         houseworkBoardList: list
     )
     .apply(theme: .init())
-    .environment(HouseworkListStore(
-        houseworkClient: .previewValue,
-        cohabitantPushNotificationClient: .previewValue,
-        houseworkManager: .init(
-            houseworkClient: .previewValue,
-            allItems: list.items
-        ),
-        items: [
-            .init(
-                items: list.items,
-                metaData: .init(selectedDate: .distantPast, calendar: .japanese)
-            )
-        ]
-    ))
     .setupEnvironmentForPreview()
     .environment(\.now, .distantPast)
+    .environment(HouseworkListStore())
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
@@ -9,39 +9,19 @@ import HometeDomain
 import HometeUI
 import SwiftUI
 
-public struct HouseworkBoardScreen: View {
-    @State var houseworkListStore: HouseworkListStore?
-    
-    public static func make(houseworkListStore: HouseworkListStore?) -> some View {
-        HouseworkBoardScreen(houseworkListStore: houseworkListStore)
-    }
-    
-    public var body: some View {
-        if let houseworkListStore {
-            HouseworkBoardView()
-                .environment(houseworkListStore)
-        } else {
-            // TODO: グループ登録前は利用できない旨の空表示を出す
-            ContentUnavailableView(
-                "グループの登録または参加を行うと、家事の管理ができるようになります。",
-                systemImage: ""
-            )
-        }
-    }
-}
-
 struct HouseworkBoardView: View {
     @Environment(\.calendar) var calendar
     @Environment(\.now) var anchorDate
     @Environment(HouseworkListStore.self) var houseworkListStore
     
+    @Binding var houseworkBoardList: HouseworkBoardList
+    @Binding var dateList: HouseworkDateList
+    
     @State var navigationPath = AppNavigationPath<HouseworkBoardRoute>()
-    @State var dateList = HouseworkDateList()
     @State var selectedHouseworkState = HouseworkState.incomplete
-    @State var houseworkBoardList = HouseworkBoardList(items: [])
     @State var isPresentingAddHouseworkView = false
 
-    public var body: some View {
+    var body: some View {
         NavigationStack(path: $navigationPath.path) {
             ZStack {
                 VStack(spacing: .space16) {
@@ -98,11 +78,6 @@ struct HouseworkBoardView: View {
                 updateHouseworkBoardList()
             }
         }
-        .onAppear {
-            withAnimation {
-                updateHouseworkBoardList()
-            }
-        }
     }
 }
 
@@ -152,12 +127,12 @@ private extension HouseworkBoardView {
         )
     ])
     HouseworkBoardView(
-        dateList: .init(
+        houseworkBoardList: .constant(list),
+        dateList: .constant(.init(
             anchorDate: .distantPast,
             selectedDate: .distantPast,
             calendar: .japanese
-        ),
-        houseworkBoardList: list
+        ))
     )
     .apply(theme: .init())
     .setupEnvironmentForPreview()

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkDateList.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkDateList.swift
@@ -7,21 +7,21 @@
 
 import Foundation
 
-public struct HouseworkDateList: Equatable {
+struct HouseworkDateList: Equatable {
 
-    public struct Item: Equatable {
-        public let date: Date
-        public let state: HouseworkDateState
+    struct Item: Equatable {
+        let date: Date
+        let state: HouseworkDateState
     }
 
-    public let anchorDate: Date
-    public private(set) var selectedDate: Date
-    public private(set) var items: [Item]
+    let anchorDate: Date
+    private(set) var selectedDate: Date
+    private(set) var items: [Item]
 
     private static let selectableOffset = 7
     private static let unselectablePadding = 3
 
-    public init(anchorDate: Date = .now, selectedDate: Date = .now, calendar: Calendar = .autoupdatingCurrent) {
+    init(anchorDate: Date = .now, selectedDate: Date = .now, calendar: Calendar = .autoupdatingCurrent) {
         let selectedDay = calendar.startOfDay(for: selectedDate)
         self.anchorDate = anchorDate
         self.selectedDate = selectedDay

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkDateState.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkDateState.swift
@@ -5,7 +5,7 @@
 //  Created by Taichi Sato on 2026/04/04.
 //
 
-public enum HouseworkDateState: Equatable {
+enum HouseworkDateState: Equatable {
     case selected
     case selectable
     case unselectable

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkListStore.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkListStore.swift
@@ -27,13 +27,13 @@ public final class HouseworkListStore {
         houseworkClient: HouseworkClient = .previewValue,
         cohabitantPushNotificationClient: CohabitantPushNotificationClient = .previewValue,
         houseworkManager: HouseworkManager = .init(houseworkClient: .previewValue),
-        items: StoredAllHouseworkList = .init(value: [])
+        items: [DailyHouseworkList] = []
     ) {
 
         self.houseworkClient = houseworkClient
         self.cohabitantPushNotificationClient = cohabitantPushNotificationClient
         self.houseworkManager = houseworkManager
-        self.items = items
+        self.items = .init(value: items)
         
         Task {
             await startObserving()

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkListStore.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkListStore.swift
@@ -8,10 +8,11 @@
 import Foundation
 import HometeDomain
 import Observation
+import SwiftUI
 
 @MainActor
 @Observable
-final class HouseworkListStore {
+public final class HouseworkListStore {
 
     private(set) var items: StoredAllHouseworkList
     private var calendar: Calendar = .autoupdatingCurrent
@@ -22,18 +23,18 @@ final class HouseworkListStore {
 
     private let houseworkListObserveKey = "houseworkListObserveKey"
 
-    init(
+    public init(
         houseworkClient: HouseworkClient = .previewValue,
         cohabitantPushNotificationClient: CohabitantPushNotificationClient = .previewValue,
         houseworkManager: HouseworkManager = .init(houseworkClient: .previewValue),
-        items: [DailyHouseworkList] = []
+        items: StoredAllHouseworkList = .init(value: [])
     ) {
 
         self.houseworkClient = houseworkClient
         self.cohabitantPushNotificationClient = cohabitantPushNotificationClient
         self.houseworkManager = houseworkManager
-        self.items = .init(value: items)
-
+        self.items = items
+        
         Task {
             await startObserving()
         }
@@ -120,6 +121,7 @@ private extension HouseworkListStore {
                 offsetDays: HouseworkManager.listenerOffset,
                 calendar: calendar
             )
+            print("did receive current items: \(items)")
         }
     }
 

--- a/LocalPackage/Tests/HouseworkFeatureTests/HouseworkDateListTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/HouseworkDateListTest.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 import Testing
-@testable import HometeDomain
+@testable import HouseworkFeature
 
 struct HouseworkDateListTest {
 


### PR DESCRIPTION
## 経緯

`feat/display_graph` で導入された `AppTabView` 側で各 Store を一元管理する設計に合わせ、`HouseworkListStore` も同様に `AppTabView` で保持・管理するよう統一する。

これまでは `HouseworkBoardView.instantiate()` の中で `DependenciesInjectLayer` 経由で都度 `HouseworkListStore` を生成しており、タブ表示の都合で再生成・再購読が発生する余地があった。`ContributionStore` などと同じく `AppTabView` で生成・保持することで、タブ間で Store のライフサイクルを一致させる。

## 実装内容

- `HouseworkListStore` を `public` 化し、`AppTabView` で生成・保持して環境経由で渡すように変更
  - 理由: タブまたぎでの Store 再生成を避け、他 Store（`ContributionStore` / `CohabitantStore`）と同じ管理方針に揃えるため
- `HouseworkBoardScreen` ラッパーを新設し、`HouseworkListStore` が `nil`（グループ未参加状態）のときは `ContentUnavailableView` を表示
  - 理由: Store の生成タイミング（グループ参加後）と View 表示タイミングを安全に分離し、家事ボードの空状態のハンドリングを画面側に集約するため
- `HouseworkBoardView.instantiate()` を廃止
  - 理由: Store 生成責務が `AppTabView` に移ったため、View 内の DI レイヤは不要
- Preview での Store 注入を簡素化
  - 理由: テスト/プレビュー専用の煩雑な初期化を `HouseworkListStore()` の既定値（`previewValue`）に寄せ、Preview のメンテコストを下げるため

## 確認内容

- [x] 家事タブを開いて家事ボードが従来どおり表示されること
- [x] 日付切り替え・状態切り替え（未完了/完了）が正常に動作すること
- [x] タブを切り替えて戻ってきても表示が維持され、データの再フェッチによる空表示が起きないこと
- [x] グループ未参加（`cohabitantId` 未設定）時に `HouseworkBoardScreen` の空表示が出ること
- [x] Preview（`HouseworkBoardView` プレビュー）が正常に表示されること