### PR TITLE
fix: グラフの期間切り替えで同じ期間が表示される問題の修正

### DIFF
--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionAnalytics.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionAnalytics.swift
@@ -22,15 +22,14 @@ struct ContributionAnalytics: Equatable {
         displayPeriod: DisplayPointPeriod,
         calendar: Calendar
     ) async -> Self {
-        
-        let periodDates = displayPeriod.calcDatePeriod(calendar: calendar)
+
         let (weekPointList, monthPointList, yearPointList) = await buildPointList(
             members: members,
             contribution: contribution,
-            dates: periodDates,
+            anchor: displayPeriod.anchor,
             calendar: calendar
         )
-        
+
         return .init(
             weekPointList: weekPointList,
             monthPointList: monthPointList,
@@ -38,17 +37,17 @@ struct ContributionAnalytics: Equatable {
             displayPeriod: displayPeriod
         )
     }
-    
+
     func updatePeriod(
         displayPeriod: DisplayPointPeriod,
         members: CohabitantMemberList,
         contribution: HouseworkContribution,
         calendar: Calendar
     ) async -> Self {
-        
+
         guard self.displayPeriod.anchor != displayPeriod.anchor else {
-            
-            // 基準日が変わっていない場合は別の期間のpointListは計算済みなので、指定期間だけ更新する
+
+            // 基準日が変わっていない場合は週/月/年それぞれのpointListが既に算出済みなので、表示期間だけ差し替える
             return .init(
                 weekPointList: weekPointList,
                 monthPointList: monthPointList,
@@ -56,16 +55,15 @@ struct ContributionAnalytics: Equatable {
                 displayPeriod: displayPeriod
             )
         }
-        
+
         // 基準日が変わった場合はpointListを入れ替える必要があるので更新する
-        let periodDates = displayPeriod.calcDatePeriod(calendar: calendar)
         let (weekPointList, monthPointList, yearPointList) = await Self.buildPointList(
             members: members,
             contribution: contribution,
-            dates: periodDates,
+            anchor: displayPeriod.anchor,
             calendar: calendar
         )
-        
+
         return .init(
             weekPointList: weekPointList,
             monthPointList: monthPointList,
@@ -199,38 +197,45 @@ private extension ContributionAnalytics {
     static func buildPointList(
         members: CohabitantMemberList,
         contribution: HouseworkContribution,
-        dates: [Date],
+        anchor: Date,
         calendar: Calendar
     ) async -> ( // swiftlint:disable:this large_tuple
         [PointOfWeek],
         [PointOfMonth],
         [PointOfYear]
     ) {
-        
+
+        let weekDates = DisplayPointPeriod(type: .week, anchor: anchor)
+            .calcDatePeriod(calendar: calendar)
+        let monthDates = DisplayPointPeriod(type: .month, anchor: anchor)
+            .calcDatePeriod(calendar: calendar)
+        let yearDates = DisplayPointPeriod(type: .year, anchor: anchor)
+            .calcDatePeriod(calendar: calendar)
+
         async let weekPointList: [PointOfWeek] = Task.detached {
             contribution.viewablePointList(
                 members: members,
-                dates: dates,
+                dates: weekDates,
                 calendar: calendar
             )
         }.value
-        
+
         async let monthPointList: [PointOfMonth] = Task.detached {
             contribution.viewablePointList(
                 members: members,
-                dates: dates,
+                dates: monthDates,
                 calendar: calendar
             )
         }.value
-        
+
         async let yearPointList: [PointOfYear] = Task.detached {
             contribution.viewablePointList(
                 members: members,
-                dates: dates,
+                dates: yearDates,
                 calendar: calendar
             )
         }.value
-        
+
         return await (weekPointList, monthPointList, yearPointList)
     }
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/DisplayPointPeriod.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/DisplayPointPeriod.swift
@@ -20,7 +20,7 @@ struct DisplayPointPeriod: Equatable, Hashable {
             value: -1,
             to: anchor
         ),
-              let start = calendar.date(byAdding: .day, value: 1, to: decreasedDate) else { return nil }
+              let start = calendar.date(byAdding: type.granularity, value: 1, to: decreasedDate) else { return nil }
         let end = anchor
         return start...end
     }

--- a/LocalPackage/Sources/Features/ContributionFeature/Preview/ContributionHelper.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Preview/ContributionHelper.swift
@@ -100,21 +100,26 @@ extension ContributionAnalytics {
             ownId: "user1"
         )
 
-        let dates = displayPeriod.calcDatePeriod(calendar: calendar)
+        let weekDates = DisplayPointPeriod(type: .week, anchor: anchor)
+            .calcDatePeriod(calendar: calendar)
+        let monthDates = DisplayPointPeriod(type: .month, anchor: anchor)
+            .calcDatePeriod(calendar: calendar)
+        let yearDates = DisplayPointPeriod(type: .year, anchor: anchor)
+            .calcDatePeriod(calendar: calendar)
 
         let weekPointList: [PointOfWeek] = contribution.viewablePointList(
             members: members,
-            dates: dates,
+            dates: weekDates,
             calendar: calendar
         )
         let monthPointList: [PointOfMonth] = contribution.viewablePointList(
             members: members,
-            dates: dates,
+            dates: monthDates,
             calendar: calendar
         )
         let yearPointList: [PointOfYear] = contribution.viewablePointList(
             members: members,
-            dates: dates,
+            dates: yearDates,
             calendar: calendar
         )
 

--- a/LocalPackage/Tests/ContributionFeatureTests/ContributionAnalyticsRankingTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/ContributionAnalyticsRankingTest.swift
@@ -12,6 +12,59 @@ import HometeDomain
 
 extension ContributionAnalyticsTest.RankingCase {
 
+    @Test("displayPeriod.type=.weekで作ったanalyticsを、anchor固定でmonthへ切り替えるとmonth期間のランキングが返る")
+    func ranking_afterTypeSwitchKeepingAnchor_usesNewPeriodPointList() async throws {
+
+        // Arrange: 月間範囲には含まれるが週間範囲には含まれない日付にデータを置く
+        let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
+        let dateOutsideWeek = Date.previewDate(year: 2026, month: 4, day: 10)
+        let contribution = HouseworkContribution.makeForTest(
+            list: [
+                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))]
+            ],
+            calendar: calendar
+        )
+        let members = CohabitantMemberList(
+            value: [.init(id: "u1", userName: "ユーザー1")],
+            ownId: "u1"
+        )
+        let weekPeriod = DisplayPointPeriod(type: .week, anchor: anchor)
+        let monthPeriod = DisplayPointPeriod(type: .month, anchor: anchor)
+        let weekAnalytics = await ContributionAnalytics.make(
+            contribution: contribution,
+            members: members,
+            displayPeriod: weekPeriod,
+            calendar: calendar
+        )
+        let monthAnalytics = await weekAnalytics.updatePeriod(
+            displayPeriod: monthPeriod,
+            members: members,
+            contribution: contribution,
+            calendar: calendar
+        )
+
+        // Act
+        let result = monthAnalytics.ranking(
+            criterion: .point,
+            myUserId: "u1",
+            calendar: calendar
+        )
+
+        // Assert: 月間範囲のpointListに基づきtotalValue=50, denominator=月間日数
+        let monthDayCount = monthPeriod.calcDatePeriod(calendar: calendar).count
+        let expected: [ContributionAnalyticsRankItem] = [
+            .init(
+                rank: 1,
+                userId: "u1",
+                userName: "ユーザー1",
+                isMe: true,
+                totalValue: 50,
+                averageValue: 50.0 / Double(monthDayCount)
+            )
+        ]
+        #expect(result == expected)
+    }
+
     @Test("criterion=.point の場合はtotalポイント降順でランキングが返る")
     func ranking_byPoint_returnsDescendingOrder() throws {
 

--- a/LocalPackage/Tests/ContributionFeatureTests/ContributionAnalyticsTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/ContributionAnalyticsTest.swift
@@ -5,6 +5,8 @@
 //  Created by Taichi Sato on 2026/05/01.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 import Testing
 import HometeDomain
@@ -12,14 +14,144 @@ import HometeDomain
 
 // swiftlint:disable:next convenience_type
 struct ContributionAnalyticsTest {
+    struct MakeCase {
+        let calendar = Calendar.japanese
+    }
     struct UpdatePeriodCase {
         private let calendar = Calendar.japanese
     }
     struct CurrentListCase {
         private let calendar = Calendar.japanese
     }
-    struct RankingCase {}
+    struct RankingCase {
+        let calendar = Calendar.japanese
+    }
     struct IsEmptyCase {}
+}
+
+// MARK: - make
+
+extension ContributionAnalyticsTest.MakeCase {
+
+    @Test("displayPeriod.type=.monthで作ったanalyticsでも、week期間に切り替えると週間範囲のデータのみが集計される")
+    func make_typeMonth_thenSwitchToWeek_usesWeekDates() async throws {
+
+        // Arrange: 月間範囲には含まれるが週間範囲には含まれない日付にデータを置く
+        let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
+        let dateOutsideWeek = Date.previewDate(year: 2026, month: 4, day: 10)
+        let contribution = HouseworkContribution.makeForTest(
+            list: [
+                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))]
+            ],
+            calendar: calendar
+        )
+        let members = CohabitantMemberList(
+            value: [.init(id: "u1", userName: "ユーザー1")],
+            ownId: "u1"
+        )
+        let monthPeriod = DisplayPointPeriod(type: .month, anchor: anchor)
+        let weekPeriod = DisplayPointPeriod(type: .week, anchor: anchor)
+        let analytics = await ContributionAnalytics.make(
+            contribution: contribution,
+            members: members,
+            displayPeriod: monthPeriod,
+            calendar: calendar
+        )
+
+        // Act: anchorを変えずにtypeだけweekへ切り替える
+        let result = await analytics.updatePeriod(
+            displayPeriod: weekPeriod,
+            members: members,
+            contribution: contribution,
+            calendar: calendar
+        )
+
+        // Assert: 週間範囲には04-10が含まれないので達成数0
+        let expected: [UserHouseworkAchieved] = [
+            .init(userId: "u1", userName: "ユーザー1", achievedCount: 0)
+        ]
+        #expect(result.achieved() == expected)
+    }
+
+    @Test("displayPeriod.type=.weekで作ったanalyticsでも、month期間に切り替えると月間範囲のデータが集計される")
+    func make_typeWeek_thenSwitchToMonth_usesMonthDates() async throws {
+
+        // Arrange: 月間範囲には含まれるが週間範囲には含まれない日付にデータを置く
+        let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
+        let dateOutsideWeek = Date.previewDate(year: 2026, month: 4, day: 10)
+        let contribution = HouseworkContribution.makeForTest(
+            list: [
+                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))]
+            ],
+            calendar: calendar
+        )
+        let members = CohabitantMemberList(
+            value: [.init(id: "u1", userName: "ユーザー1")],
+            ownId: "u1"
+        )
+        let weekPeriod = DisplayPointPeriod(type: .week, anchor: anchor)
+        let monthPeriod = DisplayPointPeriod(type: .month, anchor: anchor)
+        let analytics = await ContributionAnalytics.make(
+            contribution: contribution,
+            members: members,
+            displayPeriod: weekPeriod,
+            calendar: calendar
+        )
+
+        // Act: anchorを変えずにtypeだけmonthへ切り替える
+        let result = await analytics.updatePeriod(
+            displayPeriod: monthPeriod,
+            members: members,
+            contribution: contribution,
+            calendar: calendar
+        )
+
+        // Assert: 月間範囲には04-10が含まれるので達成数1
+        let expected: [UserHouseworkAchieved] = [
+            .init(userId: "u1", userName: "ユーザー1", achievedCount: 1)
+        ]
+        #expect(result.achieved() == expected)
+    }
+
+    @Test("displayPeriod.type=.monthで作ったanalyticsでも、year期間に切り替えると年間範囲のデータが集計される")
+    func make_typeMonth_thenSwitchToYear_usesYearDates() async throws {
+
+        // Arrange: 年間範囲には含まれるが月間範囲には含まれない日付にデータを置く
+        let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
+        let dateOutsideMonth = Date.previewDate(year: 2025, month: 8, day: 15)
+        let contribution = HouseworkContribution.makeForTest(
+            list: [
+                "u1": [.init(indexedDay: dateOutsideMonth, point: .init(value: 50))]
+            ],
+            calendar: calendar
+        )
+        let members = CohabitantMemberList(
+            value: [.init(id: "u1", userName: "ユーザー1")],
+            ownId: "u1"
+        )
+        let monthPeriod = DisplayPointPeriod(type: .month, anchor: anchor)
+        let yearPeriod = DisplayPointPeriod(type: .year, anchor: anchor)
+        let analytics = await ContributionAnalytics.make(
+            contribution: contribution,
+            members: members,
+            displayPeriod: monthPeriod,
+            calendar: calendar
+        )
+
+        // Act: anchorを変えずにtypeだけyearへ切り替える
+        let result = await analytics.updatePeriod(
+            displayPeriod: yearPeriod,
+            members: members,
+            contribution: contribution,
+            calendar: calendar
+        )
+
+        // Assert: 年間範囲には2025-08-15が含まれるので達成数1
+        let expected: [UserHouseworkAchieved] = [
+            .init(userId: "u1", userName: "ユーザー1", achievedCount: 1)
+        ]
+        #expect(result.achieved() == expected)
+    }
 }
 
 // MARK: - updatePeriod

--- a/LocalPackage/Tests/ContributionFeatureTests/DisplayPointPeriodTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/DisplayPointPeriodTest.swift
@@ -64,7 +64,7 @@ extension DisplayPointPeriodTest.CalcDateRangeCase {
         let result = try #require(period.calcDateRange(calendar: calendar))
 
         // Assert
-        let expectedStart = Date.previewDate(year: 2026, month: 1, day: 1)
+        let expectedStart = Date.previewDate(year: 2026, month: 1, day: 31)
         let expectedEnd = Date.previewDate(year: 2026, month: 12, day: 31)
         #expect(result == expectedStart...expectedEnd)
     }


### PR DESCRIPTION
## 経緯

<!-- PRを作成するに至った経緯や関連のIssueのリンクを記載する -->
関連Issue: #129 

## 実装内容

<!-- なぜそのような実装を行なったかがわかるように、理由に重きを置いて記載する -->
表示期間のdateの配列が全て同じ期間に適用されていたのが原因だったので、各期間のデータ生成で使用するdateの配列が、期間に対応した配列を使用するよう修正。

## 確認内容

<!-- 修正した内容が正しく動作していることを確認する方法とその内容を記載する -->

- [x] 問題の事象が発生しないこと
