### PR TITLE
chore: SwiftFormatの導入とコードスタイル統一

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -5,7 +5,7 @@
 --swift-version 6
 
 # 除外パス（.swiftlint.yml と揃える）
---exclude ProjectTools,DangerTools,vendor,LocalPackage/.build
+--exclude ProjectTools,DangerTools,vendor,LocalPackage/.build,LocalPackage/Package.swift
 
 # 型宣言（struct/class/enum/actor/extension/protocol）の `{` 直後に空行を入れる
 # 注: 関数/closure/if などの `{` には SwiftFormat 仕様上適用不可

--- a/.swiftformat
+++ b/.swiftformat
@@ -7,6 +7,23 @@
 # 除外パス（.swiftlint.yml と揃える）
 --exclude ProjectTools,DangerTools,vendor,LocalPackage/.build
 
+# 型宣言（struct/class/enum/actor/extension/protocol）の `{` 直後に空行を入れる
+# 注: 関数/closure/if などの `{` には SwiftFormat 仕様上適用不可
+--type-blank-lines insert
+
+# 1行の最大幅（SwiftLint の line_length 警告閾値 120 に合わせる）
+--max-width 120
+
+# 複数行にまたがる引数・パラメータ・コレクションを before-first スタイルで整形
+#   init(
+#       hoge: hoge,
+#       huga: huga
+#   )
+--wrap-arguments before-first
+--wrap-parameters before-first
+--wrap-collections before-first
+--closing-paren balanced
+
 # 既存コードへの影響が大きいルールを無効化
 --disable organizeDeclarations
 --disable markTypes

--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,15 @@
+# SwiftFormat configuration
+# https://github.com/nicklockwood/SwiftFormat
+
+# Swiftバージョン（CLAUDE.mdに準拠）
+--swift-version 6
+
+# 除外パス（.swiftlint.yml と揃える）
+--exclude ProjectTools,DangerTools,vendor,LocalPackage/.build
+
+# 既存コードへの影響が大きいルールを無効化
+--disable organizeDeclarations
+--disable markTypes
+--disable acronyms
+--disable wrapMultilineStatementBraces
+--disable blockComments

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,6 +42,7 @@ disabled_rules:
   - type_contents_order
   - statement_position
   - identifier_name
+  - trailing_comma
 
 # Configurations
 trailing_whitespace:

--- a/LocalPackage/Sources/AppRoot/AppTabView.swift
+++ b/LocalPackage/Sources/AppRoot/AppTabView.swift
@@ -5,13 +5,13 @@
 import ContributionFeature
 import HomeFeature
 import HometeDomain
-import HouseworkFeature
 import HometeUI
+import HouseworkFeature
 import SwiftUI
 import UserNotifications
 
 struct AppTabView: View {
-    
+
     @Environment(\.appDependencies) var appDependencies
     @Environment(\.loginContext) var loginContext
     @Environment(\.calendar) var calendar
@@ -31,15 +31,16 @@ struct AppTabView: View {
             }
             .environment(
                 \.cohabitantMembers,
-                 cohabitantStore?.members ?? .init(value: [], ownId: "")
+                cohabitantStore?.members ?? .init(value: [], ownId: "")
             )
     }
+
 }
 
 // MARK: UI定義
 
 private extension AppTabView {
-    
+
     func tabView() -> some View {
         ZStack {
             if #available(iOS 18.0, *) {
@@ -87,6 +88,7 @@ private extension AppTabView {
             }
         }
     }
+
 }
 
 // MARK: プレゼンテーションロジック
@@ -94,21 +96,19 @@ private extension AppTabView {
 private extension AppTabView {
 
     func onAppear() async {
-
         setupStore()
         await requestNotificationPermission()
     }
-    
+
     func onChangeCohabitantId() {
-        
         setupStore()
     }
+
 }
 
 private extension AppTabView {
 
     func requestNotificationPermission() async {
-
         let center = UNUserNotificationCenter.current()
         do {
             let granted = try await center.requestAuthorization(options: [.alert, .sound, .badge])
@@ -117,17 +117,15 @@ private extension AppTabView {
                 return
             }
             #if os(iOS)
-            UIApplication.shared.registerForRemoteNotifications()
+                UIApplication.shared.registerForRemoteNotifications()
             #endif
         } catch {
             print("[Notifications] Authorization error: \(error)")
         }
     }
-    
+
     func setupStore() {
-        
         guard loginContext.hasCohabitant else {
-            
             cohabitantStore = nil
             contributionStore = nil
             return
@@ -147,6 +145,7 @@ private extension AppTabView {
             houseworkManager: appDependencies.houseworkManager
         )
     }
+
 }
 
 extension AppTabView {
@@ -155,7 +154,9 @@ extension AppTabView {
 
         case dashboard
         case homework
+
     }
+
 }
 
 #Preview {

--- a/LocalPackage/Sources/AppRoot/LaunchScreenView.swift
+++ b/LocalPackage/Sources/AppRoot/LaunchScreenView.swift
@@ -22,6 +22,7 @@ struct LaunchScreenView: View {
         .padding(.horizontal, .space16)
         .padding(.vertical, .space24)
     }
+
 }
 
 #Preview {

--- a/LocalPackage/Sources/AppRoot/RootView.swift
+++ b/LocalPackage/Sources/AppRoot/RootView.swift
@@ -21,13 +21,13 @@ public struct RootView: View {
             switch launchState {
             case .launching:
                 LaunchScreenView()
-            case .preLoggedIn(let auth):
+            case let .preLoggedIn(auth):
                 RegistrationAccountView(authInfo: auth)
                     .transition(.asymmetric(
                         insertion: .push(from: .leading),
                         removal: .opacity
                     ))
-            case .loggedIn(let context):
+            case let .loggedIn(context):
                 AppTabView()
                     .environment(\.loginContext, context)
                     .transition(.scale)
@@ -52,6 +52,7 @@ public struct RootView: View {
         .apply(theme: theme)
         .environment(\.launchStateProxy, .init(launchState: $launchState))
     }
+
 }
 
 public extension RootView {
@@ -74,6 +75,7 @@ public extension RootView {
         }
         .environment(\.appDependencies, dependencies)
     }
+
 }
 
 // MARK: - プレゼンテーションロジック
@@ -81,7 +83,6 @@ public extension RootView {
 private extension RootView {
 
     func onReceiveFcmToken(_ notification: NotificationCenter.Publisher.Output) {
-
         guard let fcmToken = notification.object as? String else { return }
         self.fcmToken = fcmToken
     }
@@ -93,17 +94,14 @@ private extension RootView {
         }
 
         if let account = await accountStore.load(authResult) {
-
             await updateFcmTokenIfNeeded()
             launchState = .loggedIn(context: .init(account: account))
         } else {
-
             launchState = .preLoggedIn(auth: authResult)
         }
     }
 
     func onChangeAccount() async {
-
         guard launchState.isLoggedIn,
               let account = accountStore.account else { return }
 
@@ -112,9 +110,9 @@ private extension RootView {
     }
 
     func updateFcmTokenIfNeeded() async {
-
         guard let fcmToken else { return }
         await accountStore.updateFcmTokenIfNeeded(fcmToken)
         self.fcmToken = nil
     }
+
 }

--- a/LocalPackage/Sources/AppRoot/RouteResolverInjection.swift
+++ b/LocalPackage/Sources/AppRoot/RouteResolverInjection.swift
@@ -21,6 +21,7 @@ private struct RouteResolverInjectionModifier: ViewModifier {
                 }
             })
     }
+
 }
 
 extension View {
@@ -28,4 +29,5 @@ extension View {
     func routeResolverInjection() -> some View {
         modifier(RouteResolverInjectionModifier())
     }
+
 }

--- a/LocalPackage/Sources/Features/AuthFeature/Login/LoginView.swift
+++ b/LocalPackage/Sources/Features/AuthFeature/Login/LoginView.swift
@@ -45,27 +45,25 @@ public struct LoginView: View {
         .fullScreenLoadingIndicator(loadingState)
         .commonError(content: $commonErrorContent)
     }
+
 }
 
 private extension LoginView {
 
     func onSignInWithApple(_ result: Result<SignInWithAppleResult, any Error>) async {
-
         switch result {
-        case .success(let success):
+        case let .success(success):
             do {
-
                 try await accountAuthStore.login(success)
-            }
-            catch {
-
+            } catch {
                 commonErrorContent = .init(error: error)
             }
 
-        case .failure(let failure):
+        case let .failure(failure):
             commonErrorContent = .init(error: failure)
         }
     }
+
 }
 
 #Preview {

--- a/LocalPackage/Sources/Features/AuthFeature/Login/SignInUpWithAppleButton.swift
+++ b/LocalPackage/Sources/Features/AuthFeature/Login/SignInUpWithAppleButton.swift
@@ -6,10 +6,11 @@
 //
 
 import AuthenticationServices
-import SwiftUI
 import HometeDomain
+import SwiftUI
 
 struct SignInUpWithAppleButton: View {
+
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.appDependencies.nonceGeneratorClient) var nonceGenerationClient
     @State var currentNonce: SignInWithAppleNonce?
@@ -25,6 +26,7 @@ struct SignInUpWithAppleButton: View {
         .signInWithAppleButtonStyle(colorScheme == .light ? .black : .white)
         .id(colorScheme)
     }
+
 }
 
 private extension SignInUpWithAppleButton {
@@ -39,32 +41,29 @@ private extension SignInUpWithAppleButton {
     func handleCompletion(result: Result<ASAuthorization, any Error>) {
         Task {
             switch result {
-            case .success(let authorization):
+            case let .success(authorization):
                 guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
                       let currentNonce else {
-
                     preconditionFailure("No sent sign in request.")
                 }
 
                 do {
-
                     let result = try SignInWithAppleResultFactory.make(appleIDCredential, currentNonce)
                     await onSignIn(.success(result))
                 } catch {
-
                     await onSignIn(.failure(error))
                 }
 
-            case .failure(let error):
+            case let .failure(error):
                 print("failed sign in with apple: \(error)")
                 if let error = error as? ASAuthorizationError,
                    error.code != .canceled {
-
                     await onSignIn(.failure(DomainError.failAuth))
                 }
             }
         }
     }
+
 }
 
 #Preview("SignInUpWithAppleButton_light scheme", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/Features/AuthFeature/RegistrationAccount/RegistrationAccountView.swift
+++ b/LocalPackage/Sources/Features/AuthFeature/RegistrationAccount/RegistrationAccountView.swift
@@ -11,6 +11,7 @@ import HometeUI
 import SwiftUI
 
 public struct RegistrationAccountView: View {
+
     @Environment(AccountStore.self) var accountStore
     @Environment(\.launchStateProxy) var launchStateProxy
     @LoadingState var loadingState
@@ -60,9 +61,11 @@ public struct RegistrationAccountView: View {
         }
         .fullScreenLoadingIndicator(loadingState)
     }
+
 }
 
 private extension RegistrationAccountView {
+
     func userNameCautionMessage() -> some View {
         HStack(alignment: .top, spacing: .space8) {
             Image(systemName: "exclamationmark.circle.fill")
@@ -73,6 +76,7 @@ private extension RegistrationAccountView {
         }
         .fixedSize(horizontal: false, vertical: true)
     }
+
 }
 
 // MARK: プレゼンテーションロジック
@@ -80,16 +84,14 @@ private extension RegistrationAccountView {
 private extension RegistrationAccountView {
 
     func tappedRegistrationButton() async {
-
         do {
-
             let account = try await accountStore.registerAccount(auth: authInfo, userName: inputUserName)
             launchStateProxy(.loggedIn(context: .init(account: account)))
         } catch {
-
             print("occurred error: \(error)")
         }
     }
+
 }
 
 #Preview("RegistrationAccountView_未入力") {

--- a/LocalPackage/Sources/Features/AuthFeature/RegistrationAccount/UserNameInputTextField.swift
+++ b/LocalPackage/Sources/Features/AuthFeature/RegistrationAccount/UserNameInputTextField.swift
@@ -11,6 +11,7 @@ import HometeUI
 import SwiftUI
 
 struct UserNameInputTextField: View {
+
     @Binding var userName: UserName
 
     var body: some View {
@@ -43,6 +44,7 @@ struct UserNameInputTextField: View {
             .frame(maxWidth: .infinity, alignment: .trailing)
         }
     }
+
 }
 
 #Preview("UserNameInputTextField_入力値なし", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/AllUserPointSummary.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/AllUserPointSummary.swift
@@ -8,16 +8,18 @@
 import HometeDomain
 
 /// 全ユーザーの月間家事貢献度集計
-struct AllUserPointSummary: Equatable, Sendable {
+struct AllUserPointSummary: Equatable {
 
     let items: [UserPointSummary]
 
     init(items: [UserPointSummary] = []) {
         self.items = items
     }
-    
+
     /// 達成された家事があるかどうかで、データの有無を判定
-    var hasData: Bool { !items.allSatisfy { $0.achievedCount == 0 } }
+    var hasData: Bool {
+        !items.allSatisfy { $0.achievedCount == 0 }
+    }
 
     /// ランキング形式のアイテム一覧を生成する
     func makeRanking() -> [ContributionRankItem] {
@@ -34,12 +36,12 @@ struct AllUserPointSummary: Equatable, Sendable {
                 )
             }
     }
-    
+
     /// サマリー情報からユーザー毎の達成情報のモデルを返す
     func achieved() -> [UserHouseworkAchieved] {
-        
-        return items.map {
+        items.map {
             .init(userId: $0.userId, userName: $0.userName, achievedCount: $0.achievedCount)
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionAnalytics.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionAnalytics.swift
@@ -9,7 +9,7 @@ import Foundation
 import HometeDomain
 
 struct ContributionAnalytics: Equatable {
-    
+
     let weekPointList: [PointOfWeek]
     let monthPointList: [PointOfMonth]
     let yearPointList: [PointOfYear]
@@ -22,7 +22,6 @@ struct ContributionAnalytics: Equatable {
         displayPeriod: DisplayPointPeriod,
         calendar: Calendar
     ) async -> Self {
-
         let (weekPointList, monthPointList, yearPointList) = await buildPointList(
             members: members,
             contribution: contribution,
@@ -44,9 +43,7 @@ struct ContributionAnalytics: Equatable {
         contribution: HouseworkContribution,
         calendar: Calendar
     ) async -> Self {
-
         guard self.displayPeriod.anchor != displayPeriod.anchor else {
-
             // 基準日が変わっていない場合は週/月/年それぞれのpointListが既に算出済みなので、表示期間だけ差し替える
             return .init(
                 weekPointList: weekPointList,
@@ -71,46 +68,42 @@ struct ContributionAnalytics: Equatable {
             displayPeriod: displayPeriod
         )
     }
-    
+
     /// 指定期間中に家事を達成したメンバーが一人もいない場合にtrue
     var isEmpty: Bool {
-
         switch displayPeriod.type {
         case .week:
-            return weekPointList.allSatisfy { $0.totalAchievementCount == .zero }
+            weekPointList.allSatisfy { $0.totalAchievementCount == .zero }
 
         case .month:
-            return monthPointList.allSatisfy { $0.totalAchievementCount == .zero }
+            monthPointList.allSatisfy { $0.totalAchievementCount == .zero }
 
         case .year:
-            return yearPointList.allSatisfy { $0.totalAchievementCount == .zero }
+            yearPointList.allSatisfy { $0.totalAchievementCount == .zero }
         }
     }
 
-    func currentList(calendar: Calendar) -> AllUserViewablePointList {
-
-        return switch displayPeriod.type {
-
+    func currentList(calendar _: Calendar) -> AllUserViewablePointList {
+        switch displayPeriod.type {
         case .week: .make(
-            list: weekPointList,
-            displayPeriod: displayPeriod.type
-        )
+                list: weekPointList,
+                displayPeriod: displayPeriod.type
+            )
 
         case .month: .make(
-            list: monthPointList,
-            displayPeriod: displayPeriod.type
-        )
+                list: monthPointList,
+                displayPeriod: displayPeriod.type
+            )
 
         case .year: .make(
-            list: yearPointList,
-            displayPeriod: displayPeriod.type
-        )
+                list: yearPointList,
+                displayPeriod: displayPeriod.type
+            )
         }
     }
-    
+
     /// 指定期間中のユーザー毎の家事達成情報
     func achieved() -> [UserHouseworkAchieved] {
-
         switch displayPeriod.type {
         case .week:
             weekPointList.map {
@@ -118,12 +111,12 @@ struct ContributionAnalytics: Equatable {
             }
 
         case .month: monthPointList.map {
-            .init(userId: $0.userId, userName: $0.userName, achievedCount: $0.totalAchievementCount)
-        }
+                .init(userId: $0.userId, userName: $0.userName, achievedCount: $0.totalAchievementCount)
+            }
 
         case .year: yearPointList.map {
-            .init(userId: $0.userId, userName: $0.userName, achievedCount: $0.totalAchievementCount)
-        }
+                .init(userId: $0.userId, userName: $0.userName, achievedCount: $0.totalAchievementCount)
+            }
         }
     }
 
@@ -133,7 +126,6 @@ struct ContributionAnalytics: Equatable {
         myUserId: String,
         calendar: Calendar
     ) -> [ContributionAnalyticsRankItem] {
-
         let denominator = max(displayPeriod.calcDatePeriod(calendar: calendar).count, 1)
         let sortedEntries = userTotals(criterion: criterion)
             .sorted { $0.totalValue > $1.totalValue }
@@ -152,21 +144,23 @@ struct ContributionAnalytics: Equatable {
         }
         return items
     }
+
 }
 
 private extension ContributionAnalytics {
 
     struct UserTotalEntry {
+
         let userId: String
         let userName: String
         let totalValue: Int
+
     }
 
     func userTotals(criterion: ContributionAnalyticsRankingCriterion) -> [UserTotalEntry] {
-
         switch displayPeriod.type {
         case .week:
-            return weekPointList.map {
+            weekPointList.map {
                 .init(
                     userId: $0.userId,
                     userName: $0.userName,
@@ -175,7 +169,7 @@ private extension ContributionAnalytics {
             }
 
         case .month:
-            return monthPointList.map {
+            monthPointList.map {
                 .init(
                     userId: $0.userId,
                     userName: $0.userName,
@@ -184,7 +178,7 @@ private extension ContributionAnalytics {
             }
 
         case .year:
-            return yearPointList.map {
+            yearPointList.map {
                 .init(
                     userId: $0.userId,
                     userName: $0.userName,
@@ -204,7 +198,6 @@ private extension ContributionAnalytics {
         [PointOfMonth],
         [PointOfYear]
     ) {
-
         let weekDates = DisplayPointPeriod(type: .week, anchor: anchor)
             .calcDatePeriod(calendar: calendar)
         let monthDates = DisplayPointPeriod(type: .month, anchor: anchor)
@@ -238,4 +231,5 @@ private extension ContributionAnalytics {
 
         return await (weekPointList, monthPointList, yearPointList)
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionAnalyticsRankItem.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionAnalyticsRankItem.swift
@@ -5,9 +5,11 @@
 //  Created by Taichi Sato on 2026/05/08.
 //
 
-struct ContributionAnalyticsRankItem: Identifiable, Equatable, Sendable {
+struct ContributionAnalyticsRankItem: Identifiable, Equatable {
 
-    var id: String { userId }
+    var id: String {
+        userId
+    }
 
     /// 順位（1始まり）
     let rank: Int
@@ -21,4 +23,5 @@ struct ContributionAnalyticsRankItem: Identifiable, Equatable, Sendable {
     let totalValue: Int
     /// 平均値（週・月の場合は1日あたり、年の場合は1ヶ月あたり）
     let averageValue: Double
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionAnalyticsRankingCriterion.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionAnalyticsRankingCriterion.swift
@@ -5,13 +5,16 @@
 //  Created by Taichi Sato on 2026/05/08.
 //
 
-enum ContributionAnalyticsRankingCriterion: String, CaseIterable, Identifiable, Sendable {
+enum ContributionAnalyticsRankingCriterion: String, CaseIterable, Identifiable {
+
     /// 獲得ポイント
     case point
     /// 家事達成数
     case achievement
 
-    var id: String { rawValue }
+    var id: String {
+        rawValue
+    }
 
     var title: String {
         switch self {
@@ -26,4 +29,5 @@ enum ContributionAnalyticsRankingCriterion: String, CaseIterable, Identifiable, 
         case .achievement: "件"
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionRankItem.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionRankItem.swift
@@ -7,9 +7,11 @@
 
 import Foundation
 
-struct ContributionRankItem: Identifiable, Equatable, Sendable {
+struct ContributionRankItem: Identifiable, Equatable {
 
-    var id: String { userId }
+    var id: String {
+        userId
+    }
 
     /// 順位（1始まり）
     let rank: Int
@@ -23,4 +25,5 @@ struct ContributionRankItem: Identifiable, Equatable, Sendable {
     let monthlyPoint: Point
     /// 達成した家事件数
     let achievedCount: Int
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionStore.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ContributionStore.swift
@@ -32,7 +32,6 @@ public final class ContributionStore {
         houseworkManager: HouseworkManager = .init(houseworkClient: .previewValue),
         calendar: Calendar = .current
     ) {
-
         self.houseworkManager = houseworkManager
         self.calendar = calendar
 
@@ -40,6 +39,7 @@ public final class ContributionStore {
             await startObserving()
         }
     }
+
 }
 
 // MARK: private
@@ -47,7 +47,6 @@ public final class ContributionStore {
 private extension ContributionStore {
 
     func startObserving() async {
-        
         let stream = await houseworkManager.createObserver(observeKey)
         for await items in stream {
             await updatePoints(from: items)
@@ -57,12 +56,12 @@ private extension ContributionStore {
     }
 
     func updatePoints(from items: [HouseworkItem]) async {
-        
-        let calendar = self.calendar
+        let calendar = calendar
         let contribution = await Task.detached {
             // 貢献度のモデル生成は重い処理なのでバックグラウンドで実行する
-            return HouseworkContribution.make(by: items, calendar: calendar)
+            HouseworkContribution.make(by: items, calendar: calendar)
         }.value
-        self.contiribution = contribution
+        contiribution = contribution
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/DisplayPointPeriod.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/DisplayPointPeriod.swift
@@ -8,26 +8,25 @@
 import Foundation
 
 struct DisplayPointPeriod: Equatable, Hashable {
+
     /// 表示期間の種別
     var type: PeriodType
     /// 表示期間の基準日
     let anchor: Date
 
     func calcDateRange(calendar: Calendar) -> ClosedRange<Date>? {
-
         guard let decreasedDate = calendar.date(
             byAdding: type.component,
             value: -1,
             to: anchor
         ),
-              let start = calendar.date(byAdding: type.granularity, value: 1, to: decreasedDate) else { return nil }
+            let start = calendar.date(byAdding: type.granularity, value: 1, to: decreasedDate) else { return nil }
         let end = anchor
-        return start...end
+        return start ... end
     }
 
     /// グラフにプロットする粒度としてDateの配列を返す
     func calcDatePeriod(calendar: Calendar) -> [Date] {
-        
         var dates: [Date] = []
         guard let range: ClosedRange<Date> = calcDateRange(calendar: calendar) else {
             return []
@@ -50,9 +49,8 @@ struct DisplayPointPeriod: Equatable, Hashable {
 
         return dates
     }
-    
+
     func shiftPeriod(by value: Int, calendar: Calendar) -> Self {
-        
         guard let newAnchor = calendar.date(
             byAdding: type.component,
             value: value,
@@ -62,13 +60,14 @@ struct DisplayPointPeriod: Equatable, Hashable {
     }
 
     enum PeriodType {
+
         /// 週
         case week
         /// 月
         case month
         /// 年
         case year
-        
+
         /// 対応する期間の範囲
         var component: Calendar.Component {
             switch self {
@@ -77,7 +76,7 @@ struct DisplayPointPeriod: Equatable, Hashable {
             case .year: .year
             }
         }
-        
+
         /// 期間内のデータの粒度
         var granularity: Calendar.Component {
             switch self {
@@ -85,5 +84,7 @@ struct DisplayPointPeriod: Equatable, Hashable {
             case .month, .week: .day
             }
         }
+
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/HouseworkContribution.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/HouseworkContribution.swift
@@ -19,7 +19,6 @@ public struct HouseworkContribution: Equatable, Sendable {
     }
 
     static func make(by houseworkItems: [HouseworkItem], calendar: Calendar) -> Self {
-
         let completedItems = houseworkItems.filter { $0.state == .completed }
         let groupedByUserItems: [String: [HouseworkItem]] = Dictionary(
             grouping: completedItems
@@ -47,9 +46,8 @@ public struct HouseworkContribution: Equatable, Sendable {
         dates: [Date],
         calendar: Calendar
     ) -> [PointOfYear] {
-
-        return members.value.map { member in
-            return .make(
+        members.value.map { member in
+            .make(
                 by: list[member.id] ?? [:],
                 userId: member.id,
                 userName: member.userName,
@@ -64,9 +62,8 @@ public struct HouseworkContribution: Equatable, Sendable {
         dates: [Date],
         calendar: Calendar
     ) -> [PointOfMonth] {
-
-        return members.value.map { member in
-            return .make(
+        members.value.map { member in
+            .make(
                 by: list[member.id] ?? [:],
                 userId: member.id,
                 userName: member.userName,
@@ -81,9 +78,8 @@ public struct HouseworkContribution: Equatable, Sendable {
         dates: [Date],
         calendar: Calendar
     ) -> [PointOfWeek] {
-
-        return members.value.map { member in
-            return .make(
+        members.value.map { member in
+            .make(
                 by: list[member.id] ?? [:],
                 userId: member.id,
                 userName: member.userName,
@@ -99,35 +95,34 @@ public struct HouseworkContribution: Equatable, Sendable {
         members: CohabitantMemberList,
         myUserId: String
     ) -> AllUserPointSummary {
-
         let userItems: [UserPointSummary] = members.value
             .compactMap { member in
+                guard let userMap = list[member.id] else {
+                    return UserPointSummary(
+                        userId: member.id,
+                        userName: member.userName,
+                        isMe: member.id == myUserId,
+                        monthlyPoint: .init(value: .zero),
+                        achievedCount: .zero
+                    )
+                }
 
-            guard let userMap = list[member.id] else {
+                let targetList = userMap.values.filter {
+                    calendar.isDate($0.indexedDay, equalTo: month, toGranularity: .month)
+                }
+
+                let monthlyPoint = targetList.reduce(0) { $0 + $1.point.value }
+                let achievedCount = targetList.reduce(0) { $0 + $1.achievedCount }
                 return UserPointSummary(
                     userId: member.id,
                     userName: member.userName,
                     isMe: member.id == myUserId,
-                    monthlyPoint: .init(value: .zero),
-                    achievedCount: .zero
+                    monthlyPoint: .init(value: monthlyPoint),
+                    achievedCount: achievedCount
                 )
             }
 
-            let targetList = userMap.values.filter {
-                calendar.isDate($0.indexedDay, equalTo: month, toGranularity: .month)
-            }
-
-            let monthlyPoint = targetList.reduce(0) { $0 + $1.point.value }
-            let achievedCount = targetList.reduce(0) { $0 + $1.achievedCount }
-            return UserPointSummary(
-                userId: member.id,
-                userName: member.userName,
-                isMe: member.id == myUserId,
-                monthlyPoint: .init(value: monthlyPoint),
-                achievedCount: achievedCount
-            )
-        }
-
         return .init(items: userItems)
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/Point.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/Point.swift
@@ -7,5 +7,7 @@
 
 /// ポイントを表すモデル
 struct Point: Equatable, Hashable {
+
     let value: Int
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/UserHouseworkAchieved.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/UserHouseworkAchieved.swift
@@ -6,11 +6,14 @@
 //
 
 struct UserHouseworkAchieved: Hashable, Identifiable {
-    
+
     let userId: String
     let userName: String
     /// 達成した家事の数
     let achievedCount: Int
-    
-    var id: String { userId }
+
+    var id: String {
+        userId
+    }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/UserPointSummary.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/UserPointSummary.swift
@@ -9,9 +9,11 @@ import Foundation
 import HometeDomain
 
 /// ユーザーの家事貢献度集計結果
-struct UserPointSummary: Equatable, Sendable, Identifiable {
+struct UserPointSummary: Equatable, Identifiable {
 
-    var id: String { userId }
+    var id: String {
+        userId
+    }
 
     /// ユーザーID
     let userId: String
@@ -27,4 +29,5 @@ struct UserPointSummary: Equatable, Sendable, Identifiable {
 
     /// もらった感謝の数（自分が実行しレビューされて完了した家事の数）
     let achievedCount: Int
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/AllUserCumulativeData.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/AllUserCumulativeData.swift
@@ -8,17 +8,16 @@
 import Foundation
 
 struct AllUserCumulativeData: Equatable {
-    
+
     /// グラフに表示する累積データ
     let list: [ViewablePointList]
     /// 表示区間
     let displayPeriod: DisplayPointPeriod.PeriodType
-    
+
     static func make(
         list: [ViewablePointList],
         displayPeriod: DisplayPointPeriod.PeriodType
     ) -> Self {
-        
         let cumulativeList: [ViewablePointList] = list.map { userData in
             var running = 0
             let cumulatedList: [ViewablePointElement] = userData.sortedElements.map {
@@ -32,17 +31,17 @@ struct AllUserCumulativeData: Equatable {
                 elements: .init(cumulatedList)
             )
         }
-        
+
         print("cumulativeList: \(cumulativeList)")
         return .init(
             list: cumulativeList,
             displayPeriod: displayPeriod
         )
     }
-    
+
     /// 指定日時点でのユーザー毎の取得ポイント累計
     func cumulativePointEntries(for date: Date, calendar: Calendar) -> [PointEntry] {
-        return list.flatMap { userData in
+        list.flatMap { userData in
             let filtered = userData.elements.filter {
                 calendar.isDate($0.date, equalTo: date, toGranularity: displayPeriod.granularity)
             }
@@ -58,10 +57,11 @@ struct AllUserCumulativeData: Equatable {
             }
         }
     }
-    
+
     /// タップ位置の日付に最も近い、データが存在する日付を返す
     func nearestDate(to date: Date) -> Date? {
         list.flatMap { $0.elements.map(\.date) }
             .min { abs($0.timeIntervalSince(date)) < abs($1.timeIntervalSince(date)) }
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/AllUserViewablePointList.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/AllUserViewablePointList.swift
@@ -14,32 +14,30 @@ struct AllUserViewablePointList: Equatable {
     /// 表示区間
     let displayPeriod: DisplayPointPeriod.PeriodType
 
-    static func make<T: GenerableViewablePointList>(
-        list: [T],
+    static func make(
+        list: [some GenerableViewablePointList],
         displayPeriod: DisplayPointPeriod.PeriodType
     ) -> Self {
-        
-        return .init(
+        .init(
             list: list.map { $0.generate() },
             displayPeriod: displayPeriod
         )
     }
-    
+
     /// 指定日のユーザー毎のポイント取得
     func pointEntries(for date: Date, calendar: Calendar) -> [PointEntry] {
-        
-        return list.compactMap { userData in
+        list.compactMap { userData in
             guard let element = userData.elements.first(where: {
                 calendar.isDate($0.date, equalTo: date, toGranularity: displayPeriod.granularity)
             }) else { return nil }
             return PointEntry(id: userData.userId, userName: userData.userName, point: element.point.value)
         }
     }
-    
+
     /// タップ位置の日付に最も近い、データが存在する日付を返す
     func nearestDate(to date: Date) -> Date? {
-        
-        return list.flatMap { $0.elements.map(\.date) }
+        list.flatMap { $0.elements.map(\.date) }
             .min { abs($0.timeIntervalSince(date)) < abs($1.timeIntervalSince(date)) }
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointEntry.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointEntry.swift
@@ -6,8 +6,9 @@
 //
 
 struct PointEntry: Identifiable, Equatable {
-    
+
     let id: String
     let userName: String
     let point: Int
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointOfDay.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointOfDay.swift
@@ -9,29 +9,32 @@ import Foundation
 
 /// 一日のポイント
 struct PointOfDay: Equatable, Hashable {
+
     let indexedDay: Date
     let point: Point
     let achievedCount: Int
 
-    var date: Date { indexedDay }
+    var date: Date {
+        indexedDay
+    }
 
     init(indexedDay: Date, point: Point, achievedCount: Int = 1) {
         self.indexedDay = indexedDay
         self.point = point
         self.achievedCount = achievedCount
     }
+
 }
 
-extension Sequence where Element == PointOfDay {
-    
+extension Sequence<PointOfDay> {
+
     /// ポイントと家事達成数の合計を返す
     func calcTotalValue() -> (Point, Int) {
-
-        return self.reduce((Point(value: .zero), .zero), { partialResult, pointOfDay in
-            
+        reduce((Point(value: .zero), .zero)) { partialResult, pointOfDay in
             let point = Point(value: partialResult.0.value + pointOfDay.point.value)
             let achievementCount = partialResult.1 + pointOfDay.achievedCount
             return (point, achievementCount)
-        })
+        }
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointOfMonth.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointOfMonth.swift
@@ -28,12 +28,11 @@ struct PointOfMonth: Equatable, Hashable {
         dates: [Date],
         calendar: Calendar
     ) -> Self {
-
         let allDays: [PointOfDay] = dates.map { targetDate in
             pointOfDayByDate[calendar.startOfDay(for: targetDate)]
                 ?? .init(indexedDay: targetDate, point: .init(value: .zero), achievedCount: .zero)
         }
-        
+
         let (totalPoint, totalAchivementCount) = allDays.calcTotalValue()
 
         return .init(
@@ -53,23 +52,21 @@ struct PointOfMonth: Equatable, Hashable {
         userName: String,
         calendar: Calendar
     ) -> [Self] {
-
         let separetedDic = pointOfDayByDate.values
             .reduce([DateComponents: Set<PointOfDay>]()) { partialResult, pointOfDay in
+                let month = monthComponent(pointOfDay: pointOfDay, calendar: calendar)
+                var result = partialResult
 
-            let month = monthComponent(pointOfDay: pointOfDay, calendar: calendar)
-            var result = partialResult
+                if let elements = result[month] {
+                    var currentMonthElements = elements
+                    currentMonthElements.insert(pointOfDay)
+                    result[month] = currentMonthElements
+                } else {
+                    result[month] = [pointOfDay]
+                }
 
-            if let elements = result[month] {
-                var currentMonthElements = elements
-                currentMonthElements.insert(pointOfDay)
-                result[month] = currentMonthElements
-            } else {
-                result[month] = [pointOfDay]
+                return result
             }
-
-            return result
-        }
 
         return separetedDic.compactMap { components, elements in
             guard let startDate = calendar.date(from: components) else { return nil }
@@ -84,39 +81,39 @@ struct PointOfMonth: Equatable, Hashable {
             )
         }
     }
+
 }
 
 extension PointOfMonth: GenerableViewablePointList {
 
     func generate() -> ViewablePointList {
-
-        return .init(
+        .init(
             userId: userId,
             userName: userName,
             total: total,
             elements: .init(elements.map { .init(point: $0.point, date: $0.indexedDay) })
         )
     }
+
 }
 
 private extension PointOfMonth {
 
     static func monthComponent(pointOfDay: PointOfDay, calendar: Calendar) -> DateComponents {
-
-        return calendar.dateComponents([.year, .month], from: pointOfDay.indexedDay)
+        calendar.dateComponents([.year, .month], from: pointOfDay.indexedDay)
     }
+
 }
 
-extension Sequence where Element == PointOfMonth {
-    
+extension Sequence<PointOfMonth> {
+
     /// ポイントと家事達成数の合計を返す
     func calcTotalValue() -> (Point, Int) {
-
-        return self.reduce((Point(value: .zero), .zero), { partialResult, monthOfDay in
-            
+        reduce((Point(value: .zero), .zero)) { partialResult, monthOfDay in
             let point = Point(value: partialResult.0.value + monthOfDay.total.value)
             let achievementCount = partialResult.1 + monthOfDay.totalAchievementCount
             return (point, achievementCount)
-        })
+        }
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointOfWeek.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointOfWeek.swift
@@ -16,8 +16,13 @@ struct PointOfWeek: Equatable, Hashable {
     let elements: Set<PointOfDay>
     let startDate: Date
 
-    var point: Point { total }
-    var date: Date { startDate }
+    var point: Point {
+        total
+    }
+
+    var date: Date {
+        startDate
+    }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(userId)
@@ -31,7 +36,6 @@ struct PointOfWeek: Equatable, Hashable {
         dates: [Date],
         calendar: Calendar
     ) -> Self {
-
         let allDays: [PointOfDay] = dates.map { targetDate in
             pointOfDayByDate[calendar.startOfDay(for: targetDate)]
                 ?? .init(indexedDay: targetDate, point: .init(value: .zero), achievedCount: .zero)
@@ -46,17 +50,18 @@ struct PointOfWeek: Equatable, Hashable {
             startDate: dates.first ?? Date()
         )
     }
+
 }
 
 extension PointOfWeek: GenerableViewablePointList {
 
     func generate() -> ViewablePointList {
-
-        return .init(
+        .init(
             userId: userId,
             userName: userName,
             total: total,
             elements: .init(elements.map { .init(point: $0.point, date: $0.indexedDay) })
         )
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointOfYear.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/PointOfYear.swift
@@ -16,7 +16,6 @@ struct PointOfYear: Equatable, Hashable {
     let elements: Set<PointOfMonth>
 
     func hash(into hasher: inout Hasher) {
-
         hasher.combine(userId)
     }
 
@@ -27,7 +26,6 @@ struct PointOfYear: Equatable, Hashable {
         dates: [Date],
         calendar: Calendar
     ) -> Self {
-
         let targetDataByDate = pointOfDayByDate.filter { _, pointOfDay in
             dates.contains {
                 calendar.isDate($0, equalTo: pointOfDay.indexedDay, toGranularity: .month)
@@ -68,17 +66,18 @@ struct PointOfYear: Equatable, Hashable {
             elements: .init(allMonths)
         )
     }
+
 }
 
 extension PointOfYear: GenerableViewablePointList {
 
     func generate() -> ViewablePointList {
-
-        return .init(
+        .init(
             userId: userId,
             userName: userName,
             total: total,
             elements: .init(elements.map { .init(point: $0.total, date: $0.startDate) })
         )
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/ViewablePointElement.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/ViewablePointElement.swift
@@ -11,4 +11,5 @@ struct ViewablePointElement: Equatable, Hashable {
 
     let point: Point
     let date: Date
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/ViewablePointList.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Model/ViewablePoint/ViewablePointList.swift
@@ -15,13 +15,16 @@ struct ViewablePointList: Equatable, Hashable {
     let total: Point
     /// 表示するポイントのリスト
     let elements: Set<ViewablePointElement>
-    
+
     var sortedElements: [ViewablePointElement] {
         elements.sorted { $0.date < $1.date }
     }
+
 }
 
 /// ViewablePointListを生成するインターフェース
 protocol GenerableViewablePointList {
+
     func generate() -> ViewablePointList
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/Preview/ContributionHelper.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/Preview/ContributionHelper.swift
@@ -7,146 +7,148 @@
 
 #if DEBUG
 
-import Foundation
-import HometeDomain
+    import Foundation
+    import HometeDomain
 
-extension HouseworkContribution {
+    extension HouseworkContribution {
 
-    /// Preview・テスト用サンプルデータを生成する
-    /// 週・月・年の各表示期間（基準日: 2026-04-30）をカバーするデータを含む
-    static func makeForPreview() -> Self {
-        let user1Days: [PointOfDay] = [
-            // 年間ビュー用 (2025-04-30 〜 2026-04-30)
-            .init(indexedDay: .previewDate(year: 2025, month: 5, day: 10), point: .init(value: 30)),
-            .init(indexedDay: .previewDate(year: 2025, month: 6, day: 15), point: .init(value: 20)),
-            .init(indexedDay: .previewDate(year: 2025, month: 7, day: 8), point: .init(value: 45)),
-            .init(indexedDay: .previewDate(year: 2025, month: 8, day: 22), point: .init(value: 25)),
-            .init(indexedDay: .previewDate(year: 2025, month: 9, day: 5), point: .init(value: 35)),
-            .init(indexedDay: .previewDate(year: 2025, month: 10, day: 18), point: .init(value: 15)),
-            .init(indexedDay: .previewDate(year: 2025, month: 11, day: 12), point: .init(value: 40)),
-            .init(indexedDay: .previewDate(year: 2025, month: 12, day: 25), point: .init(value: 50)),
-            .init(indexedDay: .previewDate(year: 2026, month: 1, day: 7), point: .init(value: 10)),
-            .init(indexedDay: .previewDate(year: 2026, month: 2, day: 14), point: .init(value: 30)),
-            .init(indexedDay: .previewDate(year: 2026, month: 3, day: 20), point: .init(value: 25)),
-            // 月間ビュー用 (2026-03-30 〜 2026-04-30)
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 2), point: .init(value: 10)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 8), point: .init(value: 20)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 14), point: .init(value: 15)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 20), point: .init(value: 30)),
-            // 週間ビュー用 (2026-04-23 〜 2026-04-30)
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 24), point: .init(value: 20)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 26), point: .init(value: 15)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 28), point: .init(value: 25)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 30), point: .init(value: 18))
-        ]
-        let user2Days: [PointOfDay] = [
-            // 年間ビュー用 (2025-04-30 〜 2026-04-30)
-            .init(indexedDay: .previewDate(year: 2025, month: 5, day: 20), point: .init(value: 15)),
-            .init(indexedDay: .previewDate(year: 2025, month: 6, day: 8), point: .init(value: 35)),
-            .init(indexedDay: .previewDate(year: 2025, month: 7, day: 25), point: .init(value: 20)),
-            .init(indexedDay: .previewDate(year: 2025, month: 8, day: 10), point: .init(value: 40)),
-            .init(indexedDay: .previewDate(year: 2025, month: 9, day: 18), point: .init(value: 10)),
-            .init(indexedDay: .previewDate(year: 2025, month: 10, day: 5), point: .init(value: 50)),
-            .init(indexedDay: .previewDate(year: 2025, month: 11, day: 28), point: .init(value: 30)),
-            .init(indexedDay: .previewDate(year: 2025, month: 12, day: 12), point: .init(value: 25)),
-            .init(indexedDay: .previewDate(year: 2026, month: 1, day: 22), point: .init(value: 45)),
-            .init(indexedDay: .previewDate(year: 2026, month: 2, day: 5), point: .init(value: 20)),
-            .init(indexedDay: .previewDate(year: 2026, month: 3, day: 15), point: .init(value: 35)),
-            // 月間ビュー用 (2026-03-30 〜 2026-04-30)
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 5), point: .init(value: 15)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 11), point: .init(value: 25)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 18), point: .init(value: 10)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 27), point: .init(value: 35)),
-            // 週間ビュー用 (2026-04-23 〜 2026-04-30)
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 23), point: .init(value: 10)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 25), point: .init(value: 30)),
-            .init(indexedDay: .previewDate(year: 2026, month: 4, day: 29), point: .init(value: 20))
-        ]
-        return makeForTest(
-            list: ["user1": user1Days, "user2": user2Days],
-            calendar: .japanese
-        )
-    }
-
-    static func makeForTest(
-        list: [String: [PointOfDay]] = [:],
-        calendar: Calendar = .japanese
-    ) -> Self {
-        let converted: [String: [Date: PointOfDay]] = list.mapValues { pointOfDays in
-            Dictionary(
-                pointOfDays.map { (calendar.startOfDay(for: $0.indexedDay), $0) },
-                uniquingKeysWith: { first, _ in first }
+        /// Preview・テスト用サンプルデータを生成する
+        /// 週・月・年の各表示期間（基準日: 2026-04-30）をカバーするデータを含む
+        static func makeForPreview() -> Self {
+            let user1Days: [PointOfDay] = [
+                // 年間ビュー用 (2025-04-30 〜 2026-04-30)
+                .init(indexedDay: .previewDate(year: 2025, month: 5, day: 10), point: .init(value: 30)),
+                .init(indexedDay: .previewDate(year: 2025, month: 6, day: 15), point: .init(value: 20)),
+                .init(indexedDay: .previewDate(year: 2025, month: 7, day: 8), point: .init(value: 45)),
+                .init(indexedDay: .previewDate(year: 2025, month: 8, day: 22), point: .init(value: 25)),
+                .init(indexedDay: .previewDate(year: 2025, month: 9, day: 5), point: .init(value: 35)),
+                .init(indexedDay: .previewDate(year: 2025, month: 10, day: 18), point: .init(value: 15)),
+                .init(indexedDay: .previewDate(year: 2025, month: 11, day: 12), point: .init(value: 40)),
+                .init(indexedDay: .previewDate(year: 2025, month: 12, day: 25), point: .init(value: 50)),
+                .init(indexedDay: .previewDate(year: 2026, month: 1, day: 7), point: .init(value: 10)),
+                .init(indexedDay: .previewDate(year: 2026, month: 2, day: 14), point: .init(value: 30)),
+                .init(indexedDay: .previewDate(year: 2026, month: 3, day: 20), point: .init(value: 25)),
+                // 月間ビュー用 (2026-03-30 〜 2026-04-30)
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 2), point: .init(value: 10)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 8), point: .init(value: 20)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 14), point: .init(value: 15)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 20), point: .init(value: 30)),
+                // 週間ビュー用 (2026-04-23 〜 2026-04-30)
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 24), point: .init(value: 20)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 26), point: .init(value: 15)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 28), point: .init(value: 25)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 30), point: .init(value: 18)),
+            ]
+            let user2Days: [PointOfDay] = [
+                // 年間ビュー用 (2025-04-30 〜 2026-04-30)
+                .init(indexedDay: .previewDate(year: 2025, month: 5, day: 20), point: .init(value: 15)),
+                .init(indexedDay: .previewDate(year: 2025, month: 6, day: 8), point: .init(value: 35)),
+                .init(indexedDay: .previewDate(year: 2025, month: 7, day: 25), point: .init(value: 20)),
+                .init(indexedDay: .previewDate(year: 2025, month: 8, day: 10), point: .init(value: 40)),
+                .init(indexedDay: .previewDate(year: 2025, month: 9, day: 18), point: .init(value: 10)),
+                .init(indexedDay: .previewDate(year: 2025, month: 10, day: 5), point: .init(value: 50)),
+                .init(indexedDay: .previewDate(year: 2025, month: 11, day: 28), point: .init(value: 30)),
+                .init(indexedDay: .previewDate(year: 2025, month: 12, day: 12), point: .init(value: 25)),
+                .init(indexedDay: .previewDate(year: 2026, month: 1, day: 22), point: .init(value: 45)),
+                .init(indexedDay: .previewDate(year: 2026, month: 2, day: 5), point: .init(value: 20)),
+                .init(indexedDay: .previewDate(year: 2026, month: 3, day: 15), point: .init(value: 35)),
+                // 月間ビュー用 (2026-03-30 〜 2026-04-30)
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 5), point: .init(value: 15)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 11), point: .init(value: 25)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 18), point: .init(value: 10)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 27), point: .init(value: 35)),
+                // 週間ビュー用 (2026-04-23 〜 2026-04-30)
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 23), point: .init(value: 10)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 25), point: .init(value: 30)),
+                .init(indexedDay: .previewDate(year: 2026, month: 4, day: 29), point: .init(value: 20)),
+            ]
+            return makeForTest(
+                list: ["user1": user1Days, "user2": user2Days],
+                calendar: .japanese
             )
         }
-        return .init(list: converted)
-    }
-}
 
-extension ContributionAnalytics {
+        static func makeForTest(
+            list: [String: [PointOfDay]] = [:],
+            calendar: Calendar = .japanese
+        ) -> Self {
+            let converted: [String: [Date: PointOfDay]] = list.mapValues { pointOfDays in
+                Dictionary(
+                    pointOfDays.map { (calendar.startOfDay(for: $0.indexedDay), $0) },
+                    uniquingKeysWith: { first, _ in first }
+                )
+            }
+            return .init(list: converted)
+        }
 
-    /// Preview用サンプルデータを生成する（基準日: 2026-04-30）
-    static func makeForPreview(
-        type: DisplayPointPeriod.PeriodType = .month
-    ) -> Self {
-        let calendar = Calendar.japanese
-        let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
-        let displayPeriod = DisplayPointPeriod(type: type, anchor: anchor)
-        let contribution = HouseworkContribution.makeForPreview()
-        let members = CohabitantMemberList(
-            value: [
-                .init(id: "user1", userName: "田中"),
-                .init(id: "user2", userName: "佐藤")
-            ],
-            ownId: "user1"
-        )
-
-        let weekDates = DisplayPointPeriod(type: .week, anchor: anchor)
-            .calcDatePeriod(calendar: calendar)
-        let monthDates = DisplayPointPeriod(type: .month, anchor: anchor)
-            .calcDatePeriod(calendar: calendar)
-        let yearDates = DisplayPointPeriod(type: .year, anchor: anchor)
-            .calcDatePeriod(calendar: calendar)
-
-        let weekPointList: [PointOfWeek] = contribution.viewablePointList(
-            members: members,
-            dates: weekDates,
-            calendar: calendar
-        )
-        let monthPointList: [PointOfMonth] = contribution.viewablePointList(
-            members: members,
-            dates: monthDates,
-            calendar: calendar
-        )
-        let yearPointList: [PointOfYear] = contribution.viewablePointList(
-            members: members,
-            dates: yearDates,
-            calendar: calendar
-        )
-
-        return .init(
-            weekPointList: weekPointList,
-            monthPointList: monthPointList,
-            yearPointList: yearPointList,
-            displayPeriod: displayPeriod
-        )
     }
 
-    static func makeForTest(
-        weekPointList: [PointOfWeek] = [],
-        monthPointList: [PointOfMonth] = [],
-        yearPointList: [PointOfYear] = [],
-        displayPeriod: DisplayPointPeriod = .init(
-            type: .month,
-            anchor: .previewDate(year: 2026, month: 4, day: 30)
-        )
-    ) -> Self {
-        .init(
-            weekPointList: weekPointList,
-            monthPointList: monthPointList,
-            yearPointList: yearPointList,
-            displayPeriod: displayPeriod
-        )
+    extension ContributionAnalytics {
+
+        /// Preview用サンプルデータを生成する（基準日: 2026-04-30）
+        static func makeForPreview(
+            type: DisplayPointPeriod.PeriodType = .month
+        ) -> Self {
+            let calendar = Calendar.japanese
+            let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
+            let displayPeriod = DisplayPointPeriod(type: type, anchor: anchor)
+            let contribution = HouseworkContribution.makeForPreview()
+            let members = CohabitantMemberList(
+                value: [
+                    .init(id: "user1", userName: "田中"),
+                    .init(id: "user2", userName: "佐藤"),
+                ],
+                ownId: "user1"
+            )
+
+            let weekDates = DisplayPointPeriod(type: .week, anchor: anchor)
+                .calcDatePeriod(calendar: calendar)
+            let monthDates = DisplayPointPeriod(type: .month, anchor: anchor)
+                .calcDatePeriod(calendar: calendar)
+            let yearDates = DisplayPointPeriod(type: .year, anchor: anchor)
+                .calcDatePeriod(calendar: calendar)
+
+            let weekPointList: [PointOfWeek] = contribution.viewablePointList(
+                members: members,
+                dates: weekDates,
+                calendar: calendar
+            )
+            let monthPointList: [PointOfMonth] = contribution.viewablePointList(
+                members: members,
+                dates: monthDates,
+                calendar: calendar
+            )
+            let yearPointList: [PointOfYear] = contribution.viewablePointList(
+                members: members,
+                dates: yearDates,
+                calendar: calendar
+            )
+
+            return .init(
+                weekPointList: weekPointList,
+                monthPointList: monthPointList,
+                yearPointList: yearPointList,
+                displayPeriod: displayPeriod
+            )
+        }
+
+        static func makeForTest(
+            weekPointList: [PointOfWeek] = [],
+            monthPointList: [PointOfMonth] = [],
+            yearPointList: [PointOfYear] = [],
+            displayPeriod: DisplayPointPeriod = .init(
+                type: .month,
+                anchor: .previewDate(year: 2026, month: 4, day: 30)
+            )
+        ) -> Self {
+            .init(
+                weekPointList: weekPointList,
+                monthPointList: monthPointList,
+                yearPointList: yearPointList,
+                displayPeriod: displayPeriod
+            )
+        }
+
     }
-}
 
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/ContributionAnalyticsScreen.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/ContributionAnalyticsScreen.swift
@@ -41,12 +41,12 @@ public struct ContributionAnalyticsScreen: View {
             }
         }
     }
+
 }
 
 private extension ContributionAnalyticsScreen {
-    
+
     func onChangeContribution() async {
-        
         let contribution = contributionStore.contiribution
         analytics = await .make(
             contribution: contribution,
@@ -55,9 +55,8 @@ private extension ContributionAnalyticsScreen {
             calendar: calendar
         )
     }
-    
-    func onChangePeriod() async {
 
+    func onChangePeriod() async {
         let contribution = contributionStore.contiribution
         analytics = await analytics?.updatePeriod(
             displayPeriod: selectedPeriod,
@@ -66,4 +65,5 @@ private extension ContributionAnalyticsScreen {
             calendar: calendar
         )
     }
+
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/ContributionAnalyticsView.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/ContributionAnalyticsView.swift
@@ -41,12 +41,13 @@ struct ContributionAnalyticsView: View {
                 .padding(.vertical, .space8)
         }
     }
+
 }
 
 // MARK: SubView
 
 private extension ContributionAnalyticsView {
-    
+
     func graphContent(analytics: ContributionAnalytics) -> some View {
         VStack(spacing: .space32) {
             pointGraph(pointData: analytics.currentList(calendar: calendar))
@@ -67,7 +68,7 @@ private extension ContributionAnalyticsView {
             )
         }
     }
-    
+
     @ViewBuilder
     func pointGraph(pointData: AllUserViewablePointList) -> some View {
         PointsTimeSeriesChartView(viewableData: pointData)
@@ -91,74 +92,75 @@ private extension ContributionAnalyticsView {
             .subPrimaryButtonStyle()
         }
     }
+
 }
 
 // MARK: プレゼンテーションロジック
 
 private extension ContributionAnalyticsView {
-    
-    func tappedLatestAchievedPeriodShowButton() {
 
+    func tappedLatestAchievedPeriodShowButton() {
         guard let latestDate = latestAchievedDate else { return }
         let clampedAnchor = min(latestDate, now)
         selectedPeriod = .init(type: selectedPeriod.type, anchor: clampedAnchor)
     }
+
 }
 
 #if DEBUG
-#Preview("ContributionAnalyticsView_週間", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .week,
-        anchor: .previewDate(year: 2026, month: 4, day: 30)
-    )
-    ContributionAnalyticsView(
-        selectedPeriod: $selectedPeriod,
-        analytics: .makeForPreview(type: .week),
-        myUserId: "user1",
-        latestAchievedDate: nil
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("ContributionAnalyticsView_週間", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .week,
+            anchor: .previewDate(year: 2026, month: 4, day: 30)
+        )
+        ContributionAnalyticsView(
+            selectedPeriod: $selectedPeriod,
+            analytics: .makeForPreview(type: .week),
+            myUserId: "user1",
+            latestAchievedDate: nil
+        )
+        .setupEnvironmentForPreview()
+    }
 
-#Preview("ContributionAnalyticsView_月間", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .month,
-        anchor: .previewDate(year: 2026, month: 4, day: 30)
-    )
-    ContributionAnalyticsView(
-        selectedPeriod: $selectedPeriod,
-        analytics: .makeForPreview(type: .month),
-        myUserId: "user1",
-        latestAchievedDate: nil
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("ContributionAnalyticsView_月間", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .month,
+            anchor: .previewDate(year: 2026, month: 4, day: 30)
+        )
+        ContributionAnalyticsView(
+            selectedPeriod: $selectedPeriod,
+            analytics: .makeForPreview(type: .month),
+            myUserId: "user1",
+            latestAchievedDate: nil
+        )
+        .setupEnvironmentForPreview()
+    }
 
-#Preview("ContributionAnalyticsView_年間", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .year,
-        anchor: .previewDate(year: 2026, month: 4, day: 30)
-    )
-    ContributionAnalyticsView(
-        selectedPeriod: $selectedPeriod,
-        analytics: .makeForPreview(type: .year),
-        myUserId: "user1",
-        latestAchievedDate: nil
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("ContributionAnalyticsView_年間", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .year,
+            anchor: .previewDate(year: 2026, month: 4, day: 30)
+        )
+        ContributionAnalyticsView(
+            selectedPeriod: $selectedPeriod,
+            analytics: .makeForPreview(type: .year),
+            myUserId: "user1",
+            latestAchievedDate: nil
+        )
+        .setupEnvironmentForPreview()
+    }
 
-#Preview("ContributionAnalyticsView_空表示", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .month,
-        anchor: .previewDate(year: 2026, month: 4, day: 30)
-    )
-    ContributionAnalyticsView(
-        selectedPeriod: $selectedPeriod,
-        analytics: .makeForTest(displayPeriod: selectedPeriod),
-        myUserId: "user1",
-        latestAchievedDate: nil
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("ContributionAnalyticsView_空表示", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .month,
+            anchor: .previewDate(year: 2026, month: 4, day: 30)
+        )
+        ContributionAnalyticsView(
+            selectedPeriod: $selectedPeriod,
+            analytics: .makeForTest(displayPeriod: selectedPeriod),
+            myUserId: "user1",
+            latestAchievedDate: nil
+        )
+        .setupEnvironmentForPreview()
+    }
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/AllUserDataAnnotation.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/AllUserDataAnnotation.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 struct AllUserDataAnnotation: View {
-    
+
     @Environment(\.timeZone) var timeZone
     @Environment(\.locale) var locale
-    
+
     let entries: [PointEntry]
     let selectedDate: Date
     let displayPeriod: DisplayPointPeriod.PeriodType
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: .space4) {
             Text(selectedDate, format: titleDateFormat)
@@ -40,42 +40,43 @@ struct AllUserDataAnnotation: View {
                 .shadow(color: .black.opacity(0.15), radius: 4, y: 2)
         }
     }
+
 }
 
 private extension AllUserDataAnnotation {
-    
+
     var titleDateFormat: Date.FormatStyle {
-        var style: Date.FormatStyle
-        switch displayPeriod {
-        case .year: style = .dateTime.year().month().locale(locale)
-        case .month, .week: style = .dateTime.month().day().locale(locale)
+        var style: Date.FormatStyle = switch displayPeriod {
+        case .year: .dateTime.year().month().locale(locale)
+        case .month, .week: .dateTime.month().day().locale(locale)
         }
         style.timeZone = timeZone
         return style
     }
+
 }
 
 #if DEBUG
-#Preview("AllUserDataAnnotation_データ有り", traits: .sizeThatFitsLayout) {
-    AllUserDataAnnotation(
-       entries: [
-        .init(id: "1", userName: "佐藤", point: 20),
-        .init(id: "2", userName: "佐藤2", point: 1000000)
-       ],
-       selectedDate: .previewDate(year: 2026, month: 1, day: 1),
-       displayPeriod: .week
-    )
-    .setupEnvironmentForPreview()
-    .padding(.space16)
-}
+    #Preview("AllUserDataAnnotation_データ有り", traits: .sizeThatFitsLayout) {
+        AllUserDataAnnotation(
+            entries: [
+                .init(id: "1", userName: "佐藤", point: 20),
+                .init(id: "2", userName: "佐藤2", point: 1_000_000),
+            ],
+            selectedDate: .previewDate(year: 2026, month: 1, day: 1),
+            displayPeriod: .week
+        )
+        .setupEnvironmentForPreview()
+        .padding(.space16)
+    }
 
-#Preview("AllUserDataAnnotation_データ無し", traits: .sizeThatFitsLayout) {
-    AllUserDataAnnotation(
-       entries: [],
-       selectedDate: .previewDate(year: 2026, month: 1, day: 1),
-       displayPeriod: .week
-    )
-    .setupEnvironmentForPreview()
-    .padding(.space16)
-}
+    #Preview("AllUserDataAnnotation_データ無し", traits: .sizeThatFitsLayout) {
+        AllUserDataAnnotation(
+            entries: [],
+            selectedDate: .previewDate(year: 2026, month: 1, day: 1),
+            displayPeriod: .week
+        )
+        .setupEnvironmentForPreview()
+        .padding(.space16)
+    }
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/AnalyticsPeriodHeader.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/AnalyticsPeriodHeader.swift
@@ -8,24 +8,25 @@
 import SwiftUI
 
 struct AnalyticsPeriodHeader: View {
-    
+
     @Environment(\.locale) var locale
     @Environment(\.calendar) var calendar
     @Environment(\.now) var now
     @Environment(\.timeZone) var timeZone
-    
+
     @Binding var selectedPeriod: DisplayPointPeriod
-    
+
     var body: some View {
         VStack(spacing: .space16) {
             periodTypePicker()
             periodNavigationHeader()
         }
     }
+
 }
 
 private extension AnalyticsPeriodHeader {
-    
+
     func periodTypePicker() -> some View {
         Picker("表示期間", selection: $selectedPeriod.type) {
             Text("週").tag(DisplayPointPeriod.PeriodType.week)
@@ -63,11 +64,9 @@ private extension AnalyticsPeriodHeader {
     var isAtCurrentDate: Bool {
         calendar.isDate(selectedPeriod.anchor, inSameDayAs: now)
     }
-    
+
     func periodTitle() -> String {
-        
         guard !calendar.isDate(selectedPeriod.anchor, inSameDayAs: now) else {
-            
             // 基準日が今日の場合は直近の表示にする
             return switch selectedPeriod.type {
             case .week: "直近1週間"
@@ -75,18 +74,17 @@ private extension AnalyticsPeriodHeader {
             case .year: "直近1年"
             }
         }
-        
+
         guard let dateRange = selectedPeriod.calcDateRange(calendar: calendar) else { return "" }
-        var dateFormatStyle: Date.FormatStyle
-        switch selectedPeriod.type {
+        var dateFormatStyle: Date.FormatStyle = switch selectedPeriod.type {
         case .week:
-            dateFormatStyle = .dateTime.month(.defaultDigits).day().locale(locale)
+            .dateTime.month(.defaultDigits).day().locale(locale)
 
         case .month:
-            dateFormatStyle = .dateTime.month(.defaultDigits).day().locale(locale)
+            .dateTime.month(.defaultDigits).day().locale(locale)
 
         case .year:
-            dateFormatStyle = .dateTime.year().month(.defaultDigits).locale(locale)
+            .dateTime.year().month(.defaultDigits).locale(locale)
         }
         dateFormatStyle.timeZone = timeZone
 
@@ -94,19 +92,18 @@ private extension AnalyticsPeriodHeader {
         let end = dateRange.upperBound.formatted(dateFormatStyle)
         return "\(start) 〜 \(end)"
     }
+
 }
 
 // MARK: プレゼンテーションロジック
 
 private extension AnalyticsPeriodHeader {
-    
+
     func tappedShiftLeftButton() {
-        
         selectedPeriod = selectedPeriod.shiftPeriod(by: -1, calendar: calendar)
     }
-    
-    func tappedShiftRightButton() {
 
+    func tappedShiftRightButton() {
         let shifted = selectedPeriod.shiftPeriod(by: 1, calendar: calendar)
         if shifted.anchor > now {
             selectedPeriod = .init(type: shifted.type, anchor: now)
@@ -114,66 +111,67 @@ private extension AnalyticsPeriodHeader {
             selectedPeriod = shifted
         }
     }
+
 }
 
 #if DEBUG
-#Preview("AnalyticsPeriodHeader_直近1週間の表示", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .week,
-        anchor: .previewDate(year: 2026, month: 4, day: 30)
-    )
-    AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
-        .setupEnvironmentForPreview()
-        .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
-}
+    #Preview("AnalyticsPeriodHeader_直近1週間の表示", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .week,
+            anchor: .previewDate(year: 2026, month: 4, day: 30)
+        )
+        AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
+            .setupEnvironmentForPreview()
+            .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
+    }
 
-#Preview("AnalyticsPeriodHeader_直近1ヶ月の表示", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .month,
-        anchor: .previewDate(year: 2026, month: 4, day: 30)
-    )
-    AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
-        .setupEnvironmentForPreview()
-        .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
-}
+    #Preview("AnalyticsPeriodHeader_直近1ヶ月の表示", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .month,
+            anchor: .previewDate(year: 2026, month: 4, day: 30)
+        )
+        AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
+            .setupEnvironmentForPreview()
+            .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
+    }
 
-#Preview("AnalyticsPeriodHeader_直近1年の表示", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .year,
-        anchor: .previewDate(year: 2026, month: 4, day: 30)
-    )
-    AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
-        .setupEnvironmentForPreview()
-        .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
-}
+    #Preview("AnalyticsPeriodHeader_直近1年の表示", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .year,
+            anchor: .previewDate(year: 2026, month: 4, day: 30)
+        )
+        AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
+            .setupEnvironmentForPreview()
+            .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
+    }
 
-#Preview("AnalyticsPeriodHeader_直近でない1週間の表示", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .week,
-        anchor: .previewDate(year: 2026, month: 3, day: 30)
-    )
-    AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
-        .setupEnvironmentForPreview()
-        .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
-}
+    #Preview("AnalyticsPeriodHeader_直近でない1週間の表示", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .week,
+            anchor: .previewDate(year: 2026, month: 3, day: 30)
+        )
+        AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
+            .setupEnvironmentForPreview()
+            .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
+    }
 
-#Preview("AnalyticsPeriodHeader_直近でない1ヶ月の表示", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .month,
-        anchor: .previewDate(year: 2026, month: 3, day: 30)
-    )
-    AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
-        .setupEnvironmentForPreview()
-        .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
-}
+    #Preview("AnalyticsPeriodHeader_直近でない1ヶ月の表示", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .month,
+            anchor: .previewDate(year: 2026, month: 3, day: 30)
+        )
+        AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
+            .setupEnvironmentForPreview()
+            .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
+    }
 
-#Preview("AnalyticsPeriodHeader_直近でない1年の表示", traits: .sizeThatFitsLayout) {
-    @Previewable @State var selectedPeriod = DisplayPointPeriod(
-        type: .year,
-        anchor: .previewDate(year: 2026, month: 3, day: 30)
-    )
-    AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
-        .setupEnvironmentForPreview()
-        .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
-}
+    #Preview("AnalyticsPeriodHeader_直近でない1年の表示", traits: .sizeThatFitsLayout) {
+        @Previewable @State var selectedPeriod = DisplayPointPeriod(
+            type: .year,
+            anchor: .previewDate(year: 2026, month: 3, day: 30)
+        )
+        AnalyticsPeriodHeader(selectedPeriod: $selectedPeriod)
+            .setupEnvironmentForPreview()
+            .environment(\.now, .previewDate(year: 2026, month: 4, day: 30))
+    }
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/AnalyticsRankingRow.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/AnalyticsRankingRow.swift
@@ -53,54 +53,55 @@ struct AnalyticsRankingRow: View {
     private var formattedAverage: String {
         String(format: "%.1f%@", item.averageValue, totalUnit)
     }
+
 }
 
 #if DEBUG
-#Preview("AnalyticsRankingRow_1位_あなた", traits: .sizeThatFitsLayout) {
-    AnalyticsRankingRow(
-        item: .init(
-            rank: 1,
-            userId: "user1",
-            userName: "田中",
-            isMe: true,
-            totalValue: 120,
-            averageValue: 17.1
-        ),
-        totalUnit: "pt",
-        averageDenominatorUnit: "日"
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("AnalyticsRankingRow_1位_あなた", traits: .sizeThatFitsLayout) {
+        AnalyticsRankingRow(
+            item: .init(
+                rank: 1,
+                userId: "user1",
+                userName: "田中",
+                isMe: true,
+                totalValue: 120,
+                averageValue: 17.1
+            ),
+            totalUnit: "pt",
+            averageDenominatorUnit: "日"
+        )
+        .setupEnvironmentForPreview()
+    }
 
-#Preview("AnalyticsRankingRow_2位", traits: .sizeThatFitsLayout) {
-    AnalyticsRankingRow(
-        item: .init(
-            rank: 2,
-            userId: "user2",
-            userName: "佐藤",
-            isMe: false,
-            totalValue: 40,
-            averageValue: 5.7
-        ),
-        totalUnit: "pt",
-        averageDenominatorUnit: "日"
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("AnalyticsRankingRow_2位", traits: .sizeThatFitsLayout) {
+        AnalyticsRankingRow(
+            item: .init(
+                rank: 2,
+                userId: "user2",
+                userName: "佐藤",
+                isMe: false,
+                totalValue: 40,
+                averageValue: 5.7
+            ),
+            totalUnit: "pt",
+            averageDenominatorUnit: "日"
+        )
+        .setupEnvironmentForPreview()
+    }
 
-#Preview("AnalyticsRankingRow_達成数", traits: .sizeThatFitsLayout) {
-    AnalyticsRankingRow(
-        item: .init(
-            rank: 1,
-            userId: "user1",
-            userName: "田中",
-            isMe: false,
-            totalValue: 24,
-            averageValue: 2.0
-        ),
-        totalUnit: "件",
-        averageDenominatorUnit: "月"
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("AnalyticsRankingRow_達成数", traits: .sizeThatFitsLayout) {
+        AnalyticsRankingRow(
+            item: .init(
+                rank: 1,
+                userId: "user1",
+                userName: "田中",
+                isMe: false,
+                totalValue: 24,
+                averageValue: 2.0
+            ),
+            totalUnit: "件",
+            averageDenominatorUnit: "月"
+        )
+        .setupEnvironmentForPreview()
+    }
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/AnalyticsRankingSection.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/AnalyticsRankingSection.swift
@@ -15,8 +15,8 @@ struct AnalyticsRankingSection: View {
     let selectedPriodType: DisplayPointPeriod.PeriodType
 
     @State private var selectedCriterion: ContributionAnalyticsRankingCriterion = .point
-    
-    // ランキング行の高さ
+
+    /// ランキング行の高さ
     private static let rowHeight: CGFloat = 70
 
     var body: some View {
@@ -35,18 +35,19 @@ struct AnalyticsRankingSection: View {
             .padding(.horizontal, .space16)
 
             #if os(iOS)
-            TabView(selection: $selectedCriterion) {
-                rankingList(items: pointRanking, criterion: .point)
-                    .tag(ContributionAnalyticsRankingCriterion.point)
+                TabView(selection: $selectedCriterion) {
+                    rankingList(items: pointRanking, criterion: .point)
+                        .tag(ContributionAnalyticsRankingCriterion.point)
 
-                rankingList(items: achievementRanking, criterion: .achievement)
-                    .tag(ContributionAnalyticsRankingCriterion.achievement)
-            }
-            .tabViewStyle(.page(indexDisplayMode: .never))
-            .frame(height: tabViewHeight)
+                    rankingList(items: achievementRanking, criterion: .achievement)
+                        .tag(ContributionAnalyticsRankingCriterion.achievement)
+                }
+                .tabViewStyle(.page(indexDisplayMode: .never))
+                .frame(height: tabViewHeight)
             #endif
         }
     }
+
 }
 
 private extension AnalyticsRankingSection {
@@ -75,47 +76,48 @@ private extension AnalyticsRankingSection {
         let rowCount = max(pointRanking.count, achievementRanking.count, 1)
         return CGFloat(rowCount) * (Self.rowHeight + 1)
     }
-    
+
     var averageDenominatorUnit: String {
         switch selectedPriodType {
         case .week, .month: "日"
         case .year: "月"
         }
     }
+
 }
 
 #if DEBUG
-#Preview("AnalyticsRankingSection_週", traits: .sizeThatFitsLayout) {
-    AnalyticsRankingSection(
-        pointRanking: [
-            .init(rank: 1, userId: "user1", userName: "田中", isMe: true, totalValue: 78, averageValue: 11.1),
-            .init(rank: 2, userId: "user2", userName: "佐藤", isMe: false, totalValue: 60, averageValue: 8.6),
-            .init(rank: 3, userId: "user3", userName: "佐藤", isMe: false, totalValue: 50, averageValue: 8.2),
-            .init(rank: 4, userId: "user4", userName: "佐藤", isMe: false, totalValue: 40, averageValue: 8.1)
-        ],
-        achievementRanking: [
-            .init(rank: 1, userId: "user1", userName: "田中", isMe: true, totalValue: 5, averageValue: 0.7),
-            .init(rank: 2, userId: "user2", userName: "佐藤", isMe: false, totalValue: 3, averageValue: 0.4),
-            .init(rank: 3, userId: "user3", userName: "佐藤", isMe: false, totalValue: 50, averageValue: 8.2),
-            .init(rank: 4, userId: "user4", userName: "佐藤", isMe: false, totalValue: 40, averageValue: 8.1)
-        ],
-        selectedPriodType: .week
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("AnalyticsRankingSection_週", traits: .sizeThatFitsLayout) {
+        AnalyticsRankingSection(
+            pointRanking: [
+                .init(rank: 1, userId: "user1", userName: "田中", isMe: true, totalValue: 78, averageValue: 11.1),
+                .init(rank: 2, userId: "user2", userName: "佐藤", isMe: false, totalValue: 60, averageValue: 8.6),
+                .init(rank: 3, userId: "user3", userName: "佐藤", isMe: false, totalValue: 50, averageValue: 8.2),
+                .init(rank: 4, userId: "user4", userName: "佐藤", isMe: false, totalValue: 40, averageValue: 8.1),
+            ],
+            achievementRanking: [
+                .init(rank: 1, userId: "user1", userName: "田中", isMe: true, totalValue: 5, averageValue: 0.7),
+                .init(rank: 2, userId: "user2", userName: "佐藤", isMe: false, totalValue: 3, averageValue: 0.4),
+                .init(rank: 3, userId: "user3", userName: "佐藤", isMe: false, totalValue: 50, averageValue: 8.2),
+                .init(rank: 4, userId: "user4", userName: "佐藤", isMe: false, totalValue: 40, averageValue: 8.1),
+            ],
+            selectedPriodType: .week
+        )
+        .setupEnvironmentForPreview()
+    }
 
-#Preview("AnalyticsRankingSection_年", traits: .sizeThatFitsLayout) {
-    AnalyticsRankingSection(
-        pointRanking: [
-            .init(rank: 1, userId: "user2", userName: "佐藤", isMe: false, totalValue: 350, averageValue: 29.2),
-            .init(rank: 2, userId: "user1", userName: "田中", isMe: true, totalValue: 280, averageValue: 23.3)
-        ],
-        achievementRanking: [
-            .init(rank: 1, userId: "user1", userName: "田中", isMe: true, totalValue: 24, averageValue: 2.0),
-            .init(rank: 2, userId: "user2", userName: "佐藤", isMe: false, totalValue: 18, averageValue: 1.5)
-        ],
-        selectedPriodType: .year
-    )
-    .setupEnvironmentForPreview()
-}
+    #Preview("AnalyticsRankingSection_年", traits: .sizeThatFitsLayout) {
+        AnalyticsRankingSection(
+            pointRanking: [
+                .init(rank: 1, userId: "user2", userName: "佐藤", isMe: false, totalValue: 350, averageValue: 29.2),
+                .init(rank: 2, userId: "user1", userName: "田中", isMe: true, totalValue: 280, averageValue: 23.3),
+            ],
+            achievementRanking: [
+                .init(rank: 1, userId: "user1", userName: "田中", isMe: true, totalValue: 24, averageValue: 2.0),
+                .init(rank: 2, userId: "user2", userName: "佐藤", isMe: false, totalValue: 18, averageValue: 1.5),
+            ],
+            selectedPriodType: .year
+        )
+        .setupEnvironmentForPreview()
+    }
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/CumulativePointsAreaChartView.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/CumulativePointsAreaChartView.swift
@@ -14,9 +14,9 @@ struct CumulativePointsAreaChartView: View {
     @Environment(\.locale) private var locale
     @Environment(\.calendar) private var calendar
     @Environment(\.timeZone) var timeZone
-    
+
     @State var selectedDate: Date?
-    
+
     let viewableData: AllUserCumulativeData
 
     var body: some View {
@@ -28,21 +28,22 @@ struct CumulativePointsAreaChartView: View {
                 GraphDescriptionPopoverButton(
                     title: "獲得ポイントの累積からわかること",
                     message: """
-                        期間の最初から日が経つごとに積み上がっていく合計ポイントです。
-                        期間の終わりで最も高い位置にいる人が、その期間中にもっとも多くポイントを獲得した人です。
-                        線の傾きが急な時期は、その日に多くポイントを獲得した時期を表します。
-                        """
+                    期間の最初から日が経つごとに積み上がっていく合計ポイントです。
+                    期間の終わりで最も高い位置にいる人が、その期間中にもっとも多くポイントを獲得した人です。
+                    線の傾きが急な時期は、その日に多くポイントを獲得した時期を表します。
+                    """
                 )
             }
             graphContent(viewableData.list)
         }
     }
+
 }
 
 // MARK: UI定義
 
 private extension CumulativePointsAreaChartView {
-    
+
     func graphContent(_ list: [ViewablePointList]) -> some View {
         Chart {
             ForEach(list, id: \.self) { userData in
@@ -84,7 +85,7 @@ private extension CumulativePointsAreaChartView {
             }
         }
     }
-    
+
     func userCumulativeArea(_ userData: ViewablePointList) -> some ChartContent {
         ForEach(userData.sortedElements, id: \.self) { element in
             AreaMark(
@@ -100,7 +101,7 @@ private extension CumulativePointsAreaChartView {
             .foregroundStyle(by: .value("ユーザー", userData.userName))
         }
     }
-    
+
     func selectedChartMark(_ selectedDate: Date) -> some ChartContent {
         RuleMark(x: .value("日付", selectedDate))
             .foregroundStyle(.secondary.opacity(0.3))
@@ -118,15 +119,15 @@ private extension CumulativePointsAreaChartView {
                 )
             }
     }
-    
+
     var xAxisStride: AxisMarkValues {
         switch viewableData.displayPeriod {
         case .week:
-            return .automatic(desiredCount: 7)
+            .automatic(desiredCount: 7)
         case .month:
-            return .automatic(desiredCount: 5)
+            .automatic(desiredCount: 5)
         case .year:
-            return .automatic(desiredCount: 12)
+            .automatic(desiredCount: 12)
         }
     }
 
@@ -136,19 +137,20 @@ private extension CumulativePointsAreaChartView {
         case .month: .dateTime.day().locale(locale)
         case .week: .dateTime.weekday(.abbreviated).locale(locale)
         }
-        
+
         formatStyle.timeZone = timeZone
         return formatStyle
     }
-    
+
     var graphTitle: String {
         let unitStr = switch viewableData.displayPeriod {
         case .year: "月ごと"
         case .month, .week: "日ごと"
         }
-        
+
         return "\(unitStr)獲得ポイントの累積"
     }
+
 }
 
 // MARK: プレゼンテーションロジック
@@ -156,60 +158,60 @@ private extension CumulativePointsAreaChartView {
 private extension CumulativePointsAreaChartView {
 
     func handleTap(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) {
-
         let frame = geometry.frame(in: .local)
         guard let tapDate: Date = proxy.value(atX: location.x - frame.minX) else { return }
         let nearest = viewableData.nearestDate(to: tapDate)
         selectedDate = selectedDate == nearest ? nil : nearest
     }
+
 }
 
 #if DEBUG
-#Preview("CumulativePointsAreaChartView_週間 (日別)", traits: .sizeThatFitsLayout) {
-    let allUserList = ContributionAnalytics
-        .makeForPreview(type: .week)
-        .currentList(calendar: .japanese)
+    #Preview("CumulativePointsAreaChartView_週間 (日別)", traits: .sizeThatFitsLayout) {
+        let allUserList = ContributionAnalytics
+            .makeForPreview(type: .week)
+            .currentList(calendar: .japanese)
 
-    CumulativePointsAreaChartView(
-        viewableData: AllUserCumulativeData.make(
-            list: allUserList.list,
-            displayPeriod: .week
+        CumulativePointsAreaChartView(
+            viewableData: AllUserCumulativeData.make(
+                list: allUserList.list,
+                displayPeriod: .week
+            )
         )
-    )
-    .frame(height: 240)
-    .setupEnvironmentForPreview()
-    .padding(.space16)
-}
+        .frame(height: 240)
+        .setupEnvironmentForPreview()
+        .padding(.space16)
+    }
 
-#Preview("CumulativePointsAreaChartView_月間 (日別)", traits: .sizeThatFitsLayout) {
-    let allUserList = ContributionAnalytics
-        .makeForPreview(type: .month)
-        .currentList(calendar: .japanese)
+    #Preview("CumulativePointsAreaChartView_月間 (日別)", traits: .sizeThatFitsLayout) {
+        let allUserList = ContributionAnalytics
+            .makeForPreview(type: .month)
+            .currentList(calendar: .japanese)
 
-    CumulativePointsAreaChartView(
-        viewableData: AllUserCumulativeData.make(
-            list: allUserList.list,
-            displayPeriod: .month
+        CumulativePointsAreaChartView(
+            viewableData: AllUserCumulativeData.make(
+                list: allUserList.list,
+                displayPeriod: .month
+            )
         )
-    )
-    .frame(height: 240)
-    .setupEnvironmentForPreview()
-    .padding(.space16)
-}
+        .frame(height: 240)
+        .setupEnvironmentForPreview()
+        .padding(.space16)
+    }
 
-#Preview("CumulativePointsAreaChartView_年間 (月別)", traits: .sizeThatFitsLayout) {
-    let allUserList = ContributionAnalytics
-        .makeForPreview(type: .year)
-        .currentList(calendar: .japanese)
+    #Preview("CumulativePointsAreaChartView_年間 (月別)", traits: .sizeThatFitsLayout) {
+        let allUserList = ContributionAnalytics
+            .makeForPreview(type: .year)
+            .currentList(calendar: .japanese)
 
-    CumulativePointsAreaChartView(
-        viewableData: AllUserCumulativeData.make(
-            list: allUserList.list,
-            displayPeriod: .year
+        CumulativePointsAreaChartView(
+            viewableData: AllUserCumulativeData.make(
+                list: allUserList.list,
+                displayPeriod: .year
+            )
         )
-    )
-    .frame(height: 240)
-    .setupEnvironmentForPreview()
-    .padding(.space16)
-}
+        .frame(height: 240)
+        .setupEnvironmentForPreview()
+        .padding(.space16)
+    }
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/PointsTimeSeriesChartView.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Analytics/SubViews/PointsTimeSeriesChartView.swift
@@ -15,9 +15,9 @@ struct PointsTimeSeriesChartView: View {
     @Environment(\.locale) private var locale
     @Environment(\.calendar) private var calendar
     @Environment(\.timeZone) private var timeZone
-    
+
     let viewableData: AllUserViewablePointList
-    
+
     @State var selectedDate: Date?
 
     var body: some View {
@@ -29,20 +29,21 @@ struct PointsTimeSeriesChartView: View {
                 GraphDescriptionPopoverButton(
                     title: "獲得ポイントからわかること",
                     message: """
-                        期間中、\(periodUnitLabel)に獲得したポイントを表します。
-                        同じ日のユーザー同士を比較すれば、その日に誰がよく頑張ったかが一目でわかります。
-                        """
+                    期間中、\(periodUnitLabel)に獲得したポイントを表します。
+                    同じ日のユーザー同士を比較すれば、その日に誰がよく頑張ったかが一目でわかります。
+                    """
                 )
             }
             graphContent(viewableData.list)
         }
     }
+
 }
 
 // MARK: UI定義
 
 private extension PointsTimeSeriesChartView {
-    
+
     func graphContent(_ list: [ViewablePointList]) -> some View {
         Chart {
             ForEach(list, id: \.self) { userData in
@@ -78,7 +79,7 @@ private extension PointsTimeSeriesChartView {
             }
         }
     }
-    
+
     func userDataPlotContent(_ userData: ViewablePointList) -> some ChartContent {
         ForEach(userData.sortedElements, id: \.self) { element in
             LineMark(
@@ -93,7 +94,7 @@ private extension PointsTimeSeriesChartView {
             .foregroundStyle(by: .value("ユーザー", userData.userName))
         }
     }
-    
+
     func selectedChartMark(_ selectedDate: Date) -> some ChartContent {
         RuleMark(x: .value("日付", selectedDate))
             .foregroundStyle(.secondary.opacity(0.3))
@@ -112,47 +113,46 @@ private extension PointsTimeSeriesChartView {
                 )
             }
     }
-    
+
     var xAxisStride: AxisMarkValues {
         switch viewableData.displayPeriod {
         case .week:
-            return .automatic(desiredCount: 7)
+            .automatic(desiredCount: 7)
         case .month:
-            return .automatic(desiredCount: 5)
+            .automatic(desiredCount: 5)
         case .year:
-            return .automatic(desiredCount: 12)
+            .automatic(desiredCount: 12)
         }
     }
 
     var xLabelFormat: Date.FormatStyle {
-        var style: Date.FormatStyle
-        switch viewableData.displayPeriod {
-        case .year: style = .dateTime.month(.defaultDigits).locale(locale)
-        case .month: style = .dateTime.day().locale(locale)
-        case .week: style = .dateTime.weekday(.abbreviated).locale(locale)
+        var style: Date.FormatStyle = switch viewableData.displayPeriod {
+        case .year: .dateTime.month(.defaultDigits).locale(locale)
+        case .month: .dateTime.day().locale(locale)
+        case .week: .dateTime.weekday(.abbreviated).locale(locale)
         }
         style.timeZone = timeZone
         return style
     }
-    
+
     var periodUnitLabel: String {
-        return switch viewableData.displayPeriod {
+        switch viewableData.displayPeriod {
         case .year: "月ごとの"
         case .month, .week: "日ごとの"
         }
     }
+
 }
 
 // MARK: プレゼンテーションロジック
 
 private extension PointsTimeSeriesChartView {
-    
+
     func handleTap(
         at location: CGPoint,
         proxy: ChartProxy,
         geometry: GeometryProxy
     ) {
-        
         let frame = geometry.frame(in: .local)
         guard let tapDate: Date = proxy.value(atX: location.x - frame.minX) else { return }
         guard let nearest = viewableData.nearestDate(to: tapDate) else {
@@ -161,53 +161,54 @@ private extension PointsTimeSeriesChartView {
         }
         selectedDate = selectedDate == nearest ? nil : nearest
     }
+
 }
 
 #if DEBUG
-#Preview("PointsTimeSeriesChartView_週間 (日別)", traits: .sizeThatFitsLayout) {
-    let allUserList = ContributionAnalytics
-        .makeForPreview(type: .week)
-        .currentList(calendar: .japanese)
+    #Preview("PointsTimeSeriesChartView_週間 (日別)", traits: .sizeThatFitsLayout) {
+        let allUserList = ContributionAnalytics
+            .makeForPreview(type: .week)
+            .currentList(calendar: .japanese)
 
-    PointsTimeSeriesChartView(
-        viewableData: allUserList,
-        selectedDate: .previewDate(year: 2026, month: 4, day: 24)
-    )
-    .frame(height: 240)
-    .setupEnvironmentForPreview()
-    .padding(.horizontal, .space16)
-    .padding(.vertical, .space56)
-}
+        PointsTimeSeriesChartView(
+            viewableData: allUserList,
+            selectedDate: .previewDate(year: 2026, month: 4, day: 24)
+        )
+        .frame(height: 240)
+        .setupEnvironmentForPreview()
+        .padding(.horizontal, .space16)
+        .padding(.vertical, .space56)
+    }
 
-#Preview("PointsTimeSeriesChartView_月間 (日別)", traits: .sizeThatFitsLayout) {
-    let allUserList = ContributionAnalytics
-        .makeForPreview(type: .month)
-        .currentList(calendar: .japanese)
+    #Preview("PointsTimeSeriesChartView_月間 (日別)", traits: .sizeThatFitsLayout) {
+        let allUserList = ContributionAnalytics
+            .makeForPreview(type: .month)
+            .currentList(calendar: .japanese)
 
-    PointsTimeSeriesChartView(
-        viewableData: allUserList,
-        selectedDate: .previewDate(year: 2026, month: 4, day: 24)
-    )
-    .frame(height: 240)
-    .setupEnvironmentForPreview()
-    .padding(.horizontal, .space16)
-    .padding(.vertical, .space56)
-    // Xcode Cloudでわずかに差分が出てしまうので必要とする一致率を下げる
-    .snapshotForPreview(precision: 0.95, perceptualPrecision: 0.95)
-}
+        PointsTimeSeriesChartView(
+            viewableData: allUserList,
+            selectedDate: .previewDate(year: 2026, month: 4, day: 24)
+        )
+        .frame(height: 240)
+        .setupEnvironmentForPreview()
+        .padding(.horizontal, .space16)
+        .padding(.vertical, .space56)
+        // Xcode Cloudでわずかに差分が出てしまうので必要とする一致率を下げる
+        .snapshotForPreview(precision: 0.95, perceptualPrecision: 0.95)
+    }
 
-#Preview("PointsTimeSeriesChartView_年間 (月別)", traits: .sizeThatFitsLayout) {
-    let allUserList = ContributionAnalytics
-        .makeForPreview(type: .year)
-        .currentList(calendar: .japanese)
+    #Preview("PointsTimeSeriesChartView_年間 (月別)", traits: .sizeThatFitsLayout) {
+        let allUserList = ContributionAnalytics
+            .makeForPreview(type: .year)
+            .currentList(calendar: .japanese)
 
-    PointsTimeSeriesChartView(
-        viewableData: allUserList,
-        selectedDate: .previewDate(year: 2026, month: 4, day: 1)
-    )
-    .frame(height: 240)
-    .setupEnvironmentForPreview()
-    .padding(.horizontal, .space16)
-    .padding(.vertical, .space56)
-}
+        PointsTimeSeriesChartView(
+            viewableData: allUserList,
+            selectedDate: .previewDate(year: 2026, month: 4, day: 1)
+        )
+        .frame(height: 240)
+        .setupEnvironmentForPreview()
+        .padding(.horizontal, .space16)
+        .padding(.vertical, .space56)
+    }
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Common/ContributionPieChart.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Common/ContributionPieChart.swift
@@ -40,6 +40,7 @@ struct ContributionPieChart: View {
             .chartLegend(position: .bottom, alignment: .center)
         }
     }
+
 }
 
 #Preview(traits: .sizeThatFitsLayout) {
@@ -54,7 +55,7 @@ struct ContributionPieChart: View {
                 userId: "user2",
                 userName: "佐藤",
                 achievedCount: 2
-            )
+            ),
         ]
     )
     .frame(height: 240)

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Common/GraphDescriptionPopover.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Common/GraphDescriptionPopover.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct GraphDescriptionPopoverButton: View {
-    
+
     let title: LocalizedStringKey
     let message: LocalizedStringKey
-    
+
     @State var isShowPopover = false
 
     var body: some View {
@@ -36,6 +36,7 @@ struct GraphDescriptionPopoverButton: View {
             .presentationCompactAdaptation(.popover)
         }
     }
+
 }
 
 #Preview("GraphDescriptionPopoverButton_ポップアップ非表示", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Summary/ContributionSummaryComponent.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Summary/ContributionSummaryComponent.swift
@@ -10,7 +10,7 @@ import HometeUI
 import SwiftUI
 
 public struct ContributionSummaryComponent: View {
-    
+
     @Environment(ContributionStore.self) var contributionStore
     @Environment(\.cohabitantMembers) var members
     @Environment(\.loginContext.account.id) var userId
@@ -39,15 +39,15 @@ public struct ContributionSummaryComponent: View {
                     .environment(contributionStore)
             }
     }
+
 }
 
 private extension ContributionSummaryComponent {
 
     func onChangeContribution() async {
-
         let contribution = contributionStore.contiribution
         print("did change contribution: \(contribution), members: \(members)")
-        
+
         let myUserId = userId
 
         let summary = await Task.detached {
@@ -63,13 +63,14 @@ private extension ContributionSummaryComponent {
             self.summary = summary
         }
     }
+
 }
 
 struct ContributionSummaryContent: View {
 
     @Environment(\.calendar) var calendar
     @Environment(\.now) var now
-    
+
     @Binding var isShowAnalytics: Bool
 
     let summaries: AllUserPointSummary
@@ -96,12 +97,13 @@ struct ContributionSummaryContent: View {
             }
         }
     }
+
 }
 
 // MARK: - UI定義
 
 private extension ContributionSummaryContent {
-    
+
     func graphContent(_ summaries: AllUserPointSummary) -> some View {
         VStack(spacing: .space16) {
             ContributionGraphSection(summaries: summaries)
@@ -111,7 +113,7 @@ private extension ContributionSummaryContent {
             .primaryButtonStyle()
         }
     }
-    
+
     func rankingContent(_ ranking: [ContributionRankItem]) -> some View {
         VStack(spacing: .space8) {
             HStack(spacing: .zero) {
@@ -137,44 +139,45 @@ private extension ContributionSummaryContent {
             }
         }
     }
-    
+
     var monthTitle: String {
         let month = calendar.component(.month, from: now)
         return "\(month)月の家事貢献度サマリー"
     }
+
 }
 
 #if DEBUG
-#Preview("ContributionSummaryContent_データ有り", traits: .sizeThatFitsLayout) {
-    ContributionSummaryContent(
-        isShowAnalytics: .constant(false),
-        summaries: AllUserPointSummary(items: [
-            UserPointSummary(
-                userId: "user1",
-                userName: "田中",
-                isMe: true,
-                monthlyPoint: .init(value: 120),
-                achievedCount: 5
-            ),
-            UserPointSummary(
-                userId: "user2",
-                userName: "佐藤",
-                isMe: false,
-                monthlyPoint: .init(value: 40),
-                achievedCount: 2
-            )
-        ])
-    )
-    .environment(\.now, .previewDate(year: 2026, month: 4, day: 1))
-    .setupEnvironmentForPreview()
-}
+    #Preview("ContributionSummaryContent_データ有り", traits: .sizeThatFitsLayout) {
+        ContributionSummaryContent(
+            isShowAnalytics: .constant(false),
+            summaries: AllUserPointSummary(items: [
+                UserPointSummary(
+                    userId: "user1",
+                    userName: "田中",
+                    isMe: true,
+                    monthlyPoint: .init(value: 120),
+                    achievedCount: 5
+                ),
+                UserPointSummary(
+                    userId: "user2",
+                    userName: "佐藤",
+                    isMe: false,
+                    monthlyPoint: .init(value: 40),
+                    achievedCount: 2
+                ),
+            ])
+        )
+        .environment(\.now, .previewDate(year: 2026, month: 4, day: 1))
+        .setupEnvironmentForPreview()
+    }
 
-#Preview("ContributionSummaryContent_データ無し", traits: .sizeThatFitsLayout) {
-    ContributionSummaryContent(
-        isShowAnalytics: .constant(false),
-        summaries: AllUserPointSummary(items: [])
-    )
-    .environment(\.now, .previewDate(year: 2026, month: 4, day: 1))
-    .setupEnvironmentForPreview()
-}
+    #Preview("ContributionSummaryContent_データ無し", traits: .sizeThatFitsLayout) {
+        ContributionSummaryContent(
+            isShowAnalytics: .constant(false),
+            summaries: AllUserPointSummary(items: [])
+        )
+        .environment(\.now, .previewDate(year: 2026, month: 4, day: 1))
+        .setupEnvironmentForPreview()
+    }
 #endif

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Summary/SubViews/ContributionGraphSection.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Summary/SubViews/ContributionGraphSection.swift
@@ -13,18 +13,18 @@ struct ContributionGraphSection: View {
 
     var body: some View {
         #if os(iOS)
-        TabView {
-            charts
-                .padding(.bottom, .space48)
-        }
-        .tabViewStyle(.page(indexDisplayMode: .always))
-        .indexViewStyle(.page(backgroundDisplayMode: .always))
-        .frame(height: 300)
+            TabView {
+                charts
+                    .padding(.bottom, .space48)
+            }
+            .tabViewStyle(.page(indexDisplayMode: .always))
+            .indexViewStyle(.page(backgroundDisplayMode: .always))
+            .frame(height: 300)
         #else
-        TabView {
-            charts
-        }
-        .frame(height: 280)
+            TabView {
+                charts
+            }
+            .frame(height: 280)
         #endif
     }
 
@@ -37,6 +37,7 @@ struct ContributionGraphSection: View {
             data: summaries.achieved()
         )
     }
+
 }
 
 #Preview(traits: .sizeThatFitsLayout) {
@@ -55,7 +56,7 @@ struct ContributionGraphSection: View {
                 isMe: false,
                 monthlyPoint: .init(value: 40),
                 achievedCount: 2
-            )
+            ),
         ])
     )
 }

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Summary/SubViews/LegendPopover.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Summary/SubViews/LegendPopover.swift
@@ -26,6 +26,7 @@ struct LegendPopover: View {
         }
         .padding(.space16)
     }
+
 }
 
 #Preview(traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Summary/SubViews/SummaryPointBarChart.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Summary/SubViews/SummaryPointBarChart.swift
@@ -35,6 +35,7 @@ struct SummaryPointBarChart: View {
             .chartYAxis(.hidden)
         }
     }
+
 }
 
 #Preview(traits: .sizeThatFitsLayout) {
@@ -53,7 +54,7 @@ struct SummaryPointBarChart: View {
                 isMe: false,
                 monthlyPoint: .init(value: 40),
                 achievedCount: 2
-            )
+            ),
         ])
     )
     .frame(height: 240)

--- a/LocalPackage/Sources/Features/ContributionFeature/View/Summary/SubViews/SummaryRow.swift
+++ b/LocalPackage/Sources/Features/ContributionFeature/View/Summary/SubViews/SummaryRow.swift
@@ -57,4 +57,5 @@ struct SummaryRow: View {
         default: .secondary
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/HomeView/HomeView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/HomeView/HomeView.swift
@@ -34,8 +34,7 @@ public struct HomeView: View {
                         .task {
                             await didAppearRegisteredContent(cohabitantStore: cohabitantStore)
                         }
-                }
-                else if !loginContext.hasCohabitant {
+                } else if !loginContext.hasCohabitant {
                     NotRegisteredContent(
                         isShowCohabitantRegistrationModal: $isShowCohabitantRegistrationModal
                     )
@@ -57,10 +56,11 @@ public struct HomeView: View {
             }
         }
     }
+
 }
 
 public extension HomeView {
-    
+
     static func make(
         contributionStore: ContributionStore?,
         cohabitantStore: CohabitantStore?
@@ -70,6 +70,7 @@ public extension HomeView {
             cohabitantStore: cohabitantStore
         )
     }
+
 }
 
 // MARK: プレゼンテーションロジック
@@ -77,7 +78,6 @@ public extension HomeView {
 private extension HomeView {
 
     func didAppearRegisteredContent(cohabitantStore: CohabitantStore) async {
-
         guard let cohabitantId = loginContext.account.cohabitantId else {
             // パートナー登録完了後にcohabitantIdが無いケースは想定外なので表明としてassertionFailureを行う
             assertionFailure("Required param is nil(cohabitantId)")
@@ -92,7 +92,7 @@ private extension HomeView {
     }
 
     func didAppearNotRegisteredContent() async {
-
         await cohabitantStore?.removeSnapshotListener()
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/NotRegisteredContent.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/NotRegisteredContent.swift
@@ -10,9 +10,9 @@ import HometeUI
 import SwiftUI
 
 struct NotRegisteredContent: View {
-    
+
     @Binding var isShowCohabitantRegistrationModal: Bool
-    
+
     var body: some View {
         VStack(spacing: .zero) {
             Spacer()
@@ -38,6 +38,7 @@ struct NotRegisteredContent: View {
         }
         .padding(.horizontal, .space16)
     }
+
 }
 
 #Preview {

--- a/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/Components/PromoteHouseworkTemplateBanner.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/Components/PromoteHouseworkTemplateBanner.swift
@@ -5,12 +5,12 @@
 //  Created by 佐藤汰一 on 2025/09/04.
 //
 
-import HometeUI
 import HometeResources
+import HometeUI
 import SwiftUI
 
 struct PromoteHouseworkTemplateBanner: View {
-    
+
     var body: some View {
         VStack(alignment: .center, spacing: .space24) {
             Image(.promoteHouseworkTemplateBannerIcon)
@@ -31,6 +31,7 @@ struct PromoteHouseworkTemplateBanner: View {
             .primaryButtonStyle()
         }
     }
+
 }
 
 #Preview(traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/Components/TimelineContent.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/Components/TimelineContent.swift
@@ -10,6 +10,7 @@ import HometeUI
 import SwiftUI
 
 struct TimelineContent: View {
+
     var body: some View {
         VStack(spacing: .space24) {
             Text("タイムライン")
@@ -28,6 +29,7 @@ struct TimelineContent: View {
             }
         }
     }
+
 }
 
 #Preview(traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/Components/TodayHouseworkListContent.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/Components/TodayHouseworkListContent.swift
@@ -10,7 +10,7 @@ import HometeUI
 import SwiftUI
 
 struct TodayHouseworkListContent: View {
-    
+
     var body: some View {
         // TODO: 家事が設定されている場合は、家事の内容を表示する
         VStack(spacing: .space24) {
@@ -41,6 +41,7 @@ struct TodayHouseworkListContent: View {
             }
         }
     }
+
 }
 
 #Preview(traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/RegisteredContent.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/RegisteredContent.swift
@@ -11,12 +11,12 @@ import HometeUI
 import SwiftUI
 
 struct RegisteredContent: View {
-    
+
     @Environment(CohabitantStore.self) var cohabiantStore
     @Environment(ContributionStore.self) var contributionStore
-    
+
     @LoadingState var loadingState
-    
+
     var body: some View {
         ZStack {
             ScrollView {
@@ -40,24 +40,26 @@ struct RegisteredContent: View {
         }
         .fullScreenLoadingIndicator(loadingState)
     }
+
 }
 
 // MARK: プレゼンテーションロジック
 
 private extension RegisteredContent {
-    
+
     func onChangeStoreInitialLoadedStatus() {
         // Storeの初回ロード完了まで、ローディング画面を表示する
         loadingState.isLoading = !contributionStore.isInitialLoaded || !cohabiantStore.isInitialLoaded
     }
+
 }
 
 #if DEBUG
-#Preview {
-    RegisteredContent()
-        .environment(ContributionStore())
-        .environment(CohabitantStore())
-        .environment(\.now, .previewDate(year: 2026, month: 4, day: 1))
-        .setupEnvironmentForPreview()
-}
+    #Preview {
+        RegisteredContent()
+            .environment(ContributionStore())
+            .environment(CohabitantStore())
+            .environment(\.now, .previewDate(year: 2026, month: 4, day: 1))
+            .setupEnvironmentForPreview()
+    }
 #endif

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/ConfirmedRegistrationPeers.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/ConfirmedRegistrationPeers.swift
@@ -5,20 +5,18 @@ struct ConfirmedRegistrationPeers: Equatable {
     private var peers: Set<MCPeerID>
 
     init(peers: Set<MCPeerID>) {
-
         self.peers = peers
     }
 
     mutating func addPeer(_ peer: MCPeerID) {
-
         peers.insert(peer)
     }
 
     func isLeadPeer(connectedPeers: Set<MCPeerID>, myPeerID: MCPeerID) -> Bool? {
-
         guard peers == connectedPeers else { return nil }
         let firstPeerID = ([myPeerID] + connectedPeers)
             .sorted { $0.displayName < $1.displayName }.first
         return firstPeerID == myPeerID
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/P2PServiceType.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/P2PServiceType.swift
@@ -6,6 +6,7 @@
 //
 
 enum P2PServiceType: String {
-    
+
     case register
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Scanner/P2PScanner.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Scanner/P2PScanner.swift
@@ -9,33 +9,29 @@ import MultipeerConnectivity
 import SwiftUI
 
 struct P2PScanner<Content: View>: View {
-    
+
     @Environment(\.myPeerID) var myPeerID
-    
+
     @State var controller: P2PScannerController?
-    
+
     let serviceType: P2PServiceType
     let session: MCSession?
     let content: (any P2PScannerClient) -> Content
-    
+
     init(
         serviceType: P2PServiceType,
         session: MCSession?,
         @ViewBuilder content: @escaping (any P2PScannerClient) -> Content
     ) {
-        
         self.serviceType = serviceType
         self.session = session
         self.content = content
     }
-    
+
     var body: some View {
         ZStack {
             if let controller {
                 content(controller)
-            }
-            else {
-                EmptyView()
             }
         }
         .onChange(of: myPeerID) {
@@ -48,14 +44,15 @@ struct P2PScanner<Content: View>: View {
             setupController()
         }
     }
+
 }
 
 private extension P2PScanner {
-    
+
     func setupController() {
-        
         guard let myPeerID,
               let session else { return }
         controller = .init(session: session, myPeerID: myPeerID, serviceType: serviceType)
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Scanner/P2PScannerClient.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Scanner/P2PScannerClient.swift
@@ -6,16 +6,18 @@
 //
 
 protocol P2PScannerClient {
-    
+
     /// スキャンを開始
     func startScan()
     /// スキャンを終了
     func finishScan()
+
 }
 
 final class P2PScannerClientMock: P2PScannerClient {
-        
+
     func startScan() {}
-    
+
     func finishScan() {}
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Scanner/P2PScannerController.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Scanner/P2PScannerController.swift
@@ -8,17 +8,16 @@
 import MultipeerConnectivity
 
 final class P2PScannerController: NSObject {
-    
+
     private let session: MCSession
     private let advertiser: MCNearbyServiceAdvertiser
     private let browser: MCNearbyServiceBrowser
-    
+
     init(
         session: MCSession,
         myPeerID: MCPeerID,
         serviceType: P2PServiceType
     ) {
-        
         self.session = session
         advertiser = MCNearbyServiceAdvertiser(
             peer: myPeerID,
@@ -26,68 +25,65 @@ final class P2PScannerController: NSObject {
             serviceType: serviceType.rawValue
         )
         browser = MCNearbyServiceBrowser(peer: myPeerID, serviceType: serviceType.rawValue)
-        
+
         super.init()
-        
+
         advertiser.delegate = self
         browser.delegate = self
     }
+
 }
 
 extension P2PScannerController: P2PScannerClient {
-    
+
     func startScan() {
-        
         advertiser.startAdvertisingPeer()
         browser.startBrowsingForPeers()
     }
-    
+
     func finishScan() {
-        
         advertiser.stopAdvertisingPeer()
         browser.stopBrowsingForPeers()
     }
+
 }
 
 extension P2PScannerController: MCNearbyServiceAdvertiserDelegate {
-    
+
     func advertiser(
-        _ advertiser: MCNearbyServiceAdvertiser,
+        _: MCNearbyServiceAdvertiser,
         didReceiveInvitationFromPeer peerID: MCPeerID,
-        withContext context: Data?,
+        withContext _: Data?,
         invitationHandler: @escaping (Bool, MCSession?) -> Void
     ) {
-        
         print("invitation from: \(peerID.displayName)")
         invitationHandler(true, session)
     }
-    
-    func advertiser(_ advertiser: MCNearbyServiceAdvertiser, didNotStartAdvertisingPeer error: any Error) {
-        
+
+    func advertiser(_: MCNearbyServiceAdvertiser, didNotStartAdvertisingPeer error: any Error) {
         print("advertising error: \(error)")
     }
+
 }
 
 extension P2PScannerController: MCNearbyServiceBrowserDelegate {
-    
+
     func browser(
         _ browser: MCNearbyServiceBrowser,
         foundPeer peerID: MCPeerID,
         // swiftlint:disable:next discouraged_optional_collection
-        withDiscoveryInfo info: [String: String]?
+        withDiscoveryInfo _: [String: String]?
     ) {
-        
         print("found device: \(peerID.displayName)")
         browser.invitePeer(peerID, to: session, withContext: nil, timeout: 10)
     }
-    
-    func browser(_ browser: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
-        
+
+    func browser(_: MCNearbyServiceBrowser, lostPeer peerID: MCPeerID) {
         print("lost device: \(peerID.displayName)")
     }
-    
-    func browser(_ browser: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: any Error) {
-        
+
+    func browser(_: MCNearbyServiceBrowser, didNotStartBrowsingForPeers error: any Error) {
         print("browsing error: \(error)")
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Session/MyPeerData.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Session/MyPeerData.swift
@@ -8,37 +8,29 @@
 import MultipeerConnectivity
 
 struct MyPeerData: Equatable {
-    
+
     let id: MCPeerID
     let archivedData: Data?
-    
+
     static func make(archivedData: Data?, displayName: String) -> Self {
-        
         do {
-            
             if let myPeerIDArchivedData = archivedData,
                let myPeerID = try NSKeyedUnarchiver.unarchivedObject(
-                ofClass: MCPeerID.self,
-                from: myPeerIDArchivedData
+                   ofClass: MCPeerID.self,
+                   from: myPeerIDArchivedData
                ) {
-                
                 if myPeerID.displayName.hasPrefix(displayName) {
-                    
                     return .init(id: myPeerID, archivedData: myPeerIDArchivedData)
-                }
-                else {
-                    
+                } else {
                     let myPeerID = MCPeerID(displayName: "\(displayName)_\(UUID().uuidString)")
                     let archivedData = try NSKeyedArchiver.archivedData(
                         withRootObject: myPeerID,
                         requiringSecureCoding: true
                     )
-                    
+
                     return .init(id: myPeerID, archivedData: archivedData)
                 }
-            }
-            else {
-                
+            } else {
                 let myPeerID = MCPeerID(displayName: "\(displayName)_\(UUID().uuidString)")
                 let archivedData = try NSKeyedArchiver.archivedData(
                     withRootObject: myPeerID,
@@ -46,12 +38,11 @@ struct MyPeerData: Equatable {
                 )
                 return .init(id: myPeerID, archivedData: archivedData)
             }
-        }
-        catch {
-            
+        } catch {
             let myPeerID = MCPeerID(displayName: "\(displayName)_\(UUID().uuidString)")
             let archivedData = try? NSKeyedArchiver.archivedData(withRootObject: myPeerID, requiringSecureCoding: true)
             return .init(id: myPeerID, archivedData: archivedData)
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PEnvironments.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PEnvironments.swift
@@ -9,8 +9,9 @@ import MultipeerConnectivity
 import SwiftUI
 
 extension EnvironmentValues {
-    
+
     @Entry var myPeerID: MCPeerID?
     @Entry var connectedPeers: Set<MCPeerID> = []
     @Entry var p2pSessionReceiveData: P2PSessionReceiveData?
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSession.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSession.swift
@@ -9,24 +9,23 @@ import MultipeerConnectivity
 import SwiftUI
 
 struct P2PSession<Content: View>: View {
-        
+
     @AppStorage(key: .archivedPeerIDDataKey) var archivedPeerIDDataKey
-    
+
     @State var session: MCSession?
     @State var myPeerID: MCPeerID?
     @State var connectedPeers: Set<MCPeerID> = []
     @State var sessionDelegate = P2PSessionDelegate()
     @State var receivedData: P2PSessionReceiveData?
-    
+
     let content: (MCSession?) -> Content
     let displayName: String
-    
+
     init(displayName: String, @ViewBuilder content: @escaping (MCSession?) -> Content) {
-        
         self.content = content
         self.displayName = displayName
     }
-    
+
     var body: some View {
         content(session)
             .environment(\.myPeerID, myPeerID)
@@ -35,20 +34,19 @@ struct P2PSession<Content: View>: View {
             .environment(\.p2pSessionProxy, .init(session: session))
             .task {
                 await onAppear()
-                
+
                 for await event in sessionDelegate.eventStream {
-                    
                     switch event {
-                    case .connected(let peerID):
+                    case let .connected(peerID):
                         connectedPeers.insert(peerID)
-                        
-                    case .disconnected(let peerID):
+
+                    case let .disconnected(peerID):
                         connectedPeers.remove(peerID)
-                        
-                    case .received(let data, let sender):
+
+                    case let .received(data, sender):
                         receivedData = .init(id: UUID(), sender: sender, body: data)
                     }
-                    
+
                     print("\(#file) event: \(event), connectedPeers: \(connectedPeers)")
                 }
             }
@@ -56,24 +54,25 @@ struct P2PSession<Content: View>: View {
                 sessionDelegate.finish()
             }
     }
+
 }
 
 private extension P2PSession {
-    
+
     func onAppear() async {
-        
         let myPeerData = MyPeerData.make(
             archivedData: archivedPeerIDDataKey,
             displayName: displayName
         )
-        self.session = MCSession(
+        session = MCSession(
             peer: myPeerData.id,
             securityIdentity: nil,
             encryptionPreference: .required
         )
         myPeerID = myPeerData.id
         archivedPeerIDDataKey = myPeerData.archivedData
-        
+
         session?.delegate = sessionDelegate
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSessionDelegate.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSessionDelegate.swift
@@ -8,63 +8,57 @@
 import MultipeerConnectivity
 
 final class P2PSessionDelegate: NSObject, MCSessionDelegate {
-    
+
     let eventStream: AsyncStream<P2PSessionEvent>
     private let continuation: AsyncStream<P2PSessionEvent>.Continuation
-    
+
     override init() {
-        
         let (eventStream, continuation) = AsyncStream<P2PSessionEvent>.makeStream()
         self.eventStream = eventStream
         self.continuation = continuation
-        
+
         super.init()
     }
-    
+
     func finish() {
-        
         continuation.finish()
     }
-        
-    func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
-        
+
+    func session(_: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
         print("did change session state: \(state)")
         if state == .connected {
-            
             print("connected to: \(peerID.displayName)")
             continuation.yield(.connected(peerID: peerID))
-        }
-        else if state == .notConnected {
-            
+        } else if state == .notConnected {
             print("disconnected to: \(peerID.displayName)")
             continuation.yield(.disconnected(peerID: peerID))
         }
     }
-    
-    func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
-        
+
+    func session(_: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
         print("didReceive from: \(peerID.displayName), data: \(data)")
         continuation.yield(.received(data: data, sender: peerID))
     }
-    
-    // ...他のMCSessionDelegateメソッドは空実装...
+
+    /// ...他のMCSessionDelegateメソッドは空実装...
     func session(
-        _ session: MCSession,
-        didReceive stream: InputStream,
-        withName streamName: String,
-        fromPeer peerID: MCPeerID
+        _: MCSession,
+        didReceive _: InputStream,
+        withName _: String,
+        fromPeer _: MCPeerID
     ) {}
     func session(
-        _ session: MCSession,
-        didStartReceivingResourceWithName resourceName: String,
-        fromPeer peerID: MCPeerID,
-        with progress: Progress
+        _: MCSession,
+        didStartReceivingResourceWithName _: String,
+        fromPeer _: MCPeerID,
+        with _: Progress
     ) {}
     func session(
-        _ session: MCSession,
-        didFinishReceivingResourceWithName resourceName: String,
-        fromPeer peerID: MCPeerID,
-        at localURL: URL?,
-        withError error: (any Error)?
+        _: MCSession,
+        didFinishReceivingResourceWithName _: String,
+        fromPeer _: MCPeerID,
+        at _: URL?,
+        withError _: (any Error)?
     ) {}
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSessionEvent.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSessionEvent.swift
@@ -9,8 +9,9 @@ import MultipeerConnectivity
 
 @MainActor
 enum P2PSessionEvent {
-    
+
     case connected(peerID: MCPeerID)
     case disconnected(peerID: MCPeerID)
     case received(data: Data, sender: MCPeerID)
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSessionMessageProxy.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSessionMessageProxy.swift
@@ -9,34 +9,30 @@ import MultipeerConnectivity
 import SwiftUI
 
 struct P2PSessionMessageProxy {
-    
+
     private let session: MCSession?
-    
+
     init(session: MCSession?) {
-        
         self.session = session
     }
-    
+
     func send(_ message: Data, to peers: Set<MCPeerID>) {
-        
         guard let session else {
-            
             preconditionFailure("Not fount session instance.")
         }
-        
+
         do {
-            
             try session.send(message, toPeers: .init(peers), with: .reliable)
-        }
-        catch {
-            
+        } catch {
             print("Failed send message.")
             session.disconnect()
         }
     }
+
 }
 
 extension EnvironmentValues {
-    
+
     @Entry var p2pSessionProxy: P2PSessionMessageProxy?
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSessionReceiveData.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/P2P/Session/P2PSessionReceiveData.swift
@@ -8,8 +8,9 @@
 import MultipeerConnectivity
 
 struct P2PSessionReceiveData: Equatable, Identifiable {
-    
+
     let id: UUID
     let sender: MCPeerID
     let body: Data
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/CohabitantRegistrationView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/CohabitantRegistrationView.swift
@@ -11,16 +11,16 @@ import MultipeerConnectivity
 import SwiftUI
 
 public struct CohabitantRegistrationView: View {
-    
+
     @Environment(\.loginContext.account.userName) var userName
     @Environment(\.dismiss) var dismiss
     @Environment(AccountStore.self) var accountStore
-    
+
     public init() {}
 
-    // 登録処理を中断するかどうかを確認するアラート
+    /// 登録処理を中断するかどうかを確認するアラート
     @State var isPresentingConfirmCancelAlert = false
-    
+
     public var body: some View {
         NavigationStack {
             P2PSession(displayName: userName) {
@@ -51,20 +51,19 @@ public struct CohabitantRegistrationView: View {
             }
         }
     }
+
 }
 
 // MARK: プレゼンテーションロジック
 
 private extension CohabitantRegistrationView {
-    
+
     func onCompleteCohabitantRegistration(_ cohabitantId: String) async {
-        
         do {
-            
             try await accountStore.registerCohabitantId(cohabitantId)
         } catch {
-            
             print("error occurred: \(error)")
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/Extension/onCompleteCohabitantRegistration.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/Extension/onCompleteCohabitantRegistration.swift
@@ -1,16 +1,17 @@
 import SwiftUI
 
 extension EnvironmentValues {
-    
+
     /// パートナーの登録完了通知
     @Entry var onCompleteCohabitantRegistration: (_ cohabitantId: String) -> Void = { _ in }
+
 }
 
 extension View {
-    
+
     /// パートナーの登録完了通知
     func onCompleteCohabitantRegistration(handler: @escaping (_ cohabitantId: String) -> Void) -> some View {
-        
-        self.environment(\.onCompleteCohabitantRegistration, handler)
+        environment(\.onCompleteCohabitantRegistration, handler)
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CohabitantRegistrationSession.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CohabitantRegistrationSession.swift
@@ -5,18 +5,18 @@
 //  Created by 佐藤汰一 on 2025/08/27.
 //
 
-import MultipeerConnectivity
 import HometeDomain
+import MultipeerConnectivity
 import SwiftUI
 
 struct CohabitantRegistrationSession: View {
-    
+
     @Environment(AccountStore.self) var accountStore
-    
+
     @State var registrationState = CohabitantRegistrationState.scanning
-    
+
     let session: MCSession?
-        
+
     var body: some View {
         ZStack {
             switch registrationState {
@@ -28,14 +28,13 @@ struct CohabitantRegistrationSession: View {
                     )
                 }
                 .transition(.push(from: .trailing))
-            case .processing(let isLead):
+            case let .processing(isLead):
                 ZStack {
                     if isLead {
                         CohabitantRegistrationProcessingLeader(
                             registrationState: $registrationState
                         )
-                    }
-                    else {
+                    } else {
                         CohabitantRegistrationProcessingFollower(
                             registrationState: $registrationState
                         )
@@ -49,4 +48,5 @@ struct CohabitantRegistrationSession: View {
         }
         .animation(.spring, value: registrationState)
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/ConfettiRain/ConfettiRainPiece.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/ConfettiRain/ConfettiRainPiece.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ConfettiRainPiece: Identifiable {
-    
+
     let id = UUID()
     var x: CGFloat
     var color: Color
@@ -19,21 +19,23 @@ struct ConfettiRainPiece: Identifiable {
     var isAnimate: Bool
     var spinX: Double
     var spinY: Double
+
 }
 
 extension ConfettiRainPiece {
-    
+
     private static let colors: [Color] = [.red, .blue, .green, .yellow, .pink, .orange, .purple]
-    
+
     init(screenWidth: CGFloat) {
-        x = CGFloat.random(in: 0...screenWidth)
+        x = CGFloat.random(in: 0 ... screenWidth)
         color = Self.colors.randomElement() ?? .red
-        size = CGFloat.random(in: 8...16)
-        speed = Double.random(in: 4...8)
-        angle = .degrees(Double.random(in: 0...360))
-        drift = CGFloat.random(in: -40...40)
+        size = CGFloat.random(in: 8 ... 16)
+        speed = Double.random(in: 4 ... 8)
+        angle = .degrees(Double.random(in: 0 ... 360))
+        drift = CGFloat.random(in: -40 ... 40)
         isAnimate = false
-        spinX = Double.random(in: -60...60)
-        spinY = Double.random(in: -60...60)
+        spinX = Double.random(in: -60 ... 60)
+        spinY = Double.random(in: -60 ... 60)
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/ConfettiRain/ConfettiRainView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/ConfettiRain/ConfettiRainView.swift
@@ -9,10 +9,10 @@ import Combine
 import SwiftUI
 
 struct ConfettiRainView: View {
-    
+
     @State private var confettis: [ConfettiRainPiece] = []
     @State var timer = Timer.publish(every: 0.2, on: .main, in: .common).autoconnect()
-    
+
     var body: some View {
         GeometryReader { proxy in
             ForEach(confettis) { piece in
@@ -34,27 +34,25 @@ struct ConfettiRainView: View {
         }
         .drawingGroup()
     }
+
 }
 
 private extension ConfettiRainView {
-    
+
     func spawnConfetti(screenWidth: CGFloat) {
-        
-        for _ in 0..<10 {
-            
+        for _ in 0 ..< 10 {
             let piece = ConfettiRainPiece(screenWidth: screenWidth)
             confettis.append(piece)
-            
+
             // 画面下まで落ちたら削除
             withAnimation(.linear(duration: piece.speed)) {
-                
                 guard let index = confettis.firstIndex(where: { $0.id == piece.id }) else { return }
                 confettis[index].isAnimate = true
             } completion: {
-                
                 guard let index = confettis.firstIndex(where: { $0.id == piece.id }) else { return }
                 confettis.remove(at: index)
             }
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/Cracker/CrackerConfettiPiece.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/Cracker/CrackerConfettiPiece.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CrackerConfettiPiece: Identifiable {
-    
+
     let id: UUID
     let size: CGFloat
     var x: CGFloat
@@ -17,32 +17,29 @@ struct CrackerConfettiPiece: Identifiable {
     var angle: Angle
     var speed: CGFloat
     var isShow: Bool
-    
+
     private static let colors: [Color] = [.red, .blue, .green, .yellow, .pink, .orange, .purple]
-    
+
     static func makeConfettis(startX: CGFloat, startY: CGFloat, count: Int = 100) -> [Self] {
-        
-        return (0..<count).map { _ in
-            
-            return .init(
+        (0 ..< count).map { _ in
+            .init(
                 id: UUID(),
                 size: 8,
                 x: startX,
                 y: startY,
                 color: colors.randomElement() ?? .red,
-                angle: .degrees(Double.random(in: -50...50)),
+                angle: .degrees(Double.random(in: -50 ... 50)),
                 speed: 0.6,
                 isShow: true
             )
         }
     }
-    
+
     func explosion(startX: CGFloat, startY: CGFloat) -> Self {
-        
         // 周囲に散らす
-        let dx = CGFloat.random(in: (startX - 70)...(startX + 120))
-        let dy = CGFloat.random(in: (startY - 150)...(startY + 30))
-        
+        let dx = CGFloat.random(in: (startX - 70) ... (startX + 120))
+        let dy = CGFloat.random(in: (startY - 150) ... (startY + 30))
+
         return .init(
             id: id,
             size: size,
@@ -54,11 +51,10 @@ struct CrackerConfettiPiece: Identifiable {
             isShow: true
         )
     }
-    
+
     func scatter() -> Self {
-        
         // 下に移動しながら消える
-        return .init(
+        .init(
             id: id,
             size: size,
             x: x,
@@ -69,4 +65,5 @@ struct CrackerConfettiPiece: Identifiable {
             isShow: false
         )
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/Cracker/CrackerRibbon.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/Cracker/CrackerRibbon.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct CrackerRibbon: Identifiable {
-    
+
     let id: UUID
     var x: CGFloat
     var y: CGFloat
@@ -16,29 +16,26 @@ struct CrackerRibbon: Identifiable {
     var angle: Angle
     var speed: CGFloat
     var opacity: CGFloat
-    
+
     private static let colors: [Color] = [.red, .blue, .green, .yellow, .pink, .orange, .purple]
-    
+
     static func makeRibbons(startX: CGFloat, startY: CGFloat, count: Int = 25) -> [Self] {
-        
-        return (0..<count).map { _ in
-            
-            return .init(
+        (0 ..< count).map { _ in
+            .init(
                 id: UUID(),
                 x: startX,
                 y: startY,
                 color: colors.randomElement() ?? .red,
-                angle: .degrees(Double.random(in: -10...50)),
-                speed: Double.random(in: 0.5...1),
+                angle: .degrees(Double.random(in: -10 ... 50)),
+                speed: Double.random(in: 0.5 ... 1),
                 opacity: 1
             )
         }
     }
-    
+
     func explosion() -> Self {
-        
         // 設定されている角度に応じた方向に飛ばす
-        return .init(
+        .init(
             id: id,
             x: angle.degrees * 10,
             y: 0,
@@ -48,11 +45,10 @@ struct CrackerRibbon: Identifiable {
             opacity: opacity
         )
     }
-    
+
     func scatter() -> Self {
-        
         // 消える
-        return .init(
+        .init(
             id: id,
             x: x,
             y: y,
@@ -62,4 +58,5 @@ struct CrackerRibbon: Identifiable {
             opacity: 0
         )
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/Cracker/CrackerView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/AnimationComponents/Cracker/CrackerView.swift
@@ -8,14 +8,14 @@
 import SwiftUI
 
 struct CrackerView: View {
-    
+
     @State var ribbons: [CrackerRibbon] = []
     @State var confettis: [CrackerConfettiPiece] = []
     @State var launched = false
-    
+
     /// アニメーション終了したら呼ばれるクロージャ
     let completion: () -> Void
-    
+
     var body: some View {
         GeometryReader { proxy in
             ZStack {
@@ -87,69 +87,63 @@ struct CrackerView: View {
             }
         }
     }
+
 }
 
 private extension CrackerView {
-    
+
     func fireCracker(screenHeight: CGFloat) {
-                
         let startX: CGFloat = 60
         let startY: CGFloat = screenHeight - 120
-        
+
         confettis = CrackerConfettiPiece.makeConfettis(startX: startX, startY: startY)
         ribbons = CrackerRibbon.makeRibbons(startX: startX, startY: startY)
-        
+
         // アニメーション開始
-        
+
         withAnimation(.default) {
-            
-            for i in 0..<confettis.count {
-                
+
+            for i in 0 ..< confettis.count {
                 confettis[i] = confettis[i].explosion(startX: startX, startY: startY)
             }
         } completion: {
-            
             withAnimation(.linear(duration: 1.5)) {
-                
-                for i in 0..<confettis.count {
-                    
+
+                for i in 0 ..< confettis.count {
                     confettis[i] = confettis[i].scatter()
                 }
             } completion: {
-                
                 confettis.removeAll()
                 completion()
             }
         }
-        
-        for i in 0..<ribbons.count {
-            
+
+        for i in 0 ..< ribbons.count {
             withAnimation(.easeInOut(duration: ribbons[i].speed)) {
-                
                 ribbons[i] = ribbons[i].explosion()
             }
-            
+
             Task {
-                
                 try await Task.sleep(for: .seconds(ribbons[i].speed / CGFloat(2)))
                 withAnimation {
-                    
                     ribbons[i] = ribbons[i].scatter()
                 } completion: {
-                    
                     ribbons.removeAll()
                 }
             }
         }
     }
+
 }
 
 private extension CrackerView {
-    
+
     struct CrackerAnimationValue {
-        
+
         var opacity = 0.0
         var offset = CGSize.zero
         var scale = 1.0
+
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/CohabitantRegistrationCompleteView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/CompletedState/CohabitantRegistrationCompleteView.swift
@@ -11,9 +11,9 @@ import SwiftUI
 struct CohabitantRegistrationCompleteView: View {
 
     @Environment(\.dismiss) var dismiss
-    
+
     @State var isCracked = false
-    
+
     var body: some View {
         ZStack {
             VStack(spacing: .space16) {
@@ -35,8 +35,7 @@ struct CohabitantRegistrationCompleteView: View {
             ZStack {
                 if isCracked {
                     ConfettiRainView()
-                }
-                else {
+                } else {
                     CrackerView {
                         withAnimation {
                             isCracked = true
@@ -49,4 +48,5 @@ struct CohabitantRegistrationCompleteView: View {
         }
         .hideNavigationBar()
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ProcessingState/CohabitantRegistrationProcessingFollowerView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ProcessingState/CohabitantRegistrationProcessingFollowerView.swift
@@ -11,18 +11,18 @@ import MultipeerConnectivity
 import SwiftUI
 
 struct CohabitantRegistrationProcessingFollower: View {
-    
+
     @Environment(\.p2pSessionProxy) var p2pSessionProxy
     @Environment(\.p2pSessionReceiveData) var receiveData
     @Environment(\.loginContext.account.id) var accountId
     @Environment(\.onCompleteCohabitantRegistration) var onCompleteCohabitantRegistration
-    
+
     @State var cohabitantId: String?
     @State var confirmedRolePeers: Set<MCPeerID> = []
     @State var leadPeer: MCPeerID?
-    
+
     @Binding var registrationState: CohabitantRegistrationState
-    
+
     var body: some View {
         CohabitantRegistrationProcessingView(
             confirmedRolePeers: $confirmedRolePeers,
@@ -35,57 +35,51 @@ struct CohabitantRegistrationProcessingFollower: View {
             dispatchReceivedMessage(data, sender: newValue.sender)
         }
     }
+
 }
 
 private extension CohabitantRegistrationProcessingFollower {
-    
+
     func dispatchReceivedMessage(_ data: CohabitantRegistrationMessage, sender: MCPeerID) {
-        
         // 登録前メッセージ受信時は、役割を確認し自身の役割に応じた処理を行う
         if data.memberRole?.isLeader ?? false {
-            
             onFindLeader(sender)
         }
         // 同居人IDの共有メッセージ受信時は、
         // 同居人IDをローカルに保存して登録完了通知をリードデバイスに通知
         else if let cohabitantId = data.cohabitantId {
-            
             onReceiveCohabitantId(cohabitantId)
         }
         // 登録完了通知を受信したら、状態を登録完了にする
         else if data.isComplete ?? false {
-            
             registrationState = .completed
         }
     }
-    
+
     func onFindLeader(_ peerID: MCPeerID) {
-        
         leadPeer = peerID
         confirmedRolePeers.insert(peerID)
-        
+
         // すでに同居人IDを受け取っていたら、完了メッセージを送信する
         if cohabitantId != nil {
-            
             sendCompleteMessageIfNeeded()
         }
     }
-    
+
     func onReceiveCohabitantId(_ cohabitantId: String) {
-        
         self.cohabitantId = cohabitantId
         onCompleteCohabitantRegistration(cohabitantId)
         sendCompleteMessageIfNeeded()
     }
-    
+
     func sendCompleteMessageIfNeeded() {
-        
         guard let leadPeer else { return }
-        
+
         let message = CohabitantRegistrationMessage(type: .complete)
         p2pSessionProxy?.send(
             message.encodedData(),
             to: [leadPeer]
         )
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ProcessingState/CohabitantRegistrationProcessingLeader.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ProcessingState/CohabitantRegistrationProcessingLeader.swift
@@ -1,5 +1,5 @@
 //
-//  CohabitantRegistrationProcessingLeaderView.swift
+//  CohabitantRegistrationProcessingLeader.swift
 //  homete
 //
 //  Created by 佐藤汰一 on 2025/08/28.
@@ -11,7 +11,7 @@ import MultipeerConnectivity
 import SwiftUI
 
 struct CohabitantRegistrationProcessingLeader: View {
-    
+
     @Environment(\.dismiss) var dismiss
     @Environment(\.appDependencies.cohabitantClient) var cohabitantClient
     @Environment(\.p2pSessionProxy) var p2pSessionProxy
@@ -20,18 +20,18 @@ struct CohabitantRegistrationProcessingLeader: View {
     @Environment(\.p2pSessionReceiveData) var receiveData
     @Environment(\.loginContext.account.id) var accountId
     @Environment(\.onCompleteCohabitantRegistration) var onCompleteCohabitantRegistration
-        
+
     // 登録処理の役割の通知が済んでいるデバイスリスト
     @State var confirmedRolePeers: Set<MCPeerID> = []
     @State var cohabitantsAccountId: Set<String> = []
-    // 登録完了したデバイスリスト
+    /// 登録完了したデバイスリスト
     @State var completedRegistrationPeers: Set<MCPeerID> = []
     // 同居人レコードの登録に失敗した時のアラート
     @State var isPresentingFailedRegistrationIdAlert = false
     @State var cohabitantId: String?
-    
+
     @Binding var registrationState: CohabitantRegistrationState
-    
+
     var body: some View {
         CohabitantRegistrationProcessingView(
             confirmedRolePeers: $confirmedRolePeers,
@@ -65,65 +65,57 @@ struct CohabitantRegistrationProcessingLeader: View {
             dispatchReceivedMessage(data, newValue.sender)
         }
     }
+
 }
 
 private extension CohabitantRegistrationProcessingLeader {
-    
+
     func dispatchReceivedMessage(_ data: CohabitantRegistrationMessage, _ sender: MCPeerID) {
-        
         // フォロワーからのメッセージであれば、
         // 登録時に使用するアカウントIDをオンメモリに保持しておく
         if let accountId = data.memberRole?.accountId {
-            
             print("dispatchReceivedMessage share accountId")
             cohabitantsAccountId.insert(accountId)
             confirmedRolePeers.insert(sender)
         }
         // フォロワーからの同居人登録完了メッセージ受信時は、保持している完了したメンバーに加える
         else if data.isComplete ?? false {
-            
             completedRegistrationPeers.insert(sender)
         }
     }
-    
+
     func onReadyRegistration() {
-        
         print("call onReadyRegistration")
         let cohabitantId = UUID().uuidString
         self.cohabitantId = cohabitantId
-                
+
         Task {
-            
             do {
-                
                 try await cohabitantClient.register(
                     .init(
                         id: cohabitantId,
                         members: [accountId] + .init(cohabitantsAccountId)
                     )
                 )
-                
+
                 // 同居人IDをメンバーに連携する
                 let message = CohabitantRegistrationMessage(type: .shareCohabitantId(id: cohabitantId))
                 p2pSessionProxy?.send(
                     message.encodedData(),
                     to: connectedPeers
                 )
-            }
-            catch {
-                
+            } catch {
                 // エラーアラートを表示
                 isPresentingFailedRegistrationIdAlert = true
             }
         }
     }
-    
+
     func onCompletedRegistration() {
-        
         guard let cohabitantId else {
             preconditionFailure("Not found required param(cohabitantId)")
         }
-        
+
         onCompleteCohabitantRegistration(cohabitantId)
         let message = CohabitantRegistrationMessage(type: .complete)
         p2pSessionProxy?.send(
@@ -132,4 +124,5 @@ private extension CohabitantRegistrationProcessingLeader {
         )
         registrationState = .completed
     }
+
 }

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ProcessingState/CohabitantRegistrationProcessingView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ProcessingState/CohabitantRegistrationProcessingView.swift
@@ -13,21 +13,21 @@ import MultipeerConnectivity
 import SwiftUI
 
 struct CohabitantRegistrationProcessingView: View {
-    
+
     @Environment(\.p2pSessionProxy) var p2pSessionProxy
     @Environment(\.connectedPeers) var connectedPeers
-    
+
     @State var isPresentedMemberChangeAlert = false
-    
+
     // 登録処理の役割の通知が済んでいるデバイスリスト
     @Binding var confirmedRolePeers: Set<MCPeerID>
     @Binding var registrationState: CohabitantRegistrationState
-    
-    // 登録処理時の役割
+
+    /// 登録処理時の役割
     let role: CohabitantRegistrationRole
-    
+
     let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-    
+
     var body: some View {
         VStack(spacing: .zero) {
             VStack(spacing: .space16) {
@@ -52,7 +52,7 @@ struct CohabitantRegistrationProcessingView: View {
         .padding(.horizontal, .space16)
         .onReceive(timer) { _ in
             guard confirmedRolePeers != connectedPeers else { return }
-            
+
             let message = CohabitantRegistrationMessage(
                 type: .preRegistration(role: role)
             )
@@ -66,14 +66,16 @@ struct CohabitantRegistrationProcessingView: View {
         }
         .alert(
             "接続エラー",
-            isPresented: $isPresentedMemberChangeAlert) {
-                Button("OK") {
-                    registrationState = .scanning
-                }
-            } message: {
-               Text("お手数ですが、再度デバイスを近づけて通信を行ってください")
+            isPresented: $isPresentedMemberChangeAlert
+        ) {
+            Button("OK") {
+                registrationState = .scanning
             }
+        } message: {
+            Text("お手数ですが、再度デバイスを近づけて通信を行ってください")
+        }
     }
+
 }
 
 #Preview("CohabitantRegistrationProcessingView_通常ケース") {

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationInitialStateView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationInitialStateView.swift
@@ -10,7 +10,7 @@ import HometeUI
 import SwiftUI
 
 struct CohabitantRegistrationInitialStateView: View {
-        
+
     var body: some View {
         VStack(spacing: .zero) {
             VStack(alignment: .leading, spacing: .space16) {
@@ -31,6 +31,7 @@ struct CohabitantRegistrationInitialStateView: View {
         }
         .padding(.horizontal, .space16)
     }
+
 }
 
 #Preview {

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationPeersListView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationPeersListView.swift
@@ -12,13 +12,13 @@ import MultipeerConnectivity
 import SwiftUI
 
 struct CohabitantRegistrationPeersListView: View {
-    
+
     @Environment(\.p2pSessionProxy) var p2pSessionProxy
     @Environment(\.connectedPeers) var connectedPeers
-    
+
     @State var isPresentingConfirmReadyRegistrationAlert = false
     @Binding var isConfirmedReadyRegistration: Bool
-    
+
     var body: some View {
         VStack(spacing: .space16) {
             Text("デバイスの名前を確認してください")
@@ -61,45 +61,43 @@ struct CohabitantRegistrationPeersListView: View {
             }
         }
     }
+
 }
 
 private extension CohabitantRegistrationPeersListView {
-    
+
     // MARK: プレゼンテーション処理
-    
+
     func convertToDisplayNameList(_ peers: Set<MCPeerID>) -> [String] {
-        
-        return peers.compactMap {
-            
+        peers.compactMap {
             $0.displayName.components(separatedBy: "_").first
         }
     }
-    
+
     func tappedConfirmAlertAcceptButton() {
-        
         isConfirmedReadyRegistration = true
-        
+
         // メンバーが確定したことの通知を送信する
         let data = CohabitantRegistrationMessage(
-            type: .fixedMember(isOK: true),
+            type: .fixedMember(isOK: true)
         )
         p2pSessionProxy?.send(
             data.encodedData(),
-            to: connectedPeers,
+            to: connectedPeers
         )
     }
-    
+
     func tappedConfirmAlertCancelButton() {
-        
         // メンバーが確定していないことの通知を送信する
         let data = CohabitantRegistrationMessage(
-            type: .fixedMember(isOK: false),
+            type: .fixedMember(isOK: false)
         )
         p2pSessionProxy?.send(
             data.encodedData(),
-            to: connectedPeers,
+            to: connectedPeers
         )
     }
+
 }
 
 #Preview("CohabitantRegistrationPeersListView_デバイス検知済みケース") {

--- a/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationScanningStateView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/RegisterCohabitantView/SubViews/ScanningState/CohabitantRegistrationScanningStateView.swift
@@ -1,5 +1,5 @@
 //
-//  CohabitantRegistrationSearchingStateView.swift
+//  CohabitantRegistrationScanningStateView.swift
 //  homete
 //
 //  Created by 佐藤汰一 on 2025/08/17.
@@ -11,19 +11,19 @@ import MultipeerConnectivity
 import SwiftUI
 
 struct CohabitantRegistrationScanningStateView: View {
-    
+
     @Environment(\.myPeerID) var myPeerID
     @Environment(\.connectedPeers) var connectedPeers
     @Environment(\.p2pSessionReceiveData) var receiveData
     @LoadingState var loadingState
-    
+
     @State var isConfirmedReadyRegistration = false
     @State var isPresentingRejectRegistrationAlert = false
     @State var confirmedReadyRegistrationPeers = ConfirmedRegistrationPeers(peers: [])
     @Binding var registrationState: CohabitantRegistrationState
-    
+
     let scannerController: any P2PScannerClient
-    
+
     var body: some View {
         ZStack {
             if connectedPeers.isEmpty {
@@ -32,8 +32,7 @@ struct CohabitantRegistrationScanningStateView: View {
                     .onAppear {
                         isConfirmedReadyRegistration = false
                     }
-            }
-            else {
+            } else {
                 CohabitantRegistrationPeersListView(
                     isConfirmedReadyRegistration: $isConfirmedReadyRegistration
                 )
@@ -66,48 +65,43 @@ struct CohabitantRegistrationScanningStateView: View {
             dispatchReceivedMessage(data, newValue.sender)
         }
     }
+
 }
 
 private extension CohabitantRegistrationScanningStateView {
-    
+
     // MARK: プレゼンテーション処理
-    
+
     func dispatchReceivedMessage(_ data: CohabitantRegistrationMessage, _ sender: MCPeerID) {
-        
         if let isFixedMember = data.isFixedMember {
-            
             if isFixedMember {
-                
                 // 登録メンバー確定メッセージを受信し、確定であれば確定メンバーに含める
                 confirmedReadyRegistrationPeers.addPeer(sender)
-            }
-            else {
-                
+            } else {
                 // 登録メンバーが拒否した場合は、再度メンバーを選び直す
                 confirmedReadyRegistrationPeers = .init(peers: [])
                 isPresentingRejectRegistrationAlert = true
             }
         }
     }
-    
+
     func transitionToProcessingStateIfNeeded() {
-        
         loadingState.isLoading = true
-        
+
         // 自分が登録ボタンタップ済みで、かつ全てのメンバーが登録ボタンタップ済みの場合に、
         // 登録処理に移行する
         guard isConfirmedReadyRegistration,
-              let myPeerID = self.myPeerID,
-        let isLeadPeer = confirmedReadyRegistrationPeers.isLeadPeer(
-            connectedPeers: connectedPeers,
-            myPeerID: myPeerID
-        ) else { return }
-        
+              let myPeerID,
+              let isLeadPeer = confirmedReadyRegistrationPeers.isLeadPeer(
+                  connectedPeers: connectedPeers,
+                  myPeerID: myPeerID
+              ) else { return }
+
         registrationState = .processing(isLead: isLeadPeer)
     }
-    
+
     func tappedRejectAlertButton() {
-        
         isConfirmedReadyRegistration = false
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkApproval/Components/HouseworkItemPropertyListContent.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkApproval/Components/HouseworkItemPropertyListContent.swift
@@ -11,10 +11,10 @@ import HometeUI
 import SwiftUI
 
 struct HouseworkItemPropertyListContent: View {
-    
+
     @Environment(\.calendar) var calendar
     let item: HouseworkItem
-    
+
     var body: some View {
         VStack(spacing: .zero) {
             houseworkPropertyRow("日付") {
@@ -35,10 +35,11 @@ struct HouseworkItemPropertyListContent: View {
             }
         }
     }
+
 }
 
 private extension HouseworkItemPropertyListContent {
-    
+
     func houseworkPropertyRow(_ title: String, detailContent: () -> some View) -> some View {
         HStack(spacing: .zero) {
             Text(title)
@@ -49,20 +50,21 @@ private extension HouseworkItemPropertyListContent {
         }
         .padding(.space24)
     }
+
 }
 
 #if DEBUG
-#Preview(traits: .sizeThatFitsLayout) {
-    HouseworkItemPropertyListContent(item: .init(
-        id: "",
-        title: "洗濯",
-        point: 10,
-        metaData: .init(
-            indexedDate: .init(value: .previewDate(year: 1970, month: 1, day: 1)),
-            expiredAt: .init(timeIntervalSince1970: 0)
-        ),
-        executedAt: .distantFuture
-    ))
-    .setupEnvironmentForPreview()
-}
+    #Preview(traits: .sizeThatFitsLayout) {
+        HouseworkItemPropertyListContent(item: .init(
+            id: "",
+            title: "洗濯",
+            point: 10,
+            metaData: .init(
+                indexedDate: .init(value: .previewDate(year: 1970, month: 1, day: 1)),
+                expiredAt: .init(timeIntervalSince1970: 0)
+            ),
+            executedAt: .distantFuture
+        ))
+        .setupEnvironmentForPreview()
+    }
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkApproval/HouseworkApprovalView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkApproval/HouseworkApprovalView.swift
@@ -11,16 +11,16 @@ import HometeUI
 import SwiftUI
 
 public struct HouseworkApprovalView: View {
-    
+
     @Environment(CohabitantStore.self) var cohabitantStore
     @Environment(HouseworkListStore.self) var houseworkListStore
     @Environment(\.loginContext.account) var account
     @Environment(\.dismiss) var dismiss
     @CommonError var commonError
     @LoadingState var loadingState
-    
+
     @State var inputMessage = ""
-    
+
     let item: HouseworkItem
 
     public init(item: HouseworkItem) {
@@ -55,6 +55,7 @@ public struct HouseworkApprovalView: View {
             .fullScreenLoadingIndicator(loadingState)
         }
     }
+
 }
 
 private extension HouseworkApprovalView {
@@ -71,14 +72,14 @@ private extension HouseworkApprovalView {
             .padding(.vertical, .space16)
         }
     }
-    
+
     func houseworkPropertySection() -> some View {
         section {
             HouseworkItemPropertyListContent(item: item)
                 .padding(.vertical, .space8)
         }
     }
-    
+
     func inputMessageSection() -> some View {
         VStack(spacing: .space16) {
             Text("メッセージ")
@@ -92,7 +93,7 @@ private extension HouseworkApprovalView {
             }
         }
     }
-    
+
     func section(@ViewBuilder content: () -> some View) -> some View {
         content()
             .frame(maxWidth: .infinity)
@@ -101,7 +102,7 @@ private extension HouseworkApprovalView {
                     .fill(.subSurface)
             }
     }
-    
+
     func actionButtonContent() -> some View {
         VStack(spacing: .space16) {
             Button {
@@ -125,18 +126,17 @@ private extension HouseworkApprovalView {
         }
         .disabled(inputMessage.isEmpty)
     }
+
 }
 
 // MARK: プレゼンテーションロジック
 
 private extension HouseworkApprovalView {
-    
+
     func tappedApproveButton() async {
-        
         guard let cohabitantId = account.cohabitantId else { return }
-        
+
         do {
-            
             try await houseworkListStore.approved(
                 target: item,
                 now: .now,
@@ -146,17 +146,14 @@ private extension HouseworkApprovalView {
             )
             dismiss()
         } catch {
-            
             commonError = .init(error: error)
         }
     }
-    
+
     func tappedReconfirmationButton() async {
-        
         guard let cohabitantId = account.cohabitantId else { return }
-        
+
         do {
-            
             try await houseworkListStore.rejected(
                 target: item,
                 now: .now,
@@ -166,30 +163,30 @@ private extension HouseworkApprovalView {
             )
             dismiss()
         } catch {
-            
             commonError = .init(error: error)
         }
     }
+
 }
 
 #if DEBUG
-#Preview {
-    HouseworkApprovalView(item: .init(
-        id: "",
-        title: "洗濯",
-        point: 10,
-        metaData: .init(
-            indexedDate: .init(value: .previewDate(year: 1970, month: 1, day: 1)),
-            expiredAt: .init(timeIntervalSince1970: 0)
-        ),
-        executorId: "test",
-        executedAt: .distantFuture,
-    ))
-    .setupEnvironmentForPreview()
-    .environment(CohabitantStore(
-        members: [.init(id: "test", userName: "hogehoge")],
-        ownId: "test"
-    ))
-    .environment(HouseworkListStore())
-}
+    #Preview {
+        HouseworkApprovalView(item: .init(
+            id: "",
+            title: "洗濯",
+            point: 10,
+            metaData: .init(
+                indexedDate: .init(value: .previewDate(year: 1970, month: 1, day: 1)),
+                expiredAt: .init(timeIntervalSince1970: 0)
+            ),
+            executorId: "test",
+            executedAt: .distantFuture
+        ))
+        .setupEnvironmentForPreview()
+        .environment(CohabitantStore(
+            members: [.init(id: "test", userName: "hogehoge")],
+            ownId: "test"
+        ))
+        .environment(HouseworkListStore())
+    }
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardRoute.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardRoute.swift
@@ -8,10 +8,14 @@ import HometeUI
 import SwiftUI
 
 enum HouseworkBoardRoute: Hashable {
+
     /// 家事詳細画面
     case houseworkDetail(HouseworkItem)
+
 }
 
 extension EnvironmentValues {
+
     @Entry var houseworkBoardNavigationPath = AppNavigationPath<HouseworkBoardRoute>()
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
@@ -8,14 +8,15 @@
 import SwiftUI
 
 public struct HouseworkBoardScreen: View {
+
     @State var houseworkListStore: HouseworkListStore?
     @State var houseworkBoardList: HouseworkBoardList = .init(items: [])
     @State var dateList = HouseworkDateList()
-    
+
     public static func make(houseworkListStore: HouseworkListStore?) -> some View {
         HouseworkBoardScreen(houseworkListStore: houseworkListStore)
     }
-    
+
     public var body: some View {
         if let houseworkListStore {
             HouseworkBoardView(
@@ -36,16 +37,18 @@ public struct HouseworkBoardScreen: View {
             )
         }
     }
+
 }
 
 // MARK: - プレゼンテーションロジック
 
 private extension HouseworkBoardScreen {
-    
+
     func onAppeare(with store: HouseworkListStore) {
         houseworkBoardList = .init(
             dailyList: store.items.value,
             selectedDate: dateList.selectedDate
         )
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
@@ -10,13 +10,14 @@ import HometeUI
 import SwiftUI
 
 struct HouseworkBoardView: View {
+
     @Environment(\.calendar) var calendar
     @Environment(\.now) var anchorDate
     @Environment(HouseworkListStore.self) var houseworkListStore
-    
+
     @Binding var houseworkBoardList: HouseworkBoardList
     @Binding var dateList: HouseworkDateList
-    
+
     @State var navigationPath = AppNavigationPath<HouseworkBoardRoute>()
     @State var selectedHouseworkState = HouseworkState.incomplete
     @State var isPresentingAddHouseworkView = false
@@ -79,11 +80,11 @@ struct HouseworkBoardView: View {
             }
         }
     }
+
 }
 
 private extension HouseworkBoardView {
-    
-    @ViewBuilder
+
     func addHouseworkButton(action: @escaping () -> Void) -> some View {
         Button {
             action()
@@ -93,51 +94,52 @@ private extension HouseworkBoardView {
         }
         .floatingButtonStyle()
     }
-    
+
     @ViewBuilder
     func navigationHandler(_ route: HouseworkBoardRoute) -> some View {
         switch route {
-        case .houseworkDetail(let item):
+        case let .houseworkDetail(item):
             HouseworkDetailView(item: item)
         }
     }
+
 }
 
 private extension HouseworkBoardView {
-    
+
     func updateHouseworkBoardList() {
-        
         houseworkBoardList = .init(
             dailyList: houseworkListStore.items.value,
             selectedDate: dateList.selectedDate
         )
     }
+
 }
 
 #if DEBUG
-#Preview {
-    let list = HouseworkBoardList(items: [
-        .init(
-            id: "1",
-            title: "洗濯",
-            point: 20,
-            metaData: .init(
-                indexedDate: .init(value: .distantPast),
-                expiredAt: .distantPast
-            )
+    #Preview {
+        let list = HouseworkBoardList(items: [
+            .init(
+                id: "1",
+                title: "洗濯",
+                point: 20,
+                metaData: .init(
+                    indexedDate: .init(value: .distantPast),
+                    expiredAt: .distantPast
+                )
+            ),
+        ])
+        HouseworkBoardView(
+            houseworkBoardList: .constant(list),
+            dateList: .constant(.init(
+                anchorDate: .distantPast,
+                selectedDate: .distantPast,
+                calendar: .japanese
+            ))
         )
-    ])
-    HouseworkBoardView(
-        houseworkBoardList: .constant(list),
-        dateList: .constant(.init(
-            anchorDate: .distantPast,
-            selectedDate: .distantPast,
-            calendar: .japanese
-        ))
-    )
-    .apply(theme: .init())
-    .setupEnvironmentForPreview()
-    .environment(\.now, .distantPast)
-    .environment(HouseworkListStore())
-}
+        .apply(theme: .init())
+        .setupEnvironmentForPreview()
+        .environment(\.now, .distantPast)
+        .environment(HouseworkListStore())
+    }
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/DateHeader/HouseworkDateCell.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/DateHeader/HouseworkDateCell.swift
@@ -5,46 +5,49 @@
 //  Created by Taichi Sato on 2026/04/04.
 //
 
-import HometeUI
 import HometeDomain
+import HometeUI
 import SwiftUI
 
 struct HouseworkDateCell: View {
+
     @Environment(\.calendar) var calendar
     @Environment(\.locale) var locale
     @Environment(\.timeZone) var timeZone
     @Environment(\.now) var now
-        
+
     let date: Date
     let state: HouseworkDateState
     let onTap: (Date) -> Void
-    
+
     var body: some View {
         Button {
             onTap(date)
         } label: {
             Text(dateLabel())
-            .font(with: .headLineS)
-            .padding(.space8)
-            .foregroundStyle(foreground)
-            .frame(width: 60, height: 60)
-            .background {
-                Circle()
-                    .fill(background)
-            }
-            .padding(2)
-            .background {
-                if let borderColor {
+                .font(with: .headLineS)
+                .padding(.space8)
+                .foregroundStyle(foreground)
+                .frame(width: 60, height: 60)
+                .background {
                     Circle()
-                        .stroke(lineWidth: 1.5)
-                        .fill(borderColor)
+                        .fill(background)
                 }
-            }
+                .padding(2)
+                .background {
+                    if let borderColor {
+                        Circle()
+                            .stroke(lineWidth: 1.5)
+                            .fill(borderColor)
+                    }
+                }
         }
     }
+
 }
 
 private extension HouseworkDateCell {
+
     func dateLabel() -> String {
         if calendar.dateComponents(
             [.year, .month, .day],
@@ -53,18 +56,20 @@ private extension HouseworkDateCell {
             [.year, .month, .day],
             from: now
         ) {
-            return "今日"
+            "今日"
         } else {
-            return String(calendar.component(.day, from: date))
+            String(calendar.component(.day, from: date))
         }
     }
-    
+
     struct CellContent {
+
         let foreground: Color
         let background: Color
         let borderColor: Color?
+
     }
-    
+
     var foreground: Color {
         switch state {
         case .selected: .onPrimary1
@@ -72,7 +77,7 @@ private extension HouseworkDateCell {
         case .unselectable: .onPrimary3
         }
     }
-    
+
     var background: Color {
         switch state {
         case .selected: .primary1
@@ -80,34 +85,35 @@ private extension HouseworkDateCell {
         case .unselectable: .primary3
         }
     }
-    
+
     var borderColor: Color? {
         switch state {
         case .selected: .primary2
         case .selectable, .unselectable: nil
         }
     }
+
 }
 
 #if DEBUG
-#Preview("HouseworkDateCell_今日の日付", traits: .sizeThatFitsLayout) {
-    HouseworkDateCell(date: .distantPast, state: .selected) { _ in }
-        .setupEnvironmentForPreview()
-        .environment(\.now, .distantPast)
-}
+    #Preview("HouseworkDateCell_今日の日付", traits: .sizeThatFitsLayout) {
+        HouseworkDateCell(date: .distantPast, state: .selected) { _ in }
+            .setupEnvironmentForPreview()
+            .environment(\.now, .distantPast)
+    }
 
-#Preview("HouseworkDateCell_選択中の日付", traits: .sizeThatFitsLayout) {
-    HouseworkDateCell(date: .distantPast, state: .selected) { _ in }
-        .setupEnvironmentForPreview()
-}
+    #Preview("HouseworkDateCell_選択中の日付", traits: .sizeThatFitsLayout) {
+        HouseworkDateCell(date: .distantPast, state: .selected) { _ in }
+            .setupEnvironmentForPreview()
+    }
 
-#Preview("HouseworkDateCell_選択可能な日付", traits: .sizeThatFitsLayout) {
-    HouseworkDateCell(date: .distantPast, state: .selectable) { _ in }
-        .setupEnvironmentForPreview()
-}
+    #Preview("HouseworkDateCell_選択可能な日付", traits: .sizeThatFitsLayout) {
+        HouseworkDateCell(date: .distantPast, state: .selectable) { _ in }
+            .setupEnvironmentForPreview()
+    }
 
-#Preview("HouseworkDateCell_選択不可な日付", traits: .sizeThatFitsLayout) {
-    HouseworkDateCell(date: .distantPast, state: .unselectable) { _ in }
-        .setupEnvironmentForPreview()
-}
+    #Preview("HouseworkDateCell_選択不可な日付", traits: .sizeThatFitsLayout) {
+        HouseworkDateCell(date: .distantPast, state: .unselectable) { _ in }
+            .setupEnvironmentForPreview()
+    }
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/DateHeader/HouseworkDateHeaderContent.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/DateHeader/HouseworkDateHeaderContent.swift
@@ -44,6 +44,7 @@ struct HouseworkDateHeaderContent: View {
             }
         }
     }
+
 }
 
 private extension HouseworkDateHeaderContent {
@@ -54,8 +55,8 @@ private extension HouseworkDateHeaderContent {
             calendar: calendar,
             timeZone: timeZone
         )
-            .year()
-            .month()
+        .year()
+        .month()
         return dateList.selectedDate.formatted(format)
     }
 
@@ -83,19 +84,20 @@ private extension HouseworkDateHeaderContent {
                 .opacity(progress)
         }
     }
+
 }
 
 #if DEBUG
-#Preview(traits: .sizeThatFitsLayout) {
-    HouseworkDateHeaderContent(
-        dateList: .constant(.init(
-            anchorDate: .previewDate(year: 2026, month: 1, day: 1),
-            selectedDate: .previewDate(year: 2026, month: 1, day: 1),
-            calendar: .japanese
-        ))
-    )
-    .setupEnvironmentForPreview()
-    .environment(\.now, .previewDate(year: 2026, month: 1, day: 1))
-    .snapshotForPreview(delay: 2)
-}
+    #Preview(traits: .sizeThatFitsLayout) {
+        HouseworkDateHeaderContent(
+            dateList: .constant(.init(
+                anchorDate: .previewDate(year: 2026, month: 1, day: 1),
+                selectedDate: .previewDate(year: 2026, month: 1, day: 1),
+                calendar: .japanese
+            ))
+        )
+        .setupEnvironmentForPreview()
+        .environment(\.now, .previewDate(year: 2026, month: 1, day: 1))
+        .snapshotForPreview(delay: 2)
+    }
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/HouseBoardListRow.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/HouseBoardListRow.swift
@@ -10,9 +10,9 @@ import HometeUI
 import SwiftUI
 
 struct HouseBoardListRow: View {
-    
+
     let houseworkItem: HouseworkItem
-    
+
     var body: some View {
         HStack(spacing: .space16) {
             PointLabel(point: houseworkItem.point)
@@ -22,20 +22,21 @@ struct HouseBoardListRow: View {
         }
         .tag(houseworkItem.id)
     }
+
 }
 
 #if DEBUG
-#Preview(traits: .sizeThatFitsLayout) {
-    HouseBoardListRow(
-        houseworkItem: .init(
-            id: "1",
-            title: "洗濯",
-            point: 20,
-            metaData: .init(
-                indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-                expiredAt: .distantPast
+    #Preview(traits: .sizeThatFitsLayout) {
+        HouseBoardListRow(
+            houseworkItem: .init(
+                id: "1",
+                title: "洗濯",
+                point: 20,
+                metaData: .init(
+                    indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                    expiredAt: .distantPast
+                )
             )
         )
-    )
-}
+    }
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/HouseworkBoardEmptyView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/HouseworkBoardEmptyView.swift
@@ -28,15 +28,18 @@ struct HouseworkBoardEmptyView: View {
             }
         }
     }
+
 }
 
 private extension HouseworkBoardEmptyView {
 
     struct EmptyContent {
+
         let systemImage: String
         let title: String
         let message: String?
         let action: (label: String, handler: () -> Void)?
+
     }
 
     var content: EmptyContent {
@@ -57,7 +60,7 @@ private extension HouseworkBoardEmptyView {
                 action: ("家事を追加", onCreateTapped)
             )
 
-        case .noPendingApproval(let hasIncomplete):
+        case let .noPendingApproval(hasIncomplete):
             EmptyContent(
                 systemImage: "clock.badge.checkmark",
                 title: "承認待ちの家事はありません",
@@ -92,6 +95,7 @@ private extension HouseworkBoardEmptyView {
             )
         }
     }
+
 }
 
 #Preview("家事未登録") {

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/HouseworkBoardListContent.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/HouseworkBoardListContent.swift
@@ -41,18 +41,19 @@ struct HouseworkBoardListContent: View {
                 }
                 .listRowBackground(Color.clear)
                 #if os(iOS)
-                .listRowSpacing(.zero)
-                .listRowSeparator(.hidden)
+                    .listRowSpacing(.zero)
+                    .listRowSeparator(.hidden)
                 #endif
             }
             .listStyle(.plain)
             .commonError(content: $commonError)
         }
     }
+
 }
 
 private extension HouseworkBoardListContent {
-    
+
     func houseworkItemRow(_ item: HouseworkItem) -> some View {
         Button {
             navigationPath.push(.houseworkDetail(item))
@@ -72,69 +73,67 @@ private extension HouseworkBoardListContent {
         }
         #endif
     }
+
 }
 
 // プレゼンテーションロジック
 
 private extension HouseworkBoardListContent {
-    
+
     func didSwipeDeleteItemAction(_ item: HouseworkItem) async {
-        
         guard let cohabitantId = loginContext.cohabitantId else { return }
         do {
-            
             try await houseworkListStore.remove(
                 target: item,
                 cohabitantId: cohabitantId
             )
-        }
-        catch {
-            
+        } catch {
             commonError = .init(error: error)
         }
     }
+
 }
 
 #if DEBUG
-#Preview {
-    @Previewable @State var selectedState = HouseworkState.incomplete
-    HouseworkBoardListContent(
-        houseworkListStore: .init(
-            houseworkClient: .previewValue,
-            cohabitantPushNotificationClient: .previewValue
-        ),
-        state: .incomplete,
-        list: .init(items: [
-            .init(
-                id: "1",
-                title: "洗濯",
-                point: 20,
-                metaData: .init(
-                    indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-                    expiredAt: .now
-                )
+    #Preview {
+        @Previewable @State var selectedState = HouseworkState.incomplete
+        HouseworkBoardListContent(
+            houseworkListStore: .init(
+                houseworkClient: .previewValue,
+                cohabitantPushNotificationClient: .previewValue
             ),
-            .init(
-                id: "2",
-                title: "掃除",
-                point: 100,
-                metaData: .init(
-                    indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-                    expiredAt: .now
-                )
-            ),
-            .init(
-                id: "3",
-                title: "料理",
-                point: 1,
-                metaData: .init(
-                    indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-                    expiredAt: .now
-                )
-            )
-        ]),
-        selectedHouseworkState: $selectedState,
-        onCreateTapped: {}
-    )
-}
+            state: .incomplete,
+            list: .init(items: [
+                .init(
+                    id: "1",
+                    title: "洗濯",
+                    point: 20,
+                    metaData: .init(
+                        indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                        expiredAt: .now
+                    )
+                ),
+                .init(
+                    id: "2",
+                    title: "掃除",
+                    point: 100,
+                    metaData: .init(
+                        indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                        expiredAt: .now
+                    )
+                ),
+                .init(
+                    id: "3",
+                    title: "料理",
+                    point: 1,
+                    metaData: .init(
+                        indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                        expiredAt: .now
+                    )
+                ),
+            ]),
+            selectedHouseworkState: $selectedState,
+            onCreateTapped: {}
+        )
+    }
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/HouseworkBoardSegmentedControl.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/SubViews/HouseworkBoardSegmentedControl.swift
@@ -9,9 +9,9 @@ import HometeDomain
 import SwiftUI
 
 struct HouseworkBoardSegmentedControl: View {
-    
+
     @Binding var selectedHouseworkState: HouseworkState
-    
+
     var body: some View {
         Picker("", selection: $selectedHouseworkState) {
             ForEach(HouseworkState.allCases) { state in
@@ -20,17 +20,17 @@ struct HouseworkBoardSegmentedControl: View {
         }
         .pickerStyle(.segmented)
     }
+
 }
 
 extension HouseworkState {
-    
+
     var segmentTitle: LocalizedStringKey {
-        
         switch self {
-            
         case .incomplete: "未完了"
         case .pendingApproval: "承認待ち"
         case .completed: "完了"
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkDetailView/HouseworkDetailView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkDetailView/HouseworkDetailView.swift
@@ -10,17 +10,17 @@ import HometeUI
 import SwiftUI
 
 struct HouseworkDetailView: View {
-    
+
     @Environment(\.dismiss) var dismiss
     @Environment(\.loginContext.account) var account
     @Environment(HouseworkListStore.self) var houseworkListStore
     @Environment(CohabitantStore.self) var cohabitantStore
     @LoadingState var loadingState
-    
+
     @State var item: HouseworkItem
-    
+
     @CommonError var commonErrorContent
-    
+
     var body: some View {
         mainContent()
             .padding(.horizontal, .space16)
@@ -40,6 +40,7 @@ struct HouseworkDetailView: View {
                 didChangeItems()
             }
     }
+
 }
 
 private extension HouseworkDetailView {
@@ -59,39 +60,35 @@ private extension HouseworkDetailView {
             )
         }
     }
+
 }
 
 // MARK: プレゼンテーションロジック
 
 private extension HouseworkDetailView {
-    
+
     func tappedDeleteHouseworkItem() async {
-        
         guard let cohabitantId = account.cohabitantId else { return }
-        
+
         do {
-            
             try await houseworkListStore.remove(
                 target: item,
                 cohabitantId: cohabitantId
             )
             dismiss()
-        }
-        catch {
-            
+        } catch {
             commonErrorContent = .init(error: error)
         }
     }
-    
+
     func didChangeItems() {
-        
         guard let targetItem = houseworkListStore.items.item(item) else { return }
-        
+
         withAnimation {
-            
             item = targetItem
         }
     }
+
 }
 
 #Preview {
@@ -124,6 +121,6 @@ private extension HouseworkDetailView {
     .environment(HouseworkListStore())
     .environment(CohabitantStore())
     #if canImport(Prefire)
-    .prefireIgnored()
+        .prefireIgnored()
     #endif
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkDetailView/SubViews/HouseworkDetailActionContent.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkDetailView/SubViews/HouseworkDetailActionContent.swift
@@ -10,17 +10,18 @@ import HometeUI
 import SwiftUI
 
 struct HouseworkDetailActionContent: View {
+
     @Environment(HouseworkListStore.self) var houseworkListStore
     @Environment(\.routeResolver) var router
     @Environment(\.loginContext.cohabitantId) var cohabitantId
     @State var isPresentedApprovalView = false
-    
+
     @Binding var isLoading: Bool
     @Binding var commonErrorContent: DomainErrorAlertContent
-    
+
     let account: Account
     let item: HouseworkItem
-    
+
     var body: some View {
         VStack(spacing: .space16) {
             switch item.state {
@@ -29,8 +30,7 @@ struct HouseworkDetailActionContent: View {
             case .pendingApproval:
                 if item.canReview(ownUserId: account.id) {
                     approvalButton()
-                }
-                else {
+                } else {
                     undoChangeStateButton()
                 }
             case .completed:
@@ -42,10 +42,11 @@ struct HouseworkDetailActionContent: View {
             HouseworkApprovalView(item: item)
         }
     }
+
 }
 
 private extension HouseworkDetailActionContent {
-    
+
     func requestReviewButton() -> some View {
         Button {
             isLoading = true
@@ -59,7 +60,7 @@ private extension HouseworkDetailActionContent {
         }
         .subPrimaryButtonStyle()
     }
-    
+
     func undoChangeStateButton() -> some View {
         Button {
             isLoading = true
@@ -73,7 +74,7 @@ private extension HouseworkDetailActionContent {
         }
         .primaryButtonStyle()
     }
-    
+
     func approvalButton() -> some View {
         Button {
             isPresentedApprovalView = true
@@ -83,16 +84,16 @@ private extension HouseworkDetailActionContent {
         }
         .subPrimaryButtonStyle()
     }
+
 }
 
 // プレゼンテーションロジック
 
 private extension HouseworkDetailActionContent {
-    
+
     func tappedRequestConfirmButton() async {
-        
         guard let cohabitantId else { return }
-        
+
         do {
             try await houseworkListStore.requestReview(
                 target: item,
@@ -100,74 +101,71 @@ private extension HouseworkDetailActionContent {
                 executor: account.id,
                 cohabitantId: cohabitantId
             )
-        }
-        catch {
+        } catch {
             commonErrorContent = .init(error: error)
         }
     }
-    
+
     func tappedUndoStateButton() async {
-        
         guard let cohabitantId else { return }
-        
+
         do {
-            
             try await houseworkListStore.returnToIncomplete(target: item, cohabitantId: cohabitantId)
         } catch {
-            
             commonErrorContent = .init(error: error)
         }
     }
+
 }
 
 #if DEBUG
-#Preview("HouseworkDetailActionContent_未完了", traits: .sizeThatFitsLayout) {
-    HouseworkDetailActionContent(
-        isLoading: .constant(false),
-        commonErrorContent: .constant(.initial),
-        account: .init(id: "", userName: "", fcmToken: nil, cohabitantId: nil),
-        item: .init(
-            id: "",
-            title: "洗濯",
-            point: 10,
-            metaData: .init(
-                indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-                expiredAt: .distantFuture
+    #Preview("HouseworkDetailActionContent_未完了", traits: .sizeThatFitsLayout) {
+        HouseworkDetailActionContent(
+            isLoading: .constant(false),
+            commonErrorContent: .constant(.initial),
+            account: .init(id: "", userName: "", fcmToken: nil, cohabitantId: nil),
+            item: .init(
+                id: "",
+                title: "洗濯",
+                point: 10,
+                metaData: .init(
+                    indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                    expiredAt: .distantFuture
+                )
             )
         )
-    )
-    .environment(HouseworkListStore())
-}
+        .environment(HouseworkListStore())
+    }
 
-#Preview("HouseworkDetailActionContent_承認待ち_実施者アカウント", traits: .sizeThatFitsLayout) {
-    HouseworkDetailActionContent(
-        isLoading: .constant(false),
-        commonErrorContent: .constant(.initial),
-        account: .init(id: "dummy", userName: "", fcmToken: nil, cohabitantId: nil),
-        item: .makeForPreview(
-            title: "洗濯",
-            point: 10,
-            indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-            state: .pendingApproval,
-            executorId: "dummy"
+    #Preview("HouseworkDetailActionContent_承認待ち_実施者アカウント", traits: .sizeThatFitsLayout) {
+        HouseworkDetailActionContent(
+            isLoading: .constant(false),
+            commonErrorContent: .constant(.initial),
+            account: .init(id: "dummy", userName: "", fcmToken: nil, cohabitantId: nil),
+            item: .makeForPreview(
+                title: "洗濯",
+                point: 10,
+                indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                state: .pendingApproval,
+                executorId: "dummy"
+            )
         )
-    )
-    .environment(HouseworkListStore())
-}
+        .environment(HouseworkListStore())
+    }
 
-#Preview("HouseworkDetailActionContent_承認待ち_確認者アカウント", traits: .sizeThatFitsLayout) {
-    HouseworkDetailActionContent(
-        isLoading: .constant(false),
-        commonErrorContent: .constant(.initial),
-        account: .init(id: "ownAccount", userName: "", fcmToken: nil, cohabitantId: nil),
-        item: .makeForPreview(
-            title: "洗濯",
-            point: 10,
-            indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-            state: .pendingApproval,
-            executorId: "executorAccount"
+    #Preview("HouseworkDetailActionContent_承認待ち_確認者アカウント", traits: .sizeThatFitsLayout) {
+        HouseworkDetailActionContent(
+            isLoading: .constant(false),
+            commonErrorContent: .constant(.initial),
+            account: .init(id: "ownAccount", userName: "", fcmToken: nil, cohabitantId: nil),
+            item: .makeForPreview(
+                title: "洗濯",
+                point: 10,
+                indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                state: .pendingApproval,
+                executorId: "executorAccount"
+            )
         )
-    )
-    .environment(HouseworkListStore())
-}
+        .environment(HouseworkListStore())
+    }
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkDetailView/SubViews/HouseworkDetailItemListContent.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkDetailView/SubViews/HouseworkDetailItemListContent.swift
@@ -11,12 +11,12 @@ import HometeUI
 import SwiftUI
 
 struct HouseworkDetailItemListContent: View {
-    
+
     @Environment(\.calendar) var calendar
-    
+
     let cohabitantMemberList: CohabitantMemberList
     let item: HouseworkItem
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: .space24) {
             HouseworkDetailItemRow(title: "実施予定日付") {
@@ -42,6 +42,7 @@ struct HouseworkDetailItemListContent: View {
             }
         }
     }
+
 }
 
 #Preview("HouseworkDetailItemListContent_未完了時", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkDetailView/SubViews/HouseworkDetailItemRow.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkDetailView/SubViews/HouseworkDetailItemRow.swift
@@ -9,10 +9,10 @@ import HometeUI
 import SwiftUI
 
 struct HouseworkDetailItemRow<Content: View>: View {
-    
+
     let title: LocalizedStringKey
     @ViewBuilder let content: () -> Content
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: .space16) {
             Text(title)
@@ -21,4 +21,5 @@ struct HouseworkDetailItemRow<Content: View>: View {
             content()
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/DailyHouseworkList.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/DailyHouseworkList.swift
@@ -18,24 +18,25 @@ public struct DailyHouseworkList: Equatable, Sendable {
         items: [HouseworkItem],
         calendar: Calendar
     ) -> Self {
-
-        return .init(
+        .init(
             items: items,
             metaData: .init(selectedDate: selectedDate, calendar: calendar)
         )
     }
 
     /// この日付の家事情報がすでに登録済みであること
-    public var isRegistered: Bool { !items.isEmpty }
+    public var isRegistered: Bool {
+        !items.isEmpty
+    }
 
     /// すでに同じ家事が登録されているかどうか
     public func isAlreadyRegistered(_ item: HouseworkItem) -> Bool {
-
-        return items.contains { $0.title == item.title }
+        items.contains { $0.title == item.title }
     }
 
     public init(items: [HouseworkItem], metaData: DailyHouseworkMetaData) {
         self.items = items
         self.metaData = metaData
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkBoardEmptyReason.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkBoardEmptyReason.swift
@@ -8,7 +8,8 @@
 import HometeDomain
 
 /// 家事ボードの各タブが空のときの理由
-enum HouseworkBoardEmptyReason: Equatable, Sendable {
+enum HouseworkBoardEmptyReason: Equatable {
+
     /// 家事が1件も登録されていない
     case noHouseworkRegistered
     /// 未完了タブ: 全ての家事が完了または承認待ちに移行済み
@@ -51,4 +52,5 @@ enum HouseworkBoardEmptyReason: Equatable, Sendable {
             }
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkBoardList.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkBoardList.swift
@@ -13,8 +13,9 @@ struct HouseworkBoardList: Equatable {
     private(set) var items: [HouseworkItem]
 
     func items(matching state: HouseworkState) -> [HouseworkItem] {
-        return items.filter { $0.state == state }
+        items.filter { $0.state == state }
     }
+
 }
 
 extension HouseworkBoardList {
@@ -23,10 +24,10 @@ extension HouseworkBoardList {
         dailyList: [DailyHouseworkList],
         selectedDate: Date
     ) {
-
         items = dailyList
             .first {
                 $0.metaData.indexedDate == .init(value: selectedDate)
             }?.items ?? []
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkDateList.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkDateList.swift
@@ -1,5 +1,5 @@
 //
-//  HouseworkDateScrollList.swift
+//  HouseworkDateList.swift
 //  LocalPackage
 //
 //  Created by Taichi Sato on 2026/04/04.
@@ -10,8 +10,10 @@ import Foundation
 struct HouseworkDateList: Equatable {
 
     struct Item: Equatable {
+
         let date: Date
         let state: HouseworkDateState
+
     }
 
     let anchorDate: Date
@@ -25,15 +27,16 @@ struct HouseworkDateList: Equatable {
         let selectedDay = calendar.startOfDay(for: selectedDate)
         self.anchorDate = anchorDate
         self.selectedDate = selectedDay
-        self.items = Self.buildItems(anchorDate: anchorDate, selectedDate: selectedDay, calendar: calendar)
+        items = Self.buildItems(anchorDate: anchorDate, selectedDate: selectedDay, calendar: calendar)
     }
 
     /// selectableな日付を選択してitemsとselectedDateを更新する。unselectableな場合は変更なし。
-    public mutating func selectDate(_ date: Date, calendar: Calendar) {
+    mutating func selectDate(_ date: Date, calendar: Calendar) {
         guard isSelectable(date, calendar: calendar) else { return }
         selectedDate = calendar.startOfDay(for: date)
         items = Self.buildItems(anchorDate: anchorDate, selectedDate: selectedDate, calendar: calendar)
     }
+
 }
 
 private extension HouseworkDateList {
@@ -42,15 +45,14 @@ private extension HouseworkDateList {
         let anchorDay = calendar.startOfDay(for: anchorDate)
         let start = -(selectableOffset + unselectablePadding)
         let end = selectableOffset + unselectablePadding
-        return (start...end).compactMap { delta -> Item? in
+        return (start ... end).compactMap { delta -> Item? in
             guard let date = calendar.date(byAdding: .day, value: delta, to: anchorDay) else { return nil }
-            let state: HouseworkDateState
-            if date == selectedDate {
-                state = .selected
+            let state: HouseworkDateState = if date == selectedDate {
+                .selected
             } else if abs(delta) <= selectableOffset {
-                state = .selectable
+                .selectable
             } else {
-                state = .unselectable
+                .unselectable
             }
             return Item(date: date, state: state)
         }
@@ -62,4 +64,5 @@ private extension HouseworkDateList {
         guard let diff = calendar.dateComponents([.day], from: anchorDay, to: dateDay).day else { return false }
         return abs(diff) <= Self.selectableOffset
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkDateState.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkDateState.swift
@@ -6,7 +6,9 @@
 //
 
 enum HouseworkDateState: Equatable {
+
     case selected
     case selectable
     case unselectable
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkListStore.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkListStore.swift
@@ -29,23 +29,20 @@ public final class HouseworkListStore {
         houseworkManager: HouseworkManager = .init(houseworkClient: .previewValue),
         items: [DailyHouseworkList] = []
     ) {
-
         self.houseworkClient = houseworkClient
         self.cohabitantPushNotificationClient = cohabitantPushNotificationClient
         self.houseworkManager = houseworkManager
         self.items = .init(value: items)
-        
+
         Task {
             await startObserving()
         }
     }
 
     func register(newItem: HouseworkItem, cohabitantId: String) async throws {
-
         try await houseworkClient.insertOrUpdateItem(newItem, cohabitantId)
 
         Task.detached {
-
             let notificationContent = PushNotificationContent.addNewHouseworkItem(newItem.title)
             try await self.cohabitantPushNotificationClient.send(cohabitantId, notificationContent)
         }
@@ -57,7 +54,6 @@ public final class HouseworkListStore {
         executor: String,
         cohabitantId: String
     ) async throws {
-
         try await updateAndSave(target: target, cohabitantId: cohabitantId) {
             $0.updatePendingApproval(at: now, changer: executor)
         } notification: {
@@ -72,7 +68,6 @@ public final class HouseworkListStore {
         comment: String,
         cohabitantId: String
     ) async throws {
-
         try await updateAndSave(target: target, cohabitantId: cohabitantId) {
             $0.updateApproved(at: now, reviewer: reviwer.id, comment: comment)
         } notification: {
@@ -87,7 +82,6 @@ public final class HouseworkListStore {
         comment: String,
         cohabitantId: String
     ) async throws {
-
         try await updateAndSave(target: target, cohabitantId: cohabitantId) {
             $0.updateRejected(at: now, reviewer: reviwer.id, comment: comment)
         } notification: {
@@ -96,22 +90,20 @@ public final class HouseworkListStore {
     }
 
     func returnToIncomplete(target: HouseworkItem, cohabitantId: String) async throws {
-
         try await updateAndSave(target: target, cohabitantId: cohabitantId) {
             $0.updateIncomplete()
         }
     }
 
     func remove(target: HouseworkItem, cohabitantId: String) async throws {
-
         try await houseworkClient.removeItem(target, cohabitantId)
     }
+
 }
 
 private extension HouseworkListStore {
 
     func startObserving() async {
-
         let stream = await houseworkManager.createObserver(houseworkListObserveKey)
         for await newItems in stream {
             let anchorDate = await houseworkManager.listenerAnchorDate
@@ -131,7 +123,6 @@ private extension HouseworkListStore {
         transform: (HouseworkItem) -> HouseworkItem,
         notification: (() -> PushNotificationContent)? = nil
     ) async throws {
-
         guard let targetItem = items.item(target) else {
             preconditionFailure("Not found target item(\(target))")
         }
@@ -149,4 +140,5 @@ private extension HouseworkListStore {
             }
         }
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/StoredAllHouseworkList.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/StoredAllHouseworkList.swift
@@ -22,7 +22,6 @@ public struct StoredAllHouseworkList: Equatable, Sendable {
         offsetDays: Int,
         calendar: Calendar
     ) -> Self {
-
         let targetDates = Set(
             HouseworkIndexedDate.calcTargetPeriod(anchorDate: anchorDate, offsetDays: offsetDays, calendar: calendar)
         )
@@ -30,7 +29,6 @@ public struct StoredAllHouseworkList: Equatable, Sendable {
             grouping: items.filter { targetDates.contains($0.indexedDate.value) }
         ) { $0.indexedDate }
             .compactMap {
-
                 guard let firstItem = $1.first else { return nil }
                 return .init(
                     items: $1,
@@ -41,15 +39,15 @@ public struct StoredAllHouseworkList: Equatable, Sendable {
     }
 
     public func item(_ item: HouseworkItem) -> HouseworkItem? {
-
         guard let targetDayList = value.first(
             where: { $0.metaData.indexedDate == item.indexedDate }
         ),
-              let targetItem = targetDayList.items.first(where: { $0.id == item.id }) else { return nil }
+            let targetItem = targetDayList.items.first(where: { $0.id == item.id }) else { return nil }
         return targetItem
     }
 
     public mutating func removeAll() {
         value = []
     }
+
 }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Preview/HouseworkUtil.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Preview/HouseworkUtil.swift
@@ -10,35 +10,35 @@ import HometeDomain
 
 #if DEBUG
 
-extension HouseworkItem {
+    extension HouseworkItem {
 
-    static func makeForPreview(
-        id: String = UUID().uuidString,
-        title: String = "",
-        point: Int = 10,
-        indexedDate: HouseworkIndexedDate = .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-        expiredAt: Date = .distantFuture,
-        state: HouseworkState = .incomplete,
-        executorId: String? = nil,
-        executedAt: Date? = nil,
-        reviewerId: String? = nil,
-        approvedAt: Date? = nil,
-        reviewerComment: String? = nil
-    ) -> Self {
+        static func makeForPreview(
+            id: String = UUID().uuidString,
+            title: String = "",
+            point: Int = 10,
+            indexedDate: HouseworkIndexedDate = .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+            expiredAt: Date = .distantFuture,
+            state: HouseworkState = .incomplete,
+            executorId: String? = nil,
+            executedAt: Date? = nil,
+            reviewerId: String? = nil,
+            approvedAt: Date? = nil,
+            reviewerComment: String? = nil
+        ) -> Self {
+            .init(
+                id: id,
+                title: title,
+                point: point,
+                metaData: .init(indexedDate: indexedDate, expiredAt: expiredAt),
+                state: state,
+                executorId: executorId,
+                executedAt: executedAt,
+                reviewerId: reviewerId,
+                approvedAt: approvedAt,
+                reviewerComment: reviewerComment
+            )
+        }
 
-        return .init(
-            id: id,
-            title: title,
-            point: point,
-            metaData: .init(indexedDate: indexedDate, expiredAt: expiredAt),
-            state: state,
-            executorId: executorId,
-            executedAt: executedAt,
-            reviewerId: reviewerId,
-            approvedAt: approvedAt,
-            reviewerComment: reviewerComment
-        )
     }
-}
 
 #endif

--- a/LocalPackage/Sources/Features/HouseworkFeature/RegisterHouseworkView/RegisterHouseworkView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/RegisterHouseworkView/RegisterHouseworkView.swift
@@ -11,23 +11,23 @@ import HometeUI
 import SwiftUI
 
 struct RegisterHouseworkView: View {
-    
+
     @Environment(\.dismiss) var dismiss
     @Environment(HouseworkListStore.self) var houseworkListStore
     @Environment(\.loginContext.cohabitantId) var cohabitantId
     @LoadingState var loadingState
-    
+
     @State var houseworkTitle = ""
     @State var completePoint = 10.0
     @State var isPresentingDuplicationAlert = false
-    
+
     @FocusState var isShowingKeyboard: Bool
     @CommonError var commonErrorContent
-    
+
     @AppStorage(key: .houseworkEntryHistoryList) var houseworkEntryHistoryList = HouseworkHistoryList(items: [])
-    
+
     let dailyHouseworkList: DailyHouseworkList
-    
+
     var body: some View {
         ZStack {
             VStack(alignment: .leading, spacing: .space16) {
@@ -73,12 +73,13 @@ struct RegisterHouseworkView: View {
             Text("\"\(houseworkTitle)\"は既に登録されています。")
         }
     }
+
 }
 
 // MARK: - コンポーネント
 
 private extension RegisterHouseworkView {
-    
+
     func inputTextField() -> some View {
         ZStack {
             TextField(
@@ -107,7 +108,7 @@ private extension RegisterHouseworkView {
             .opacity(houseworkTitle.isEmpty ? 0 : 1)
         }
     }
-    
+
     func inputPointSlider() -> some View {
         VStack(spacing: .space8) {
             Text("完了ポイント")
@@ -115,10 +116,10 @@ private extension RegisterHouseworkView {
                 .frame(maxWidth: .infinity, alignment: .leading)
             Text(Int(completePoint).formatted())
                 .font(with: .headLineL)
-            Slider(value: $completePoint, in: 1...100, step: Double.Stride(1))
+            Slider(value: $completePoint, in: 1 ... 100, step: Double.Stride(1))
         }
     }
-    
+
     func entryHistoryContent() -> some View {
         VStack(alignment: .leading, spacing: .space16) {
             Text("入力履歴")
@@ -135,99 +136,94 @@ private extension RegisterHouseworkView {
             .listStyle(.inset)
         }
     }
+
 }
 
 // MARK: - プレゼンテーションロジック
 
 private extension RegisterHouseworkView {
-    
+
     func tappedClearTextFiledButton() {
-        
         houseworkTitle = ""
     }
-    
+
     func tappedEntryHistoryRow(_ item: String) {
-        
         houseworkTitle = item
         houseworkEntryHistoryList.moveToFrontIfExists(item)
     }
-    
+
     func tappedRegisterButton() async {
-        
         guard let cohabitantId else { return }
-        
+
         let newItem = HouseworkItem(
             id: UUID().uuidString,
             title: houseworkTitle,
             point: Int(completePoint),
             metaData: dailyHouseworkList.metaData
         )
-        
+
         guard !dailyHouseworkList.isAlreadyRegistered(newItem) else {
-            
             isPresentingDuplicationAlert = true
             return
         }
-        
+
         houseworkEntryHistoryList.addNewHistory(houseworkTitle)
-        
+
         do {
-            
             try await houseworkListStore.register(
                 newItem: newItem,
                 cohabitantId: cohabitantId
             )
             dismiss()
-        }
-        catch {
-            
+        } catch {
             print("Failed registering a new housework item: \(error)")
             commonErrorContent = .init(error: error)
         }
     }
+
 }
 
 #if DEBUG
-#Preview("RegisterHouseworkView") {
-    RegisterHouseworkView(
-        dailyHouseworkList: .init(
-            items: [],
-            metaData: .init(
-                indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-                expiredAt: .now
+    #Preview("RegisterHouseworkView") {
+        RegisterHouseworkView(
+            dailyHouseworkList: .init(
+                items: [],
+                metaData: .init(
+                    indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                    expiredAt: .now
+                )
             )
         )
-    )
-    .injectAppStorageWithPreview("RegisterHouseworkView") { userDefaults in
-        let historyList = HouseworkHistoryList(items: [
-            "洗濯", "掃除"
-        ])
-        userDefaults.setValue(historyList.rawValue, forKey: "houseworkEntryHistoryList")
+        .injectAppStorageWithPreview("RegisterHouseworkView") { userDefaults in
+            let historyList = HouseworkHistoryList(items: [
+                "洗濯", "掃除",
+            ])
+            userDefaults.setValue(historyList.rawValue, forKey: "houseworkEntryHistoryList")
+        }
+        .environment(HouseworkListStore(
+            houseworkClient: .previewValue,
+            cohabitantPushNotificationClient: .previewValue
+        ))
+        .snapshotForPreview(delay: 1)
     }
-    .environment(HouseworkListStore(
-        houseworkClient: .previewValue,
-        cohabitantPushNotificationClient: .previewValue
-    ))
-    .snapshotForPreview(delay: 1)
-}
 
-#Preview("RegisterHouseworkView_通信中") {
-    RegisterHouseworkView(
-        loadingState: .init(store: .init(isLoading: true)),
-        dailyHouseworkList: .init(
-            items: [],
-            metaData: .init(
-                indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
-                expiredAt: .now
+    #Preview("RegisterHouseworkView_通信中") {
+        RegisterHouseworkView(
+            loadingState: .init(store: .init(isLoading: true)),
+            dailyHouseworkList: .init(
+                items: [],
+                metaData: .init(
+                    indexedDate: .init(value: .previewDate(year: 2026, month: 1, day: 1)),
+                    expiredAt: .now
+                )
             )
         )
-    )
-    .environment(HouseworkListStore(
-        houseworkClient: .previewValue,
-        cohabitantPushNotificationClient: .previewValue
-    ))
-    #if canImport(Prefire)
-    .prefireIgnored()
-    #endif
-}
+        .environment(HouseworkListStore(
+            houseworkClient: .previewValue,
+            cohabitantPushNotificationClient: .previewValue
+        ))
+        #if canImport(Prefire)
+        .prefireIgnored()
+        #endif
+    }
 #endif

--- a/LocalPackage/Sources/Features/SettingFeature/SettingView.swift
+++ b/LocalPackage/Sources/Features/SettingFeature/SettingView.swift
@@ -80,15 +80,17 @@ public struct SettingView: View {
             Text("あなたのデータは全て削除され、復元することはできません。\nまた、現在参加しているグループが2名以下の場合は、グループごと削除されます。")
         }
     }
+
 }
 
 private extension SettingView {
-    @ViewBuilder
+
     func leadingNavigationBarContent() -> some View {
         NavigationBarButton(label: .close) {
             dismiss()
         }
     }
+
 }
 
 // MARK: プレゼンテーションロジック
@@ -96,31 +98,26 @@ private extension SettingView {
 private extension SettingView {
 
     func tappedLogoutRowButton() {
-
         isPresentedLogoutConfirmAlert = true
     }
 
     func tappedLogoutAlertOkButton() {
-
         accountAuthStore.logOut()
     }
 
     func tappedAccountDeletionRowButton() {
-
         isPresentedAccountDeletionConfirmAlert = true
     }
 
     func tappedAccountDeletionAlertOkButton() async {
-
         do {
-
             try await accountAuthStore.deleteAccount()
         } catch {
-
             // TODO: エラーハンドリング
             print("occurred error: \(error)")
         }
     }
+
 }
 
 #Preview {

--- a/LocalPackage/Sources/Features/SettingFeature/SubViews/SettingMenuItemButton.swift
+++ b/LocalPackage/Sources/Features/SettingFeature/SubViews/SettingMenuItemButton.swift
@@ -41,6 +41,7 @@ public struct SettingMenuItemButton: View {
             .padding(.vertical, .space8)
         }
     }
+
 }
 
 #Preview(traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/HometeDomain/Account/Account.swift
+++ b/LocalPackage/Sources/HometeDomain/Account/Account.swift
@@ -18,12 +18,13 @@ public struct Account: Equatable, Codable, Sendable {
         self.fcmToken = fcmToken
         self.cohabitantId = cohabitantId
     }
+
 }
 
 public extension Account {
 
     static func initial(auth: AccountAuthResult, userName: UserName, fcmToken: String?) -> Self {
-
-        return .init(id: auth.id, userName: userName.value, fcmToken: fcmToken, cohabitantId: nil)
+        .init(id: auth.id, userName: userName.value, fcmToken: fcmToken, cohabitantId: nil)
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Account/AccountStore.swift
+++ b/LocalPackage/Sources/HometeDomain/Account/AccountStore.swift
@@ -19,7 +19,6 @@ public final class AccountStore {
         accountInfoClient: AccountInfoClient = .previewValue,
         account: Account? = nil
     ) {
-
         self.accountInfoClient = accountInfoClient
         self.account = account
     }
@@ -28,13 +27,9 @@ public final class AccountStore {
     /// - Returns: ロードしたアカウント情報を返す（アカウントがない場合はnilを返す）
     @discardableResult
     public func load(_ auth: AccountAuthResult) async -> Account? {
-
         do {
-
             account = try await accountInfoClient.fetch(auth.id)
-        }
-        catch {
-
+        } catch {
             print("failed to fetch account info: \(error)")
         }
 
@@ -42,7 +37,6 @@ public final class AccountStore {
     }
 
     public func registerAccount(auth: AccountAuthResult, userName: UserName) async throws -> Account {
-
         let newAccount = Account(id: auth.id, userName: userName.value, fcmToken: nil, cohabitantId: nil)
         try await accountInfoClient.insertOrUpdate(newAccount)
         account = newAccount
@@ -50,13 +44,11 @@ public final class AccountStore {
     }
 
     public func updateFcmTokenIfNeeded(_ fcmToken: String) async {
-
         // 保持しているFCMトークンと異なるFCMトークンに変わった場合は、アカウント情報も新しいトークンに更新する
         guard let account,
               account.fcmToken != fcmToken else { return }
 
         do {
-
             let updatedAccount = Account(
                 id: account.id,
                 userName: account.userName,
@@ -65,17 +57,13 @@ public final class AccountStore {
             )
             try await accountInfoClient.insertOrUpdate(updatedAccount)
             self.account = updatedAccount
-        }
-        catch {
-
+        } catch {
             print("failed to update fcmToken: \(error)")
         }
     }
 
     public func registerCohabitantId(_ cohabitantId: String) async throws {
-
         guard let account else {
-
             preconditionFailure("Not found account.")
         }
 
@@ -88,4 +76,5 @@ public final class AccountStore {
         try await accountInfoClient.insertOrUpdate(updatedAccount)
         self.account = updatedAccount
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Account/LoginContext.swift
+++ b/LocalPackage/Sources/HometeDomain/Account/LoginContext.swift
@@ -10,11 +10,17 @@ public struct LoginContext: Equatable {
     public let account: Account
 
     /// パートナー登録済みかどうか
-    public var hasCohabitant: Bool { account.cohabitantId != nil }
+    public var hasCohabitant: Bool {
+        account.cohabitantId != nil
+    }
+
     /// 家族ID
-    public var cohabitantId: String? { account.cohabitantId }
+    public var cohabitantId: String? {
+        account.cohabitantId
+    }
 
     public init(account: Account) {
         self.account = account
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Account/UserName.swift
+++ b/LocalPackage/Sources/HometeDomain/Account/UserName.swift
@@ -6,23 +6,25 @@
 //
 
 public struct UserName {
+
     public var value = ""
 
     private static let limitCharacters = 10
 
     public var remainingCharacters: Int {
-        return Self.limitCharacters - value.count
+        Self.limitCharacters - value.count
     }
 
     public var isOverLimitCharacters: Bool {
-        return Self.limitCharacters < value.count
+        Self.limitCharacters < value.count
     }
 
     public var canRegistration: Bool {
-        return !value.isEmpty && !isOverLimitCharacters
+        !value.isEmpty && !isOverLimitCharacters
     }
 
     public init(value: String = "") {
         self.value = value
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/AnalyticsLog/AnalyticsEvent.swift
+++ b/LocalPackage/Sources/HometeDomain/AnalyticsLog/AnalyticsEvent.swift
@@ -14,31 +14,30 @@ public struct AnalyticsEvent: Equatable {
         self.name = name
         self.parameters = parameters
     }
+
 }
 
 public extension AnalyticsEvent {
 
     static func login(isSuccess: Bool) -> Self {
-
-        return .init(
+        .init(
             name: "login",
             parameters: ["isSuccess": "\(isSuccess)"]
         )
     }
 
     static func logout() -> Self {
-
-        return .init(
+        .init(
             name: "logout",
             parameters: [:]
         )
     }
 
     static func deleteAccount() -> Self {
-
-        return .init(
+        .init(
             name: "delete_account",
             parameters: [:]
         )
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/AppLaunch/LaunchState.swift
+++ b/LocalPackage/Sources/HometeDomain/AppLaunch/LaunchState.swift
@@ -17,8 +17,8 @@ public enum LaunchState: Equatable {
     case notLoggedIn
 
     public var isLoggedIn: Bool {
-
         if case .loggedIn = self { return true }
         return false
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/AppLaunch/LaunchStateProxy.swift
+++ b/LocalPackage/Sources/HometeDomain/AppLaunch/LaunchStateProxy.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 public struct LaunchStateProxy {
+
     @Binding private var launchState: LaunchState
 
     public init(launchState: Binding<LaunchState>) {
@@ -17,8 +18,11 @@ public struct LaunchStateProxy {
     public func callAsFunction(_ next: LaunchState) {
         launchState = next
     }
+
 }
 
-extension EnvironmentValues {
-    @Entry public var launchStateProxy = LaunchStateProxy(launchState: .constant(.notLoggedIn))
+public extension EnvironmentValues {
+
+    @Entry var launchStateProxy = LaunchStateProxy(launchState: .constant(.notLoggedIn))
+
 }

--- a/LocalPackage/Sources/HometeDomain/Authentification/AccountAuthInfo.swift
+++ b/LocalPackage/Sources/HometeDomain/Authentification/AccountAuthInfo.swift
@@ -6,6 +6,7 @@
 //
 
 public struct AccountAuthInfo: Equatable, Sendable {
+
     public let result: AccountAuthResult?
     public let alreadyLoadedAtInitiate: Bool
 
@@ -15,4 +16,5 @@ public struct AccountAuthInfo: Equatable, Sendable {
         self.result = result
         self.alreadyLoadedAtInitiate = alreadyLoadedAtInitiate
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Authentification/AccountAuthResult.swift
+++ b/LocalPackage/Sources/HometeDomain/Authentification/AccountAuthResult.swift
@@ -12,4 +12,5 @@ public struct AccountAuthResult: Equatable, Sendable {
     public init(id: String) {
         self.id = id
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Authentification/AccountAuthStore.swift
+++ b/LocalPackage/Sources/HometeDomain/Authentification/AccountAuthStore.swift
@@ -26,7 +26,6 @@ public final class AccountAuthStore {
         nonceGenerationClient: NonceGenerationClient = .previewValue,
         currentAuth: AccountAuthInfo = .initial
     ) {
-
         self.accountAuthClient = accountAuthClient
         self.analyticsClient = analyticsClient
         self.signInWithAppleClient = signInWithAppleClient
@@ -36,43 +35,33 @@ public final class AccountAuthStore {
         listener = accountAuthClient.makeListener()
 
         Task {
-
             await listen()
         }
     }
 
     public func login(_ signInResult: SignInWithAppleResult) async throws {
-
         do {
-
             let authInfo = try await accountAuthClient.signIn(signInResult.tokenId, signInResult.nonce)
             analyticsClient.setId(authInfo.id)
             analyticsClient.log(.login(isSuccess: true))
-        }
-        catch {
-
+        } catch {
             analyticsClient.log(.login(isSuccess: false))
             throw error
         }
     }
 
     public func logOut() {
-
         currentAuth = .init(result: nil, alreadyLoadedAtInitiate: true)
         analyticsClient.log(.logout())
 
         do {
-
             try accountAuthClient.signOut()
-        }
-        catch {
-
+        } catch {
             print("occurred error: \(error)")
         }
     }
 
     public func deleteAccount() async throws {
-
         // 1. 再認証
         let nonce = nonceGenerationClient()
         let signInWithAppleResult = try await signInWithAppleClient.reauthentication(nonce)
@@ -90,16 +79,16 @@ public final class AccountAuthStore {
         // 5. 状態更新
         currentAuth = .init(result: nil, alreadyLoadedAtInitiate: true)
     }
+
 }
 
 private extension AccountAuthStore {
 
     func listen() async {
-
         for await value in listener.values {
-
             currentAuth = .init(result: value, alreadyLoadedAtInitiate: true)
             print("currentAuth snapshot: \(String(describing: currentAuth))")
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Authentification/AccountListenerStream.swift
+++ b/LocalPackage/Sources/HometeDomain/Authentification/AccountListenerStream.swift
@@ -18,14 +18,13 @@ public struct AccountListenerStream {
         listenerToken: any NSObjectProtocol,
         continuation: AsyncStream<AccountAuthResult?>.Continuation
     ) {
-
         self.values = values
         self.listenerToken = listenerToken
         self.continuation = continuation
     }
 
     public func stopListening() {
-
         continuation.finish()
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Authentification/SignInWithAppleNonce.swift
+++ b/LocalPackage/Sources/HometeDomain/Authentification/SignInWithAppleNonce.swift
@@ -14,4 +14,5 @@ public struct SignInWithAppleNonce: Equatable, Sendable {
         self.original = original
         self.sha256 = sha256
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Authentification/SignInWithAppleResult.swift
+++ b/LocalPackage/Sources/HometeDomain/Authentification/SignInWithAppleResult.swift
@@ -16,4 +16,5 @@ public struct SignInWithAppleResult: Equatable, Sendable {
         self.nonce = nonce
         self.authorizationCode = authorizationCode
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantData.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantData.swift
@@ -18,4 +18,5 @@ public struct CohabitantData: Codable, Sendable {
         self.id = id
         self.members = members
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantMember.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantMember.swift
@@ -16,4 +16,5 @@ public struct CohabitantMember: Equatable, Hashable, Sendable {
         self.id = id
         self.userName = userName
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantMemberList.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantMemberList.swift
@@ -9,9 +9,8 @@ public struct CohabitantMemberList: Sendable, Equatable {
 
     private var _value: Set<CohabitantMember>
     let ownId: String
-    
+
     public var value: [CohabitantMember] {
-        
         guard let own = _value.first(where: { $0.id == ownId }) else { return [] }
         return [own] + .init(_value)
             .filter { $0.id != ownId }
@@ -24,7 +23,6 @@ public struct CohabitantMemberList: Sendable, Equatable {
     }
 
     public mutating func insert(_ element: CohabitantMember) {
-
         _value.insert(element)
     }
 
@@ -32,7 +30,6 @@ public struct CohabitantMemberList: Sendable, Equatable {
     /// - Parameter userIds: 追加するユーザーIDの候補の配列
     /// - Returns: 追加が必要なユーザーIDの配列
     public func missingMemberIds(from userIds: Set<String>) -> Set<String> {
-
         let existingIds = _value.map(\.id)
         return userIds.filter { !existingIds.contains($0) }
     }
@@ -41,7 +38,7 @@ public struct CohabitantMemberList: Sendable, Equatable {
     /// - Parameter id: ユーザーID
     /// - Returns: ユーザー名
     public func userName(_ id: String) -> String? {
-
-        return _value.first { $0.id == id }?.userName
+        _value.first { $0.id == id }?.userName
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantRegistration/CohabitantRegistrationMessage.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantRegistration/CohabitantRegistrationMessage.swift
@@ -21,12 +21,12 @@ public struct CohabitantRegistrationMessage: Codable, Equatable, Sendable {
         case shareCohabitantId(id: String)
         /// 登録完了したかどうかの確認
         case complete
+
     }
 
     /// 登録メンバーが確定したかどうか
     public var isFixedMember: Bool? {
-
-        guard case .fixedMember(let isOK) = type else {
+        guard case let .fixedMember(isOK) = type else {
             return nil
         }
         return isOK
@@ -34,9 +34,7 @@ public struct CohabitantRegistrationMessage: Codable, Equatable, Sendable {
 
     /// メンバーの役割
     public var memberRole: CohabitantRegistrationRole? {
-
-        guard case .preRegistration(let role) = type else {
-
+        guard case let .preRegistration(role) = type else {
             return nil
         }
         return role
@@ -44,9 +42,7 @@ public struct CohabitantRegistrationMessage: Codable, Equatable, Sendable {
 
     /// 同居人ID
     public var cohabitantId: String? {
-
-        guard case .shareCohabitantId(let id) = type else {
-
+        guard case let .shareCohabitantId(id) = type else {
             return nil
         }
         return id
@@ -54,18 +50,14 @@ public struct CohabitantRegistrationMessage: Codable, Equatable, Sendable {
 
     /// 登録処理が完了したかどうか
     public var isComplete: Bool? {
-
         guard case .complete = type else {
-
             return nil
         }
         return true
     }
 
     public func encodedData() -> Data {
-
         guard let encodedData = try? JSONEncoder().encode(self) else {
-
             preconditionFailure("Invalid message structure(\(self)).")
         }
         return encodedData
@@ -74,16 +66,16 @@ public struct CohabitantRegistrationMessage: Codable, Equatable, Sendable {
     public init(type: CommunicateType) {
         self.type = type
     }
+
 }
 
 public extension CohabitantRegistrationMessage {
 
     init(_ data: Data) {
-
         guard let message = try? JSONDecoder().decode(CohabitantRegistrationMessage.self, from: data) else {
-
             preconditionFailure("Invalid data(\(data)).")
         }
         self = message
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantRegistration/CohabitantRegistrationRole.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantRegistration/CohabitantRegistrationRole.swift
@@ -12,16 +12,14 @@ public enum CohabitantRegistrationRole: Codable, Equatable, Sendable {
     case lead
 
     public var isLeader: Bool {
-
-        return self == .lead
+        self == .lead
     }
 
     public var accountId: String {
-
         guard case let .follower(accountId) = self else {
-
             preconditionFailure("Please pre checking role is follower.")
         }
         return accountId
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantRegistration/CohabitantRegistrationState.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantRegistration/CohabitantRegistrationState.swift
@@ -13,4 +13,5 @@ public enum CohabitantRegistrationState: Equatable {
     case processing(isLead: Bool)
     /// 同居人の登録が完了
     case completed
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantRegistration/ConfirmedRegistrationPeers.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantRegistration/ConfirmedRegistrationPeers.swift
@@ -12,20 +12,18 @@ public struct ConfirmedRegistrationPeers: Equatable {
     private var peers: Set<MCPeerID>
 
     public init(peers: Set<MCPeerID>) {
-
         self.peers = peers
     }
 
     public mutating func addPeer(_ peer: MCPeerID) {
-
         peers.insert(peer)
     }
 
     public func isLeadPeer(connectedPeers: Set<MCPeerID>, myPeerID: MCPeerID) -> Bool? {
-
         guard peers == connectedPeers else { return nil }
         let firstPeerID = ([myPeerID] + connectedPeers)
             .sorted { $0.displayName < $1.displayName }.first
         return firstPeerID == myPeerID
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantStore.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/CohabitantStore.swift
@@ -30,14 +30,12 @@ public final class CohabitantStore {
         cohabitantClient: CohabitantClient = .previewValue,
         accountInfoClient: AccountInfoClient = .previewValue
     ) {
-
         self.members = .init(value: members, ownId: ownId)
         self.cohabitantClient = cohabitantClient
         self.accountInfoClient = accountInfoClient
     }
 
     public func addSnapshotListenerIfNeeded(_ cohabitantId: String) async {
-
         // すでに監視中の場合は何もしない
         if listenerTask != nil { return }
 
@@ -49,26 +47,21 @@ public final class CohabitantStore {
         listenerTask = Task {
 
             for await cohabitantDataList in stream {
-
                 guard let cohabitantData = cohabitantDataList.first else { continue }
 
                 for member in self.members.missingMemberIds(from: .init(cohabitantData.members)) {
-
                     do {
-
                         guard let account = try await accountInfoClient.fetch(member) else {
-
                             print("Not found account(cohabitantId: \(cohabitantId), userId: \(member))")
                             continue
                         }
                         members.insert(.init(id: member, userName: account.userName))
                         print("loaded cohabitant members: \(members)")
                     } catch {
-
                         print("error occurred: \(error)")
                     }
                 }
-                
+
                 // 初回のデータをロード完了したらその旨のフラグを立てる
                 isInitialLoaded = true
             }
@@ -78,15 +71,17 @@ public final class CohabitantStore {
     }
 
     public func removeSnapshotListener() async {
-
         listenerTask?.cancel()
         await listenerTask?.value
         listenerTask = nil
         await cohabitantClient.removeSnapshotListener(cohabitantListenerKey)
     }
+
 }
 
 public extension EnvironmentValues {
+
     /// 家事グループメンバー
     @Entry var cohabitantMembers: CohabitantMemberList = .init(value: [], ownId: "")
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/DailyHouseworkMetaData.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/DailyHouseworkMetaData.swift
@@ -16,15 +16,16 @@ public struct DailyHouseworkMetaData: Equatable, Sendable {
         self.indexedDate = indexedDate
         self.expiredAt = expiredAt
     }
+
 }
 
 public extension DailyHouseworkMetaData {
 
     init(selectedDate: Date, calendar: Calendar) {
-
         let selectedDay = calendar.startOfDay(for: selectedDate)
         let indexedDate = HouseworkIndexedDate(value: selectedDay)
         let expiredAt = calendar.date(byAdding: .year, value: 1, to: selectedDay) ?? selectedDay
         self.init(indexedDate: indexedDate, expiredAt: expiredAt)
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkHistoryList.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkHistoryList.swift
@@ -16,12 +16,13 @@ public struct HouseworkHistoryList: Equatable {
     }
 
     /// 履歴があるかどうか
-    public var hasHistory: Bool { !items.isEmpty }
+    public var hasHistory: Bool {
+        !items.isEmpty
+    }
 
     /// 引数に受け取った文字列が `items` に存在する場合、その要素を先頭へ移動します。
     /// - Parameter value: 先頭へ移動したい要素の文字列
     public mutating func moveToFrontIfExists(_ value: String) {
-
         guard let index = items.firstIndex(of: value) else { return }
         // 既に先頭なら何もしない
         if index == items.startIndex { return }
@@ -32,20 +33,21 @@ public struct HouseworkHistoryList: Equatable {
     /// 引数に受け取った文字列を `items`の先頭に追加する
     /// - Parameter value: 新しい履歴文字
     public mutating func addNewHistory(_ value: String) {
-
         guard items.contains(value) else {
-
             items.insert(value, at: 0)
             return
         }
         moveToFrontIfExists(value)
     }
+
 }
 
 extension HouseworkHistoryList: Codable {
 
     enum CodingKeys: String, CodingKey {
+
         case items
+
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -55,30 +57,28 @@ extension HouseworkHistoryList: Codable {
 
     public init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        items = try container.decode(Array<String>.self, forKey: .items)
+        items = try container.decode([String].self, forKey: .items)
     }
+
 }
 
 extension HouseworkHistoryList: RawRepresentable {
 
     public init?(rawValue: String) {
-
         guard let data = rawValue.data(using: .utf8),
               let decoded = try? JSONDecoder().decode(HouseworkHistoryList.self, from: data) else {
-
             return nil
         }
         self = decoded
     }
 
     public var rawValue: String {
-
         guard
             let data = try? JSONEncoder().encode(self),
             let jsonString = String(data: data, encoding: .utf8) else {
-
             return ""
         }
         return jsonString
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkIndexedDate.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkIndexedDate.swift
@@ -20,17 +20,15 @@ public struct HouseworkIndexedDate: Equatable, Codable, Hashable, Sendable {
         offsetDays: Int,
         calendar: Calendar
     ) -> [Date] {
-
         let base = calendar.startOfDay(for: anchorDate)
         guard offsetDays >= 0 else {
-
             return [base]
         }
         // -offset ... +offset の範囲を列挙
-        return (-offsetDays...offsetDays).compactMap { delta in
-
+        return (-offsetDays ... offsetDays).compactMap { delta in
             guard let date = calendar.date(byAdding: .day, value: delta, to: base) else { return nil }
             return date
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkItem.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkItem.swift
@@ -58,7 +58,6 @@ public struct HouseworkItem: Identifiable, Equatable, Sendable, Hashable, Codabl
     }
 
     public func formattedIndexedDate(calendar: Calendar) -> String {
-        
         let formatStyle = Date.FormatStyle(
             date: .numeric,
             time: .omitted,
@@ -66,21 +65,19 @@ public struct HouseworkItem: Identifiable, Equatable, Sendable, Hashable, Codabl
             calendar: calendar,
             timeZone: calendar.timeZone
         )
-            .year(.extended(minimumLength: 4))
-            .month(.twoDigits)
-            .day(.twoDigits)
+        .year(.extended(minimumLength: 4))
+        .month(.twoDigits)
+        .day(.twoDigits)
         return indexedDate.value.formatted(formatStyle)
     }
 
     /// レビュー可能かどうか
     public func canReview(ownUserId: String) -> Bool {
-
-        return executorId != ownUserId && state != .completed
+        executorId != ownUserId && state != .completed
     }
 
     public func updatePendingApproval(at now: Date, changer: String) -> Self {
-
-        return .init(
+        .init(
             id: id,
             indexedDate: indexedDate,
             title: title,
@@ -96,8 +93,7 @@ public struct HouseworkItem: Identifiable, Equatable, Sendable, Hashable, Codabl
     }
 
     public func updateApproved(at now: Date, reviewer: String, comment: String) -> Self {
-
-        return .init(
+        .init(
             id: id,
             indexedDate: indexedDate,
             title: title,
@@ -113,8 +109,7 @@ public struct HouseworkItem: Identifiable, Equatable, Sendable, Hashable, Codabl
     }
 
     public func updateRejected(at now: Date, reviewer: String, comment: String) -> Self {
-
-        return .init(
+        .init(
             id: id,
             indexedDate: indexedDate,
             title: title,
@@ -130,8 +125,7 @@ public struct HouseworkItem: Identifiable, Equatable, Sendable, Hashable, Codabl
     }
 
     public func updateIncomplete() -> Self {
-
-        return .init(
+        .init(
             id: id,
             indexedDate: indexedDate,
             title: title,
@@ -145,6 +139,7 @@ public struct HouseworkItem: Identifiable, Equatable, Sendable, Hashable, Codabl
             expiredAt: expiredAt
         )
     }
+
 }
 
 public extension HouseworkItem {
@@ -161,7 +156,6 @@ public extension HouseworkItem {
         approvedAt: Date? = nil,
         reviewerComment: String? = nil
     ) {
-
         self.init(
             id: id,
             indexedDate: metaData.indexedDate,
@@ -176,4 +170,5 @@ public extension HouseworkItem {
             expiredAt: metaData.expiredAt
         )
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkManager.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkManager.swift
@@ -15,7 +15,7 @@ public final actor HouseworkManager {
     public private(set) var listenerAnchorDate: Date = .now
     private var streamContinuationDic: [String: AsyncStream<[HouseworkItem]>.Continuation] = [:]
     private var observeTask: Task<Void, Never>?
-    
+
     // MARK: Dependencies
 
     private let houseworkClient: HouseworkClient
@@ -74,6 +74,7 @@ public final actor HouseworkManager {
             }
         }
     }
+
 }
 
 // MARK: private
@@ -81,20 +82,17 @@ public final actor HouseworkManager {
 private extension HouseworkManager {
 
     func upsert(_ updatedItems: [HouseworkItem]) {
-        
         var itemsDict = Dictionary(uniqueKeysWithValues: allItems.map { ($0.id, $0) })
         for item in updatedItems {
-            
             itemsDict[item.id] = item
         }
         allItems = Array(itemsDict.values)
     }
 
     func notifyObservers() {
-        
-        streamContinuationDic.forEach { _, continuation in
-            
+        for (_, continuation) in streamContinuationDic {
             continuation.yield(allItems)
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkState.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkState.swift
@@ -11,5 +11,8 @@ public enum HouseworkState: CaseIterable, Identifiable, Codable, Sendable {
     case pendingApproval
     case completed
 
-    public var id: Self { self }
+    public var id: Self {
+        self
+    }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/AccountAuthClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/AccountAuthClient.swift
@@ -1,5 +1,5 @@
 //
-//  AccountListener.swift
+//  AccountAuthClient.swift
 //  homete
 //
 //  Created by 佐藤汰一 on 2025/08/03.
@@ -20,17 +20,17 @@ public struct AccountAuthClient: Sendable {
         signIn: @Sendable @escaping (String, String) async throws -> AccountAuthResult = { _, _ in .init(id: "id") },
         signOut: @Sendable @escaping () throws -> Void = {},
         makeListener: @Sendable @escaping () -> AccountListenerStream = {
-
             let (stream, continuation) = AsyncStream<AccountAuthResult?>.makeStream()
-            return AccountListenerStream(values: stream,
-                                         listenerToken: NSObject(),
-                                         continuation: continuation)
+            return AccountListenerStream(
+                values: stream,
+                listenerToken: NSObject(),
+                continuation: continuation
+            )
         },
         reauthenticateWithApple: @Sendable @escaping (_: SignInWithAppleResult) async throws -> Void = { _ in },
         revokeAppleToken: @Sendable @escaping (_: String) async throws -> Void = { _ in },
         deleteAccount: @Sendable @escaping () async throws -> Void = {}
     ) {
-
         self.signIn = signIn
         self.signOut = signOut
         self.makeListener = makeListener
@@ -38,8 +38,11 @@ public struct AccountAuthClient: Sendable {
         self.revokeAppleToken = revokeAppleToken
         self.deleteAccount = deleteAccount
     }
+
 }
 
 public extension AccountAuthClient {
+
     static let previewValue = AccountAuthClient()
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/AccountInfoClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/AccountInfoClient.swift
@@ -17,9 +17,11 @@ public struct AccountInfoClient: Sendable {
         self.insertOrUpdate = insertOrUpdate
         self.fetch = fetch
     }
+
 }
 
 public extension AccountInfoClient {
 
     static let previewValue: AccountInfoClient = .init()
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/AnalyticsClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/AnalyticsClient.swift
@@ -14,13 +14,14 @@ public struct AnalyticsClient: Sendable {
         setId: @Sendable @escaping (String) -> Void = { _ in },
         log: @Sendable @escaping (AnalyticsEvent) -> Void = { _ in }
     ) {
-
         self.setId = setId
         self.log = log
     }
+
 }
 
 public extension AnalyticsClient {
 
     static let previewValue = AnalyticsClient()
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/AppDependencies.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/AppDependencies.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 public struct AppDependencies: Sendable {
+
     public let nonceGeneratorClient: NonceGenerationClient
     public let accountAuthClient: AccountAuthClient
     public let analyticsClient: AnalyticsClient
@@ -38,16 +39,19 @@ public struct AppDependencies: Sendable {
         self.signInWithAppleClient = signInWithAppleClient
         houseworkManager = .init(houseworkClient: houseworkClient)
     }
+
 }
 
 // MARK: Preview用の定義
 
-extension AppDependencies {
+public extension AppDependencies {
 
-    public static let previewValue: Self = .init()
+    static let previewValue: Self = .init()
+
 }
 
-extension EnvironmentValues {
+public extension EnvironmentValues {
 
-    @Entry public var appDependencies: AppDependencies = .init()
+    @Entry var appDependencies: AppDependencies = .init()
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/CohabitantClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/CohabitantClient.swift
@@ -22,14 +22,15 @@ public struct CohabitantClient: Sendable {
         ) async -> AsyncStream<[CohabitantData]> = { _, _ in .init { nil } },
         removeSnapshotListener: @Sendable @escaping (_ listenerId: String) async -> Void = { _ in }
     ) {
-
         self.register = register
         self.addSnapshotListener = addSnapshotListener
         self.removeSnapshotListener = removeSnapshotListener
     }
+
 }
 
 public extension CohabitantClient {
 
     static let previewValue: CohabitantClient = .init()
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/CohabitantPushNotificationClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/CohabitantPushNotificationClient.swift
@@ -6,14 +6,17 @@
 //
 
 public struct CohabitantPushNotificationClient: Sendable {
+
     public let send: @Sendable (_ id: String, _ content: PushNotificationContent) async throws -> Void
 
     public init(send: @Sendable @escaping (_ id: String, _ content: PushNotificationContent) async throws -> Void) {
         self.send = send
     }
+
 }
 
 public extension CohabitantPushNotificationClient {
 
     static let previewValue: CohabitantPushNotificationClient = .init { _, _ in }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/DependencyClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/DependencyClient.swift
@@ -9,4 +9,5 @@ public protocol DependencyClient: Sendable {
 
     static var liveValue: Self { get }
     static var previewValue: Self { get }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkClient.swift
@@ -23,6 +23,7 @@ public struct HouseworkClient: Sendable {
         _ from: Date,
         _ to: Date
     ) async throws -> [HouseworkItem]
+
 }
 
 public extension HouseworkClient {
@@ -49,7 +50,6 @@ public extension HouseworkClient {
             _ to: Date
         ) async throws -> [HouseworkItem] = { _, _, _ in [] }
     ) {
-
         insertOrUpdateItem = insertOrUpdateItemHandler
         removeItem = removeItemHandler
         snapshotListener = snapshotListenerHandler
@@ -58,4 +58,5 @@ public extension HouseworkClient {
     }
 
     static let previewValue = HouseworkClient()
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/NonceGenerationClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/NonceGenerationClient.swift
@@ -11,19 +11,19 @@ public struct NonceGenerationClient: Sendable {
 
     public let value: @Sendable () -> SignInWithAppleNonce
     public func callAsFunction() -> SignInWithAppleNonce {
-
-        return value()
+        value()
     }
 
     public init(value: @Sendable @escaping () -> SignInWithAppleNonce) {
         self.value = value
     }
+
 }
 
 public extension NonceGenerationClient {
 
     static let previewValue: NonceGenerationClient = .init {
-
-        return .init(original: "preview", sha256: "preview sha256")
+        .init(original: "preview", sha256: "preview sha256")
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/SignInWithAppleClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/SignInWithAppleClient.swift
@@ -6,18 +6,20 @@
 //
 
 public struct SignInWithAppleClient: Sendable {
+
     public let reauthentication: @MainActor (_ nonce: SignInWithAppleNonce) async throws -> SignInWithAppleResult
 
     public init(
         reauthentication: @MainActor @escaping (_ nonce: SignInWithAppleNonce)
         async throws -> SignInWithAppleResult = { _ in preconditionFailure() }
     ) {
-
         self.reauthentication = reauthentication
     }
+
 }
 
 public extension SignInWithAppleClient {
 
     static let previewValue = SignInWithAppleClient()
+
 }

--- a/LocalPackage/Sources/HometeDomain/DomainError.swift
+++ b/LocalPackage/Sources/HometeDomain/DomainError.swift
@@ -10,13 +10,14 @@ public enum DomainError: Error, Equatable, Sendable {
     case failAuth
     case noNetwork
     case other
+
 }
 
 public extension DomainError {
 
     static func make(_ error: (any Error)?) -> Self? {
-
         guard let error else { return nil }
         return error as? DomainError ?? .other
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Navigation/AppRoute.swift
+++ b/LocalPackage/Sources/HometeDomain/Navigation/AppRoute.swift
@@ -4,8 +4,10 @@
 //
 
 public enum AppRoute: Hashable, Sendable {
+
     /// 同居人登録画面
     case cohabitantRegistration
     /// 設定画面
     case setting
+
 }

--- a/LocalPackage/Sources/HometeDomain/NotificationCenter/NotificationCustomName.swift
+++ b/LocalPackage/Sources/HometeDomain/NotificationCenter/NotificationCustomName.swift
@@ -4,7 +4,8 @@
 
 import Foundation
 
-extension Notification.Name {
+public extension Notification.Name {
 
-    public static let didReceiveFcmToken = Notification.Name("didReceiveFcmToken")
+    static let didReceiveFcmToken = Notification.Name("didReceiveFcmToken")
+
 }

--- a/LocalPackage/Sources/HometeDomain/PushNotificationContent.swift
+++ b/LocalPackage/Sources/HometeDomain/PushNotificationContent.swift
@@ -6,6 +6,7 @@
 //
 
 public struct PushNotificationContent: Equatable, Sendable {
+
     public let title: String
     public let message: String
 
@@ -13,35 +14,37 @@ public struct PushNotificationContent: Equatable, Sendable {
         self.title = title
         self.message = message
     }
+
 }
 
 public extension PushNotificationContent {
 
     static func addNewHouseworkItem(_ houseworkTitle: String) -> Self {
-        return .init(
+        .init(
             title: "新しい家事が登録されました",
             message: houseworkTitle
         )
     }
 
     static func requestReviewMessage(houseworkTitle: String) -> Self {
-        return .init(
+        .init(
             title: "確認が必要な家事があります",
             message: "問題なければ「\(houseworkTitle)」の完了に感謝を伝えましょう！"
         )
     }
 
     static func approvedMessage(reviwerName: String, houseworkTitle: String, comment: String) -> Self {
-        return .init(
+        .init(
             title: "\(reviwerName)が「\(houseworkTitle)」を承認しました！",
             message: comment
         )
     }
 
-    static func rejectedMessage(reviwerName: String, houseworkTitle: String, comment: String) -> Self {
-        return .init(
+    static func rejectedMessage(reviwerName _: String, houseworkTitle: String, comment: String) -> Self {
+        .init(
             title: "「\(houseworkTitle)」を再確認してください",
             message: comment
         )
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Setting/SettingMenuItem.swift
+++ b/LocalPackage/Sources/HometeDomain/Setting/SettingMenuItem.swift
@@ -14,30 +14,29 @@ public enum SettingMenuItem: Equatable, CaseIterable {
     case license
 
     public var title: LocalizedStringKey {
-
         switch self {
         case .taskTemplate:
-            return "家事テンプレート"
+            "家事テンプレート"
 
         case .privacyPolicy:
-            return "プライバシーポリシー"
+            "プライバシーポリシー"
 
         case .license:
-            return "ライセンス"
+            "ライセンス"
         }
     }
 
     public var iconName: String {
-
         switch self {
         case .taskTemplate:
-            return "house"
+            "house"
 
         case .privacyPolicy:
-            return "hand.raised"
+            "hand.raised"
 
         case .license:
-            return "cube.box"
+            "cube.box"
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/SignInWithApple/SignInWithAppleResultFactory.swift
+++ b/LocalPackage/Sources/HometeDomain/SignInWithApple/SignInWithAppleResultFactory.swift
@@ -6,11 +6,11 @@ import AuthenticationServices
 import Foundation
 
 public enum SignInWithAppleResultFactory {
+
     public static func make(
         _ credential: ASAuthorizationAppleIDCredential,
         _ nonce: SignInWithAppleNonce
     ) throws -> SignInWithAppleResult {
-
         guard let appleIDToken = credential.identityToken else {
             print("Unable to fetdch identify token.")
             throw DomainError.failAuth
@@ -32,4 +32,5 @@ public enum SignInWithAppleResultFactory {
             authorizationCode: authCodeString
         )
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Date/CalendarHelper.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Date/CalendarHelper.swift
@@ -9,13 +9,15 @@ import Foundation
 
 #if DEBUG
 
-extension Calendar {
-    public static var japanese: Self {
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = .tokyo
-        calendar.locale = .jp
-        return calendar
+    public extension Calendar {
+
+        static var japanese: Self {
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = .tokyo
+            calendar.locale = .jp
+            return calendar
+        }
+
     }
-}
 
 #endif

--- a/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Date/DateHelper.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Date/DateHelper.swift
@@ -9,27 +9,29 @@ import Foundation
 
 #if DEBUG
 
-public extension Date {
-    static func previewDate(
-        year: Int,
-        month: Int,
-        day: Int,
-        hour: Int = .zero,
-        minute: Int = .zero,
-        second: Int = .zero
-    ) -> Date {
-        DateComponents(
-            calendar: .japanese,
-            timeZone: .tokyo,
-            year: year,
-            month: month,
-            day: day,
-            hour: hour,
-            minute: minute,
-            second: second
-        )
-        .date! // swiftlint:disable:this force_unwrapping
+    public extension Date {
+
+        static func previewDate(
+            year: Int,
+            month: Int,
+            day: Int,
+            hour: Int = .zero,
+            minute: Int = .zero,
+            second: Int = .zero
+        ) -> Date {
+            DateComponents(
+                calendar: .japanese,
+                timeZone: .tokyo,
+                year: year,
+                month: month,
+                day: day,
+                hour: hour,
+                minute: minute,
+                second: second
+            )
+            .date! // swiftlint:disable:this force_unwrapping
+        }
+
     }
-}
 
 #endif

--- a/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Date/LocaleHelper.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Date/LocaleHelper.swift
@@ -2,8 +2,10 @@ import Foundation
 
 #if DEBUG
 
-extension Locale {
-    public static let jp = Self.init(identifier: "ja_JP")
-}
+    public extension Locale {
+
+        static let jp = Self(identifier: "ja_JP")
+
+    }
 
 #endif

--- a/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Date/TimeZoneHelper.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Date/TimeZoneHelper.swift
@@ -9,9 +9,11 @@ import Foundation
 
 #if DEBUG
 
-extension TimeZone {
-    // swiftlint:disable:next force_unwrapping
-    public static let tokyo = Self.init(identifier: "Asia/Tokyo")!
-}
+    public extension TimeZone {
+
+        // swiftlint:disable:next force_unwrapping
+        static let tokyo = Self(identifier: "Asia/Tokyo")!
+
+    }
 
 #endif

--- a/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/HouseworkItemHelper.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/HouseworkItemHelper.swift
@@ -9,75 +9,74 @@ import Foundation
 
 #if DEBUG
 
-extension HouseworkItem {
-    
-    public static func makeForTest(
-        id: Int,
-        indexedDate: Date = .now,
-        title: String = "title",
-        point: Int = 100,
-        state: HouseworkState = .incomplete,
-        executorId: String? = nil,
-        executedAt: Date? = nil,
-        reviewerId: String? = nil,
-        approvedAt: Date? = nil,
-        reviewerComment: String? = nil,
-        expiredAt: Date = .now
-    ) -> Self {
-        
-        return .init(
-            id: "id\(id.formatted())",
-            indexedDate: .init(value: indexedDate),
-            title: title,
-            point: point,
-            state: state,
-            executorId: executorId,
-            executedAt: executedAt,
-            reviewerId: reviewerId,
-            approvedAt: approvedAt,
-            reviewerComment: reviewerComment,
-            expiredAt: expiredAt
-        )
+    public extension HouseworkItem {
+
+        static func makeForTest(
+            id: Int,
+            indexedDate: Date = .now,
+            title: String = "title",
+            point: Int = 100,
+            state: HouseworkState = .incomplete,
+            executorId: String? = nil,
+            executedAt: Date? = nil,
+            reviewerId: String? = nil,
+            approvedAt: Date? = nil,
+            reviewerComment: String? = nil,
+            expiredAt: Date = .now
+        ) -> Self {
+            .init(
+                id: "id\(id.formatted())",
+                indexedDate: .init(value: indexedDate),
+                title: title,
+                point: point,
+                state: state,
+                executorId: executorId,
+                executedAt: executedAt,
+                reviewerId: reviewerId,
+                approvedAt: approvedAt,
+                reviewerComment: reviewerComment,
+                expiredAt: expiredAt
+            )
+        }
+
+        func updateProperties(
+            indexedDate: HouseworkIndexedDate? = nil,
+            title: String? = nil,
+            point: Int? = nil,
+            state: HouseworkState? = nil,
+            executorId: String? = nil,
+            executedAt: Date? = nil,
+            reviewerId: String? = nil,
+            approvedAt: Date? = nil,
+            reviewerComment: String? = nil,
+            expiredAt: Date? = nil
+        ) -> HouseworkItem {
+            let inputIndexedDate = indexedDate ?? self.indexedDate
+            let inputTitle = title ?? self.title
+            let inputPoint = point ?? self.point
+            let inputState = state ?? self.state
+            let inputExecutorId = executorId
+            let inputExecutedAt = executedAt
+            let inputReviewerId = reviewerId
+            let inputApprovedAt = approvedAt
+            let inputReviewerComment = reviewerComment
+            let inputExpiredAt = expiredAt ?? self.expiredAt
+
+            return .init(
+                id: id,
+                indexedDate: inputIndexedDate,
+                title: inputTitle,
+                point: inputPoint,
+                state: inputState,
+                executorId: inputExecutorId,
+                executedAt: inputExecutedAt,
+                reviewerId: inputReviewerId,
+                approvedAt: inputApprovedAt,
+                reviewerComment: inputReviewerComment,
+                expiredAt: inputExpiredAt
+            )
+        }
+
     }
-    
-    public func updateProperties(
-        indexedDate: HouseworkIndexedDate? = nil,
-        title: String? = nil,
-        point: Int? = nil,
-        state: HouseworkState? = nil,
-        executorId: String? = nil,
-        executedAt: Date? = nil,
-        reviewerId: String? = nil,
-        approvedAt: Date? = nil,
-        reviewerComment: String? = nil,
-        expiredAt: Date? = nil
-    ) -> HouseworkItem {
-        
-        let inputIndexedDate = indexedDate ?? self.indexedDate
-        let inputTitle = title ?? self.title
-        let inputPoint = point ?? self.point
-        let inputState = state ?? self.state
-        let inputExecutorId = executorId
-        let inputExecutedAt = executedAt
-        let inputReviewerId = reviewerId
-        let inputApprovedAt = approvedAt
-        let inputReviewerComment = reviewerComment
-        let inputExpiredAt = expiredAt ?? self.expiredAt
-        
-        return .init(
-            id: id,
-            indexedDate: inputIndexedDate,
-            title: inputTitle,
-            point: inputPoint,
-            state: inputState,
-            executorId: inputExecutorId,
-            executedAt: inputExecutedAt,
-            reviewerId: inputReviewerId,
-            approvedAt: inputApprovedAt,
-            reviewerComment: inputReviewerComment,
-            expiredAt: inputExpiredAt
-        )
-    }
-}
 
 #endif

--- a/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/ObservationHelper.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/ObservationHelper.swift
@@ -9,26 +9,25 @@ import Observation
 
 #if DEBUG
 
-public enum ObservationHelper {
-    
-    /// Observableなオブジェクトのプロパティが変更を検知する
-    /// - Parameters:
-    ///   - apply: 変更を検知したいプロパティを返す
-    ///   - onChange: 変更検知時に発火するクロージャ
-    @MainActor
-    public static func continuousObservationTracking<T: Sendable>(
-        _ apply: @escaping @MainActor @Sendable () -> T,
-        onChange: @escaping @Sendable () -> Void
-    ) {
+    public enum ObservationHelper {
 
-        _ = withObservationTracking { apply() } onChange: {
-
-            onChange()
-            Task { @MainActor in
-                continuousObservationTracking(apply, onChange: onChange)
+        /// Observableなオブジェクトのプロパティが変更を検知する
+        /// - Parameters:
+        ///   - apply: 変更を検知したいプロパティを返す
+        ///   - onChange: 変更検知時に発火するクロージャ
+        @MainActor
+        public static func continuousObservationTracking(
+            _ apply: @escaping @MainActor @Sendable () -> some Sendable,
+            onChange: @escaping @Sendable () -> Void
+        ) {
+            _ = withObservationTracking { apply() } onChange: {
+                onChange()
+                Task { @MainActor in
+                    continuousObservationTracking(apply, onChange: onChange)
+                }
             }
         }
+
     }
-}
 
 #endif

--- a/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Preview/PreviewEnvironment.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/Preview/PreviewEnvironment.swift
@@ -9,15 +9,16 @@ import SwiftUI
 
 #if DEBUG
 
-public extension View {
-    func setupEnvironmentForPreview() -> some View {
-        var calendar = Calendar.japanese
-        calendar.timeZone = .tokyo
-        return self
-            .environment(\.locale, .jp)
-            .environment(\.timeZone, .tokyo)
-            .environment(\.calendar, calendar)
+    public extension View {
+
+        func setupEnvironmentForPreview() -> some View {
+            var calendar = Calendar.japanese
+            calendar.timeZone = .tokyo
+            return environment(\.locale, .jp)
+                .environment(\.timeZone, .tokyo)
+                .environment(\.calendar, calendar)
+        }
+
     }
-}
 
 #endif

--- a/LocalPackage/Sources/HometeDomain/Utilities/Environments.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/Environments.swift
@@ -7,7 +7,9 @@
 
 import SwiftUI
 
-extension EnvironmentValues {
+public extension EnvironmentValues {
+
     /// 現在の日付のDateオブジェクトを返す
-    @Entry public var now = Date.now
+    @Entry var now = Date.now
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/AppDependencies+liveValue.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/AppDependencies+liveValue.swift
@@ -6,9 +6,9 @@ import HometeDomain
 
 // MARK: Live用の定義
 
-extension AppDependencies {
+public extension AppDependencies {
 
-    public static let liveValue: Self = .init(
+    static let liveValue: Self = .init(
         nonceGeneratorClient: .liveValue,
         accountAuthClient: .liveValue,
         analyticsClient: .liveValue,
@@ -18,4 +18,5 @@ extension AppDependencies {
         cohabitantPushNotificationClient: .liveValue,
         signInWithAppleClient: .liveValue
     )
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Firestore/FirestoreListenerStorerable.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Firestore/FirestoreListenerStorerable.swift
@@ -10,6 +10,7 @@ protocol FirestoreListenerStorerable<Element> {
     var continuation: AsyncStream<Element>.Continuation { get }
     var listener: any ListenerRegistration { get }
     func remove()
+
 }
 
 struct FirestoreListener<Element>: FirestoreListenerStorerable {
@@ -18,8 +19,8 @@ struct FirestoreListener<Element>: FirestoreListenerStorerable {
     let listener: any ListenerRegistration
 
     func remove() {
-
         continuation.finish()
         listener.remove()
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Firestore/FirestoreService.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Firestore/FirestoreService.swift
@@ -11,42 +11,35 @@ final actor FirestoreService {
     private var listeners: [String: any FirestoreListenerStorerable] = [:]
 
     func fetch<T: Decodable>(predicate: (Firestore) -> Query) async throws -> [T] {
-
-        return try await predicate(firestore)
+        try await predicate(firestore)
             .getDocuments()
             .documents
             .map { try $0.data(as: T.self) }
     }
 
     func fetch<T: Decodable & Sendable>(predicate: (Firestore) -> DocumentReference) async throws -> T {
-
-        return try await predicate(firestore).getDocument(as: T.self)
+        try await predicate(firestore).getDocument(as: T.self)
     }
 
-    func insertOrUpdate<T: Encodable>(data: T, predicate: (Firestore) -> DocumentReference) throws {
-
+    func insertOrUpdate(data: some Encodable, predicate: (Firestore) -> DocumentReference) throws {
         try predicate(firestore).setData(from: data, merge: false)
     }
 
     func delete(predicate: (Firestore) -> DocumentReference) async throws {
-
         try await predicate(firestore).delete()
     }
 
-    func addSnapshotListener<Output>(
+    func addSnapshotListener<Output: Decodable>(
         id: String,
         predicate: (Firestore) -> Query
-    ) -> AsyncStream<[Output]> where Output: Decodable {
-
+    ) -> AsyncStream<[Output]> {
         let (stream, continuation) = AsyncStream.makeStream(
             of: [Output].self,
             bufferingPolicy: .bufferingNewest(10)
         )
         let listener = predicate(firestore)
             .addSnapshotListener { snapshots, error in
-
                 if let error {
-
                     print("occurred error at fetchSnapshotListener(type: \(Output.self), error: \(error))")
                     return
                 }
@@ -61,8 +54,8 @@ final actor FirestoreService {
     }
 
     func removeSnapshotListener(id: String) {
-
         let listener = listeners[id]
         listener?.remove()
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Firestore/Reference/CollectionPath.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Firestore/Reference/CollectionPath.swift
@@ -10,12 +10,13 @@ enum CollectionPath: String {
     case cohabitant = "Cohabitant"
     case houseworks = "Houseworks"
     case dailyHouseworks = "DailyHouseworks"
+
 }
 
 extension Firestore {
 
     func collection(path: CollectionPath) -> CollectionReference {
-
-        return self.collection(path.rawValue)
+        collection(path.rawValue)
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Firestore/Reference/FirestoreExtensionForReferencePath.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Firestore/Reference/FirestoreExtensionForReferencePath.swift
@@ -8,24 +8,20 @@ extension Firestore {
 
     /// アカウントの参照を取得する
     func accountRef(id: String) -> DocumentReference {
-
-        return self
-            .collection(CollectionPath.account.rawValue)
+        collection(CollectionPath.account.rawValue)
             .document(id)
     }
 
     /// 同居人の参照を取得する
     func cohabitantRef(id: String) -> DocumentReference {
-
-        return self
-            .collection(CollectionPath.cohabitant.rawValue)
+        collection(CollectionPath.cohabitant.rawValue)
             .document(id)
     }
 
     /// 家事コレクションの参照を取得する
     func houseworkListRef(id: String) -> CollectionReference {
-
-        return self.cohabitantRef(id: id)
+        cohabitantRef(id: id)
             .collection(CollectionPath.houseworks.rawValue)
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplAccountAuthClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplAccountAuthClient.swift
@@ -2,55 +2,48 @@
 //  ImplAccountAuthClient.swift
 //
 
-import HometeDomain
 import FirebaseAuth
+import HometeDomain
 
 extension AccountAuthClient {
 
     static let liveValue: AccountAuthClient = .init(
         signIn: { tokenId, nonce in
-
             try await signInWithApple(tokenId: tokenId, nonce: nonce)
         },
         signOut: {
-
             try Auth.auth().signOut()
         },
         makeListener: {
-
-            return Self.makeListener()
+            Self.makeListener()
         },
         reauthenticateWithApple: { signInWithAppleResult in
-
             let credential = OAuthProvider.credential(
                 providerID: .apple,
                 idToken: signInWithAppleResult.tokenId,
                 rawNonce: signInWithAppleResult.nonce
             )
             guard let user = Auth.auth().currentUser else {
-
                 throw DomainError.failAuth
             }
             try await user.reauthenticate(with: credential)
         },
         revokeAppleToken: { authorizationCode in
-
             try await Auth.auth().revokeToken(withAuthorizationCode: authorizationCode)
         },
         deleteAccount: {
-
             guard let user = Auth.auth().currentUser else {
                 throw DomainError.failAuth
             }
             try await user.delete()
         }
     )
+
 }
 
 private extension AccountAuthClient {
 
     static func signInWithApple(tokenId: String, nonce: String) async throws -> AccountAuthResult {
-
         let credential = OAuthProvider.credential(
             providerID: .apple,
             idToken: tokenId,
@@ -63,7 +56,6 @@ private extension AccountAuthClient {
     static func makeListener() -> AccountListenerStream {
         let (stream, continuation) = AsyncStream<AccountAuthResult?>.makeStream()
         let token = Auth.auth().addStateDidChangeListener { _, user in
-
             guard let user else {
                 continuation.yield(nil)
                 return
@@ -73,4 +65,5 @@ private extension AccountAuthClient {
         }
         return .init(values: stream, listenerToken: token, continuation: continuation)
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplAccountInfoClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplAccountInfoClient.swift
@@ -8,16 +8,13 @@ import HometeDomain
 extension AccountInfoClient {
 
     static let liveValue: AccountInfoClient = .init { account in
-
         try await FirestoreService.shared.insertOrUpdate(data: account) {
-
-            return $0.accountRef(id: account.id)
+            $0.accountRef(id: account.id)
         }
     } fetch: { id in
-
-        return try await FirestoreService.shared.fetch {
-
-            return $0.accountRef(id: id)
+        try await FirestoreService.shared.fetch {
+            $0.accountRef(id: id)
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplAnalyticsClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplAnalyticsClient.swift
@@ -5,23 +5,23 @@
 import HometeDomain
 
 #if os(iOS)
-import FirebaseAnalytics
-import FirebaseCrashlytics
+    import FirebaseAnalytics
+    import FirebaseCrashlytics
 
-extension AnalyticsClient {
+    extension AnalyticsClient {
 
-    static let liveValue: AnalyticsClient = .init { userId in
+        static let liveValue: AnalyticsClient = .init { userId in
+            Analytics.setUserID(userId)
+            Crashlytics.crashlytics().setUserID(userId)
+        } log: { event in
+            Analytics.logEvent(event.name, parameters: event.parameters)
+        }
 
-        Analytics.setUserID(userId)
-        Crashlytics.crashlytics().setUserID(userId)
-    } log: { event in
-
-        Analytics.logEvent(event.name, parameters: event.parameters)
     }
-}
 #else
-extension AnalyticsClient {
+    extension AnalyticsClient {
 
-    static let liveValue: AnalyticsClient = .init { _ in } log: { _ in }
-}
+        static let liveValue: AnalyticsClient = .init { _ in } log: { _ in }
+
+    }
 #endif

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplCohabitantClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplCohabitantClient.swift
@@ -8,19 +8,16 @@ import HometeDomain
 extension CohabitantClient {
 
     static let liveValue: CohabitantClient = .init { data in
-
         try await FirestoreService.shared.insertOrUpdate(data: data) {
-
-            return $0.cohabitantRef(id: data.id)
+            $0.cohabitantRef(id: data.id)
         }
     } addSnapshotListener: { listenerId, cohabitantId in
-
-        return await FirestoreService.shared.addSnapshotListener(id: listenerId) {
+        await FirestoreService.shared.addSnapshotListener(id: listenerId) {
             $0.collection(path: .cohabitant)
                 .whereField(CohabitantData.idField, isEqualTo: cohabitantId)
         }
     } removeSnapshotListener: { listenerId in
-
         await FirestoreService.shared.removeSnapshotListener(id: listenerId)
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplCohabitantPushNotificationClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplCohabitantPushNotificationClient.swift
@@ -13,7 +13,8 @@ extension CohabitantPushNotificationClient {
             .call([
                 "cohabitantId": id,
                 "title": content.title,
-                "body": content.message
+                "body": content.message,
             ])
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplHouseworkClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplHouseworkClient.swift
@@ -8,23 +8,18 @@ import HometeDomain
 extension HouseworkClient {
 
     static let liveValue = HometeDomain.HouseworkClient { item, cohabitantId in
-
         try await FirestoreService.shared.insertOrUpdate(data: item) {
-
-            return $0
+            $0
                 .houseworkListRef(id: cohabitantId)
                 .document(item.id)
         }
     } removeItemHandler: { item, cohabitantId in
-
         try await FirestoreService.shared.delete {
-
-            return $0
+            $0
                 .houseworkListRef(id: cohabitantId)
                 .document(item.id)
         }
     } snapshotListenerHandler: { id, cohabitantId, anchorDate, offset in
-
         let targetDateList = HouseworkIndexedDate.calcTargetPeriod(
             anchorDate: anchorDate,
             offsetDays: offset,
@@ -32,19 +27,17 @@ extension HouseworkClient {
         )
 
         return await FirestoreService.shared.addSnapshotListener(id: id) {
-
-            return $0.houseworkListRef(id: cohabitantId)
+            $0.houseworkListRef(id: cohabitantId)
                 .whereField("indexedDate.value", in: targetDateList)
         }
     } removeListenerHandler: { id in
-
         await FirestoreService.shared.removeSnapshotListener(id: id)
     } fetchItemsHandler: { cohabitantId, from, to in
-
-        return try await FirestoreService.shared.fetch {
+        try await FirestoreService.shared.fetch {
             $0.houseworkListRef(id: cohabitantId)
                 .whereField("indexedDate.value", isGreaterThanOrEqualTo: from)
                 .whereField("indexedDate.value", isLessThanOrEqualTo: to)
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplNonceGenerationClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplNonceGenerationClient.swift
@@ -9,33 +9,29 @@ import HometeDomain
 extension NonceGenerationClient {
 
     static let liveValue: NonceGenerationClient = .init {
-
         var randomBytes = [UInt8](repeating: 0, count: 32)
         let errorCode = SecRandomCopyBytes(kSecRandomDefault, randomBytes.count, &randomBytes)
         if errorCode != errSecSuccess {
-
-          fatalError(
-            "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
-          )
+            fatalError(
+                "Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)"
+            )
         }
 
         let charset: [Character] =
-          Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
 
         let nonce = randomBytes.map { byte in
-
-          // Pick a random character from the set, wrapping around if needed.
-          charset[Int(byte) % charset.count]
+            // Pick a random character from the set, wrapping around if needed.
+            charset[Int(byte) % charset.count]
         }
 
         return .init(original: String(nonce), sha256: Self.sha256(String(nonce)))
     }
 
     private static func sha256(_ input: String) -> String {
-
-      let inputData = Data(input.utf8)
-      let hashedData = SHA256.hash(data: inputData)
-      let hashString = hashedData.compactMap { String(format: "%02x", $0) }.joined()
-      return hashString
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        return hashedData.compactMap { String(format: "%02x", $0) }.joined()
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/Impl/ImplSignInWithAppleClient.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Impl/ImplSignInWithAppleClient.swift
@@ -8,9 +8,9 @@ import HometeDomain
 extension SignInWithAppleClient {
 
     static let liveValue = SignInWithAppleClient { nonce in
-
         let signInWithApple = SignInWithApple()
         let appleIDCredential = try await signInWithApple(nonce)
         return try SignInWithAppleResultFactory.make(appleIDCredential, nonce)
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/SignInWithApple/SignInWithApple.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/SignInWithApple/SignInWithApple.swift
@@ -10,9 +10,7 @@ final class SignInWithApple: NSObject, ASAuthorizationControllerDelegate {
     private var continuation: CheckedContinuation<ASAuthorizationAppleIDCredential, any Error>?
 
     func callAsFunction(_ nonce: SignInWithAppleNonce) async throws -> ASAuthorizationAppleIDCredential {
-
-        return try await withCheckedThrowingContinuation { continuation in
-
+        try await withCheckedThrowingContinuation { continuation in
             self.continuation = continuation
 
             let authorizationController = ASAuthorizationController(
@@ -24,20 +22,19 @@ final class SignInWithApple: NSObject, ASAuthorizationControllerDelegate {
     }
 
     func authorizationController(
-        controller: ASAuthorizationController,
+        controller _: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
-
         if case let appleIDCredential as ASAuthorizationAppleIDCredential = authorization.credential {
             continuation?.resume(returning: appleIDCredential)
         }
     }
 
     func authorizationController(
-        controller: ASAuthorizationController,
+        controller _: ASAuthorizationController,
         didCompleteWithError error: any Error
     ) {
-
         continuation?.resume(throwing: error)
     }
+
 }

--- a/LocalPackage/Sources/HometeInfrastructure/SignInWithApple/SignInWithAppleRequestFactory.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/SignInWithApple/SignInWithAppleRequestFactory.swift
@@ -8,11 +8,11 @@ import HometeDomain
 enum SignInWithAppleRequestFactory {
 
     static func make(_ nonce: SignInWithAppleNonce) -> ASAuthorizationAppleIDRequest {
-
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName]
         request.nonce = nonce.sha256
         return request
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/Components/Environment/LoginContext+Environment.swift
+++ b/LocalPackage/Sources/HometeUI/Components/Environment/LoginContext+Environment.swift
@@ -11,4 +11,5 @@ import SwiftUI
 public extension EnvironmentValues {
 
     @Entry var loginContext = LoginContext(account: .init(id: "", userName: "", fcmToken: nil, cohabitantId: nil))
+
 }

--- a/LocalPackage/Sources/HometeUI/Components/Indicator/Indicator.swift
+++ b/LocalPackage/Sources/HometeUI/Components/Indicator/Indicator.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 public struct Indicator: View {
+
     public init() {}
 
     public var body: some View {
@@ -17,4 +18,5 @@ public struct Indicator: View {
             .background(.primary3)
             .cornerRadius(.radius8)
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/Components/Indicator/LoadingIndicator.swift
+++ b/LocalPackage/Sources/HometeUI/Components/Indicator/LoadingIndicator.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 struct LoadingIndicator: View {
+
     var body: some View {
         ZStack {
             Color.loadingBg
@@ -17,9 +18,11 @@ struct LoadingIndicator: View {
         }
         .ignoresSafeArea()
     }
+
 }
 
 public extension View {
+
     func fullScreenLoadingIndicator(_ loadingState: LoadingStateStore) -> some View {
         ZStack {
             self
@@ -28,6 +31,7 @@ public extension View {
             }
         }
     }
+
 }
 
 #Preview {

--- a/LocalPackage/Sources/HometeUI/Components/Indicator/LoadingState.swift
+++ b/LocalPackage/Sources/HometeUI/Components/Indicator/LoadingState.swift
@@ -10,42 +10,43 @@ import SwiftUI
 @MainActor
 @propertyWrapper
 public struct LoadingState: DynamicProperty {
+
     @State public var store: LoadingStateStore
 
     public init() {
-        self._store = State(initialValue: LoadingStateStore())
+        _store = State(initialValue: LoadingStateStore())
     }
 
     public init(store: LoadingStateStore) {
-        self._store = State(initialValue: store)
+        _store = State(initialValue: store)
     }
 
     public var wrappedValue: LoadingStateStore {
-        return store
+        store
     }
 
     public var projectedValue: Binding<LoadingStateStore> {
-        return $store
+        $store
     }
+
 }
 
 @MainActor
 @Observable
 public final class LoadingStateStore {
+
     public var isLoading: Bool
 
     public init(isLoading: Bool = false) {
-
         self.isLoading = isLoading
     }
 
     public func task(_ operation: @MainActor @escaping () async -> Void) {
-
         isLoading = true
         Task {
-
             await operation()
             isLoading = false
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/Components/Navigation/NavigationBarButton.swift
+++ b/LocalPackage/Sources/HometeUI/Components/Navigation/NavigationBarButton.swift
@@ -26,4 +26,5 @@ public struct NavigationBarButton: View {
                 .foregroundStyle(.onSurface)
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/Components/Navigation/NavigationBarContentLabel.swift
+++ b/LocalPackage/Sources/HometeUI/Components/Navigation/NavigationBarContentLabel.swift
@@ -15,11 +15,11 @@ public struct NavigationBarContentLabel: Sendable {
     public var icon: Image {
         if let assetIcon {
             Image(assetIcon)
-        }
-        else {
+        } else {
             Image(systemName: symbolName ?? "")
         }
     }
+
 }
 
 public extension NavigationBarContentLabel {
@@ -36,4 +36,5 @@ public extension NavigationBarContentLabel {
         symbolName: "trash",
         assetIcon: nil
     )
+
 }

--- a/LocalPackage/Sources/HometeUI/Components/Navigation/NavigationBarToolbarItemModifier.swift
+++ b/LocalPackage/Sources/HometeUI/Components/Navigation/NavigationBarToolbarItemModifier.swift
@@ -1,5 +1,5 @@
 //
-//  TrailingToolbarItem.swift
+//  NavigationBarToolbarItemModifier.swift
 //  homete
 //
 
@@ -8,7 +8,9 @@ import SwiftUI
 struct NavigationBarToolbarItemModifier<ToolbarContent: View>: ViewModifier {
 
     enum Position {
+
         case leading, trailing
+
     }
 
     let position: Position
@@ -16,28 +18,30 @@ struct NavigationBarToolbarItemModifier<ToolbarContent: View>: ViewModifier {
 
     func body(content: Content) -> some View {
         #if os(iOS)
-        content.toolbar {
-            ToolbarItem(placement: position == .leading ? .topBarLeading : .topBarTrailing) {
-                self.content()
+            content.toolbar {
+                ToolbarItem(placement: position == .leading ? .topBarLeading : .topBarTrailing) {
+                    self.content()
+                }
             }
-        }
         #else
-        content
+            content
         #endif
     }
+
 }
 
 public extension View {
 
-    func trailingToolbarItem<Content: View>(
-        @ViewBuilder content: @escaping () -> Content
+    func trailingToolbarItem(
+        @ViewBuilder content: @escaping () -> some View
     ) -> some View {
         modifier(NavigationBarToolbarItemModifier(position: .trailing, content: content))
     }
 
-    func leadingToolbarItem<Content: View>(
-        @ViewBuilder content: @escaping () -> Content
+    func leadingToolbarItem(
+        @ViewBuilder content: @escaping () -> some View
     ) -> some View {
         modifier(NavigationBarToolbarItemModifier(position: .leading, content: content))
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/Components/PointLabel.swift
+++ b/LocalPackage/Sources/HometeUI/Components/PointLabel.swift
@@ -5,8 +5,8 @@
 //  Created by 佐藤汰一 on 2025/11/11.
 //
 
-import SwiftUI
 import HometeResources
+import SwiftUI
 
 public struct PointLabel: View {
 
@@ -29,6 +29,7 @@ public struct PointLabel: View {
                 }
             }
     }
+
 }
 
 #Preview("PointLabel_1桁", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/ButtonStyleUtil.swift
+++ b/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/ButtonStyleUtil.swift
@@ -9,9 +9,9 @@ import SwiftUI
 
 @MainActor
 extension ButtonStyleConfiguration {
-    
+
     func commonStyle(_ foregroundColor: Color = .onSurface) -> some View {
-        self.label
+        label
             .font(with: .headLineS)
             .padding(.horizontal, .space16)
             .padding(.vertical, .space8)
@@ -19,4 +19,5 @@ extension ButtonStyleConfiguration {
                 foregroundColor.opacity(isPressed ? 0.3 : 1)
             )
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/DestructiveButtonStyle.swift
+++ b/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/DestructiveButtonStyle.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct DestructiveButtonStyle: ButtonStyle {
-    
+
     @Environment(\.isEnabled) var isEnabled
-    
+
     func makeBody(configuration: Configuration) -> some View {
         configuration
             .commonStyle(.onDestructive)
@@ -18,13 +18,15 @@ struct DestructiveButtonStyle: ButtonStyle {
             .cornerRadius(.radius16)
             .opacity(isEnabled ? 1 : 0.5)
     }
+
 }
 
 public extension View {
 
     func destructiveButtonStyle() -> some View {
-        self.buttonStyle(DestructiveButtonStyle())
+        buttonStyle(DestructiveButtonStyle())
     }
+
 }
 
 #Preview("DestructiveButtonStyle_Enabled", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/FloatingButtonStyle.swift
+++ b/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/FloatingButtonStyle.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct FloatingButtonStyle: ButtonStyle {
-    
+
     @Environment(\.isEnabled) var isEnabled
-    
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .padding(.space16)
@@ -24,18 +24,19 @@ struct FloatingButtonStyle: ButtonStyle {
             .opacity(configuration.isPressed || !isEnabled ? 0.5 : 1)
             .addGlassEffect(!isEnabled)
     }
+
 }
 
 private extension View {
-    
+
     func addGlassEffect(_ isDisable: Bool) -> some View {
         if #available(iOS 26.0, macOS 26.0, *) {
-            return self.glassEffect(.regular.interactive(!isDisable))
-        }
-        else {
+            return glassEffect(.regular.interactive(!isDisable))
+        } else {
             return self
         }
     }
+
 }
 
 public extension View {
@@ -43,8 +44,9 @@ public extension View {
     /// 宙に浮いたようなボタンのスタイル
     /// - Description: iOS26ではLiquid Glassの効果があるボタンになる
     func floatingButtonStyle() -> some View {
-        self.buttonStyle(FloatingButtonStyle())
+        buttonStyle(FloatingButtonStyle())
     }
+
 }
 
 #Preview("FloatingButtonStyle_テキストボタン", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/PrimaryButton.swift
+++ b/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/PrimaryButton.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct PrimaryButtonStyle: ButtonStyle {
-    
+
     @Environment(\.isEnabled) var isEnabled
-    
+
     func makeBody(configuration: Configuration) -> some View {
         configuration
             .commonStyle()
@@ -23,13 +23,15 @@ struct PrimaryButtonStyle: ButtonStyle {
             .opacity(isEnabled ? 1 : 0.5)
             .disabled(!isEnabled)
     }
+
 }
 
 public extension View {
 
     func primaryButtonStyle() -> some View {
-        self.buttonStyle(PrimaryButtonStyle())
+        buttonStyle(PrimaryButtonStyle())
     }
+
 }
 
 #Preview("PrimaryButtonStyle_Enabled", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/SubPrimaryButtonStyle.swift
+++ b/LocalPackage/Sources/HometeUI/DesignSystem/Buttons/SubPrimaryButtonStyle.swift
@@ -8,9 +8,9 @@
 import SwiftUI
 
 struct SubPrimaryButtonStyle: ButtonStyle {
-    
+
     @Environment(\.isEnabled) var isEnabled
-    
+
     func makeBody(configuration: Configuration) -> some View {
         configuration
             .commonStyle()
@@ -18,13 +18,15 @@ struct SubPrimaryButtonStyle: ButtonStyle {
             .cornerRadius(.radius16)
             .opacity(isEnabled ? 1 : 0.5)
     }
+
 }
 
 public extension View {
 
     func subPrimaryButtonStyle() -> some View {
-        self.buttonStyle(SubPrimaryButtonStyle())
+        buttonStyle(SubPrimaryButtonStyle())
     }
+
 }
 
 #Preview("SubPrimaryButtonStyle_Enabled", traits: .sizeThatFitsLayout) {

--- a/LocalPackage/Sources/HometeUI/DesignSystem/DesignSystem.swift
+++ b/LocalPackage/Sources/HometeUI/DesignSystem/DesignSystem.swift
@@ -22,6 +22,7 @@ public extension CGFloat {
     static let space48: CGFloat = 48
     static let space56: CGFloat = 56
     static let space64: CGFloat = 64
+
 }
 
 // MARK: Fontの定義
@@ -38,9 +39,7 @@ public extension DesignSystem {
         case boldCaption
 
         var value: SwiftUI.Font {
-
             switch self {
-
             case .headLineL: .title.weight(.heavy)
             case .headLineM: .title2.weight(.heavy)
             case .headLineS: .headline
@@ -49,15 +48,17 @@ public extension DesignSystem {
             case .boldCaption: .caption.bold()
             }
         }
+
     }
+
 }
 
 public extension View {
 
     func font(with font: DesignSystem.Font) -> some View {
-
-        return self.font(font.value)
+        self.font(font.value)
     }
+
 }
 
 // MARK: CornerRadiusの定義
@@ -68,20 +69,23 @@ public extension DesignSystem {
 
         case radius8 = 8
         case radius16 = 16
+
     }
+
 }
 
 public extension View {
 
     func cornerRadius(_ radius: DesignSystem.Corner) -> some View {
-        self.clipShape(RoundedRectangle(radius: radius))
+        clipShape(RoundedRectangle(radius: radius))
     }
+
 }
 
 public extension RoundedRectangle {
 
     init(radius: DesignSystem.Corner) {
-
         self.init(cornerRadius: radius.rawValue)
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/DesignSystem/Theme/Theme.swift
+++ b/LocalPackage/Sources/HometeUI/DesignSystem/Theme/Theme.swift
@@ -13,18 +13,19 @@ public struct Theme {
     public let segmentedControl: SegmentedControl
 
     public init(segmentedControl: SegmentedControl = .init()) {
-
         self.segmentedControl = segmentedControl
     }
+
 }
 
 public extension View {
 
     func apply(theme: Theme) -> some View {
-        self.onAppear {
+        onAppear {
             theme.applySegmentedControl()
         }
     }
+
 }
 
 // MARK: - セグメントボタンの定義
@@ -52,20 +53,21 @@ public extension Theme {
             self.selectedForegroundColor = selectedForegroundColor
             self.foregroundColor = foregroundColor
         }
+
     }
 
     func applySegmentedControl() {
-
         #if canImport(UIKit)
-        UISegmentedControl.appearance().setTitleTextAttributes(
-            [.foregroundColor: UIColor(Color.primary2)],
-            for: .normal
-        )
-        UISegmentedControl.appearance().setTitleTextAttributes(
-            [.foregroundColor: UIColor(Color.onSurface)],
-            for: .selected
-        )
-        UISegmentedControl.appearance().backgroundColor = UIColor(Color.primary3)
+            UISegmentedControl.appearance().setTitleTextAttributes(
+                [.foregroundColor: UIColor(Color.primary2)],
+                for: .normal
+            )
+            UISegmentedControl.appearance().setTitleTextAttributes(
+                [.foregroundColor: UIColor(Color.onSurface)],
+                for: .selected
+            )
+            UISegmentedControl.appearance().backgroundColor = UIColor(Color.primary3)
         #endif
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Alert/CommonError.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Alert/CommonError.swift
@@ -16,7 +16,7 @@ public struct CommonError: DynamicProperty {
 
     public var wrappedValue: DomainErrorAlertContent {
         get {
-            return _content
+            _content
         }
         nonmutating set {
             _content = newValue
@@ -24,6 +24,7 @@ public struct CommonError: DynamicProperty {
     }
 
     public var projectedValue: Binding<DomainErrorAlertContent> {
-        return $_content
+        $_content
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Alert/DomainErrorAlertContent.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Alert/DomainErrorAlertContent.swift
@@ -18,34 +18,35 @@ public struct DomainErrorAlertContent: Sendable {
         self.error = error
     }
 
-    public var hasError: Bool { error != nil }
+    public var hasError: Bool {
+        error != nil
+    }
 
     public var errorMessage: LocalizedStringKey? {
-
         switch error {
-
         case .failAuth:
-            return "認証に失敗しました。再度サインインをお試しください。"
+            "認証に失敗しました。再度サインインをお試しください。"
 
         case .noNetwork:
-            return "通信に失敗しました"
+            "通信に失敗しました"
 
         case .other:
-            return "不明のエラーが発生しました"
+            "不明のエラーが発生しました"
 
         default:
-            return nil
+            nil
         }
     }
 
     public static let initial = DomainErrorAlertContent(isPresenting: false, error: nil)
+
 }
 
 public extension DomainErrorAlertContent {
 
     init(error: any Error) {
-
         isPresenting = true
         self.error = .make(error)
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Alert/View+Extension.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Alert/View+Extension.swift
@@ -13,15 +13,18 @@ public extension View {
         content: Binding<DomainErrorAlertContent>,
         onDismiss: @escaping () -> Void = {}
     ) -> some View {
-        self
-            .alert("操作が完了しませんでした",
-                   isPresented: content.wrappedValue.hasError ? content.isPresenting : .constant(false),
-                   actions: {
+        alert(
+            "操作が完了しませんでした",
+            isPresented: content.wrappedValue.hasError ? content.isPresenting : .constant(false),
+            actions: {
                 Button("OK") {
                     onDismiss()
                 }
-            }, message: {
+            },
+            message: {
                 Text(content.wrappedValue.errorMessage ?? "")
-            })
+            }
+        )
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/AppStorage/AppStorageExtensions.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/AppStorage/AppStorageExtensions.swift
@@ -12,15 +12,16 @@ import SwiftUI
 public extension SwiftUI.AppStorage where Value == Data? {
 
     init(key: AppStorageOptionalDataKey) {
-
         self.init(key.rawValue)
     }
+
 }
 
 public enum AppStorageOptionalDataKey: String {
 
     /// アーカイブされたP2P通信での自身のID
     case archivedPeerIDDataKey
+
 }
 
 // MARK: - カスタムオブジェクト用の拡張
@@ -28,24 +29,25 @@ public enum AppStorageOptionalDataKey: String {
 public extension SwiftUI.AppStorage where Value: RawRepresentable, Value.RawValue == String {
 
     init(wrappedValue: Value, key: AppStorageCustomTypeKey) {
-
         self.init(wrappedValue: wrappedValue, key.rawValue)
     }
+
 }
 
 public enum AppStorageCustomTypeKey: String {
 
     /// 家事入力の履歴
     case houseworkEntryHistoryList
+
 }
 
 // MARK: - Preview用のDIヘルパー
 
 public struct InjectAppStorageWithPreviewModifier: ViewModifier {
+
     private let userDefaults: UserDefaults
 
     public init(_ suiteName: String, _ registerHandler: @escaping (UserDefaults) -> Void) {
-
         // swiftlint:disable:next force_unwrapping
         userDefaults = UserDefaults(suiteName: suiteName)!
         userDefaults.removePersistentDomain(forName: suiteName)
@@ -56,6 +58,7 @@ public struct InjectAppStorageWithPreviewModifier: ViewModifier {
         content
             .defaultAppStorage(userDefaults)
     }
+
 }
 
 public extension View {
@@ -64,6 +67,7 @@ public extension View {
         _ suiteName: String,
         registerHandler: @escaping (UserDefaults) -> Void = { _ in }
     ) -> some View {
-        self.modifier(InjectAppStorageWithPreviewModifier(suiteName, registerHandler))
+        modifier(InjectAppStorageWithPreviewModifier(suiteName, registerHandler))
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Constants.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Constants.swift
@@ -6,5 +6,7 @@
 //
 
 public enum Constants {
+
     public static let appName = "homete"
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/DependenciesInjectLayer.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/DependenciesInjectLayer.swift
@@ -11,11 +11,11 @@ public struct DependenciesInjectLayer<Content: View>: View {
     let content: (AppDependencies) -> Content
 
     public init(@ViewBuilder content: @escaping (AppDependencies) -> Content) {
-
         self.content = content
     }
 
     public var body: some View {
         content(appDependencies)
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Modifiers/AutomaticToolbarVisibilityModifier.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Modifiers/AutomaticToolbarVisibilityModifier.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct AutomaticToolbarVisibilityModifier: ViewModifier {
-    
+
     let visibility: Visibility
     let position: ToolbarPlacement
-    
+
     func body(content: Content) -> some View {
         if #available(iOS 18.0, *) {
             content
@@ -20,6 +20,7 @@ struct AutomaticToolbarVisibilityModifier: ViewModifier {
             content.toolbar(visibility, for: position)
         }
     }
+
 }
 
 public extension View {
@@ -28,9 +29,11 @@ public extension View {
         visibility: Visibility,
         for position: ToolbarPlacement
     ) -> some View {
-        self.modifier(AutomaticToolbarVisibilityModifier(
+        modifier(AutomaticToolbarVisibilityModifier(
             visibility: visibility,
-            position: position)
+            position: position
+        )
         )
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Modifiers/FullScreenCoverOnIOS.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Modifiers/FullScreenCoverOnIOS.swift
@@ -7,15 +7,16 @@ import SwiftUI
 
 public extension View {
 
-    func fullScreenCoverOnIOS<Content: View>(
+    func fullScreenCoverOnIOS(
         isPresented: Binding<Bool>,
         onDismiss: (() -> Void)? = nil,
-        @ViewBuilder content: @escaping () -> Content
+        @ViewBuilder content: @escaping () -> some View
     ) -> some View {
         #if os(iOS)
-        self.fullScreenCover(isPresented: isPresented, onDismiss: onDismiss, content: content)
+            fullScreenCover(isPresented: isPresented, onDismiss: onDismiss, content: content)
         #else
-        self
+            self
         #endif
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Modifiers/HideNavigationBarModifier.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Modifiers/HideNavigationBarModifier.swift
@@ -9,9 +9,10 @@ public extension View {
 
     func hideNavigationBar() -> some View {
         #if os(iOS)
-        self.automaticToolbarVisibility(visibility: .hidden, for: .navigationBar)
+            automaticToolbarVisibility(visibility: .hidden, for: .navigationBar)
         #else
-        self
+            self
         #endif
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Modifiers/InlineNavigationBarTitleDisplayMode.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Modifiers/InlineNavigationBarTitleDisplayMode.swift
@@ -9,9 +9,10 @@ public extension View {
 
     func inlineNavigationBarTitleDisplayMode() -> some View {
         #if os(iOS)
-        self.navigationBarTitleDisplayMode(.inline)
+            navigationBarTitleDisplayMode(.inline)
         #else
-        self
+            self
         #endif
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Navigation/AppNavigationPath.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Navigation/AppNavigationPath.swift
@@ -17,17 +17,15 @@ public final class AppNavigationPath<Route: Hashable> {
     }
 
     public func popToRoot() {
-
         path.removeAll()
     }
 
     public func pop() {
-
         _ = path.popLast()
     }
 
     public func push(_ route: Route) {
-
         path.append(route)
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/Navigation/RouteResolver.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/Navigation/RouteResolver.swift
@@ -10,8 +10,8 @@ public struct RouteResolver: Sendable {
 
     private var _resolve: @MainActor @Sendable (AppRoute) -> AnyView
 
-    public init<V: View>(
-        @ViewBuilder resolve: @escaping @MainActor @Sendable (AppRoute) -> V
+    public init(
+        @ViewBuilder resolve: @escaping @MainActor @Sendable (AppRoute) -> some View
     ) {
         _resolve = { AnyView(resolve($0)) }
     }
@@ -20,14 +20,19 @@ public struct RouteResolver: Sendable {
     public func resolve(_ route: AppRoute) -> some View {
         _resolve(route)
     }
+
 }
 
 public extension EnvironmentValues {
+
     @Entry var routeResolver: RouteResolver = .preview
+
 }
 
 public extension RouteResolver {
+
     static let preview = RouteResolver { route in
         Text("Preview: \(String(describing: route))")
     }
+
 }

--- a/LocalPackage/Sources/HometeUI/ViewUtilities/PrefireViewModifiers.swift
+++ b/LocalPackage/Sources/HometeUI/ViewUtilities/PrefireViewModifiers.swift
@@ -8,25 +8,29 @@
 import SwiftUI
 
 #if canImport(Prefire)
-import Prefire
+    import Prefire
 
-public extension View {
-    func snapshotForPreview(
-        delay: Double = .zero,
-        precision: Float = 1.0,
-        perceptualPrecision: Float = 1.0
-    ) -> some View {
-        snapshot(delay: delay, precision: precision, perceptualPrecision: perceptualPrecision)
+    public extension View {
+
+        func snapshotForPreview(
+            delay: Double = .zero,
+            precision: Float = 1.0,
+            perceptualPrecision: Float = 1.0
+        ) -> some View {
+            snapshot(delay: delay, precision: precision, perceptualPrecision: perceptualPrecision)
+        }
+
     }
-}
 #else
-public extension View {
-    func snapshotForPreview(
-        delay: Double = .zero,
-        precision: Float = 1.0,
-        perceptualPrecision: Float = 1.0
-    ) -> some View {
-        self
+    public extension View {
+
+        func snapshotForPreview(
+            delay _: Double = .zero,
+            precision _: Float = 1.0,
+            perceptualPrecision _: Float = 1.0
+        ) -> some View {
+            self
+        }
+
     }
-}
 #endif

--- a/LocalPackage/Tests/ContributionFeatureTests/AllUserCumulativeDataTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/AllUserCumulativeDataTest.swift
@@ -5,18 +5,20 @@
 //  Created by Taichi Sato on 2026/05/07.
 //
 
+@testable import ContributionFeature
 import Foundation
 import Testing
-@testable import ContributionFeature
 
 // swiftlint:disable:next convenience_type
-struct AllUserCumulativeDataTest {
+enum AllUserCumulativeDataTest {
+
     struct MakeCase {}
     struct CumulativePointEntriesCase {}
+
 }
 
 extension AllUserCumulativeDataTest.MakeCase {
-    
+
     static let april20 = Date.previewDate(year: 2026, month: 4, day: 20)
     static let april21 = Date.previewDate(year: 2026, month: 4, day: 21)
     static let april22 = Date.previewDate(year: 2026, month: 4, day: 22)
@@ -24,17 +26,16 @@ extension AllUserCumulativeDataTest.MakeCase {
     static let april24 = Date.previewDate(year: 2026, month: 4, day: 24)
     static let april25 = Date.previewDate(year: 2026, month: 4, day: 25)
     static let april26 = Date.previewDate(year: 2026, month: 4, day: 26)
-    
+
     static let userId1 = "u1"
     static let userName1 = "田中"
     static let userId2 = "u2"
     static let userName2 = "鈴木"
 
     @Test("単一ユーザーの累計ポイントが日付順に正しく計算される")
-    func make_calcsCumulativePoints_forSingleUser() throws {
-
+    func make_calcsCumulativePoints_forSingleUser() {
         // Arrange
-        let weekDates: [Date] = (20...26).map {
+        let weekDates: [Date] = (20 ... 26).map {
             Date.previewDate(year: 2026, month: 4, day: $0)
         }
         let viewableList: [ViewablePointList] = [
@@ -43,14 +44,14 @@ extension AllUserCumulativeDataTest.MakeCase {
                     by: [
                         Self.april20: .init(indexedDay: Self.april20, point: .init(value: 10)),
                         Self.april22: .init(indexedDay: Self.april22, point: .init(value: 30)),
-                        Self.april25: .init(indexedDay: Self.april25, point: .init(value: 20))
+                        Self.april25: .init(indexedDay: Self.april25, point: .init(value: 20)),
                     ],
                     userId: Self.userId1,
                     userName: Self.userName1,
                     dates: weekDates,
                     calendar: .japanese
                 )
-                .generate()
+                .generate(),
         ]
 
         // Act
@@ -73,9 +74,9 @@ extension AllUserCumulativeDataTest.MakeCase {
                         .init(point: .init(value: 40), date: Self.april23),
                         .init(point: .init(value: 40), date: Self.april24),
                         .init(point: .init(value: 60), date: Self.april25),
-                        .init(point: .init(value: 60), date: Self.april26)
+                        .init(point: .init(value: 60), date: Self.april26),
                     ]
-                )
+                ),
             ],
             displayPeriod: .week
         )
@@ -84,10 +85,9 @@ extension AllUserCumulativeDataTest.MakeCase {
 
     @Test("複数ユーザーの場合、ユーザーごとに独立して累計計算される")
     // swiftlint:disable:next function_body_length
-    func make_calcsCumulativePoints_perUserIndependently() throws {
-
+    func make_calcsCumulativePoints_perUserIndependently() {
         // Arrange
-        let weekDates: [Date] = (20...26).map {
+        let weekDates: [Date] = (20 ... 26).map {
             Date.previewDate(year: 2026, month: 4, day: $0)
         }
         let viewableList: [ViewablePointList] = [
@@ -95,7 +95,7 @@ extension AllUserCumulativeDataTest.MakeCase {
                 .make(
                     by: [
                         Self.april20: .init(indexedDay: Self.april20, point: .init(value: 10)),
-                        Self.april22: .init(indexedDay: Self.april22, point: .init(value: 30))
+                        Self.april22: .init(indexedDay: Self.april22, point: .init(value: 30)),
                     ],
                     userId: Self.userId1,
                     userName: Self.userName1,
@@ -107,14 +107,14 @@ extension AllUserCumulativeDataTest.MakeCase {
                 .make(
                     by: [
                         Self.april21: .init(indexedDay: Self.april21, point: .init(value: 5)),
-                        Self.april22: .init(indexedDay: Self.april22, point: .init(value: 15))
+                        Self.april22: .init(indexedDay: Self.april22, point: .init(value: 15)),
                     ],
                     userId: Self.userId2,
                     userName: Self.userName2,
                     dates: weekDates,
                     calendar: .japanese
                 )
-                .generate()
+                .generate(),
         ]
 
         // Act
@@ -137,7 +137,7 @@ extension AllUserCumulativeDataTest.MakeCase {
                         .init(point: .init(value: 40), date: Self.april23),
                         .init(point: .init(value: 40), date: Self.april24),
                         .init(point: .init(value: 40), date: Self.april25),
-                        .init(point: .init(value: 40), date: Self.april26)
+                        .init(point: .init(value: 40), date: Self.april26),
                     ]
                 ),
                 .init(
@@ -151,14 +151,15 @@ extension AllUserCumulativeDataTest.MakeCase {
                         .init(point: .init(value: 20), date: Self.april23),
                         .init(point: .init(value: 20), date: Self.april24),
                         .init(point: .init(value: 20), date: Self.april25),
-                        .init(point: .init(value: 20), date: Self.april26)
+                        .init(point: .init(value: 20), date: Self.april26),
                     ]
-                )
+                ),
             ],
             displayPeriod: .week
         )
         #expect(result == expected)
     }
+
 }
 
 extension AllUserCumulativeDataTest.CumulativePointEntriesCase {
@@ -175,10 +176,9 @@ extension AllUserCumulativeDataTest.CumulativePointEntriesCase {
     static let userName1 = "田中"
 
     @Test("指定した日付に一致する累計エントリが返される（日粒度）")
-    func cumulativePointEntries_returnsMatchingEntries_forDayGranularity() throws {
-
+    func cumulativePointEntries_returnsMatchingEntries_forDayGranularity() {
         // Arrange
-        let weekDates: [Date] = (20...26).map {
+        let weekDates: [Date] = (20 ... 26).map {
             Date.previewDate(year: 2026, month: 4, day: $0)
         }
         let viewableList: [ViewablePointList] = [
@@ -186,14 +186,14 @@ extension AllUserCumulativeDataTest.CumulativePointEntriesCase {
                 .make(
                     by: [
                         Self.april20: .init(indexedDay: Self.april20, point: .init(value: 10)),
-                        Self.april22: .init(indexedDay: Self.april22, point: .init(value: 30))
+                        Self.april22: .init(indexedDay: Self.april22, point: .init(value: 30)),
                     ],
                     userId: Self.userId1,
                     userName: Self.userName1,
                     dates: weekDates,
                     calendar: .japanese
                 )
-                .generate()
+                .generate(),
         ]
         let sut = AllUserCumulativeData.make(
             list: viewableList,
@@ -205,16 +205,15 @@ extension AllUserCumulativeDataTest.CumulativePointEntriesCase {
 
         // Assert
         let expected: [PointEntry] = [
-            .init(id: Self.userId1, userName: Self.userName1, point: 40)
+            .init(id: Self.userId1, userName: Self.userName1, point: 40),
         ]
         #expect(entries == expected)
     }
 
     @Test("データがない日付を指定した場合は補完値（直前までの累計）が返される")
-    func cumulativePointEntries_returnsCarriedOverValue_whenNoDataForDate() throws {
-
+    func cumulativePointEntries_returnsCarriedOverValue_whenNoDataForDate() {
         // Arrange: april20 のみデータがある状態で、補完日(april23)を問い合わせる
-        let weekDates: [Date] = (20...26).map {
+        let weekDates: [Date] = (20 ... 26).map {
             Date.previewDate(year: 2026, month: 4, day: $0)
         }
         let viewableList: [ViewablePointList] = [
@@ -226,7 +225,7 @@ extension AllUserCumulativeDataTest.CumulativePointEntriesCase {
                     dates: weekDates,
                     calendar: .japanese
                 )
-                .generate()
+                .generate(),
         ]
         let sut = AllUserCumulativeData.make(
             list: viewableList,
@@ -238,16 +237,15 @@ extension AllUserCumulativeDataTest.CumulativePointEntriesCase {
 
         // Assert: 補完日も累計エントリとして返り、値は直前までの累計（10）が引き継がれる
         let expected: [PointEntry] = [
-            .init(id: Self.userId1, userName: Self.userName1, point: 10)
+            .init(id: Self.userId1, userName: Self.userName1, point: 10),
         ]
         #expect(entries == expected)
     }
 
     @Test("年間データの場合は月粒度でフィルタリングされる")
-    func cumulativePointEntries_filtersWithMonthGranularity_forYearPeriod() throws {
-
+    func cumulativePointEntries_filtersWithMonthGranularity_forYearPeriod() {
         // Arrange
-        let yearDates: [Date] = (1...12).map {
+        let yearDates: [Date] = (1 ... 12).map {
             Date.previewDate(year: 2026, month: $0, day: 1)
         }
         let viewableList: [ViewablePointList] = [
@@ -255,14 +253,14 @@ extension AllUserCumulativeDataTest.CumulativePointEntriesCase {
                 .make(
                     by: [
                         Self.jan1: .init(indexedDay: Self.jan1, point: .init(value: 20)),
-                        Self.mar15: .init(indexedDay: Self.mar15, point: .init(value: 30))
+                        Self.mar15: .init(indexedDay: Self.mar15, point: .init(value: 30)),
                     ],
                     userId: Self.userId1,
                     userName: Self.userName1,
                     dates: yearDates,
                     calendar: .japanese
                 )
-                .generate()
+                .generate(),
         ]
         let sut = AllUserCumulativeData.make(
             list: viewableList,
@@ -274,8 +272,9 @@ extension AllUserCumulativeDataTest.CumulativePointEntriesCase {
 
         // Assert
         let expected: [PointEntry] = [
-            .init(id: Self.userId1, userName: Self.userName1, point: 50)
+            .init(id: Self.userId1, userName: Self.userName1, point: 50),
         ]
         #expect(entries == expected)
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/AllUserPointSummaryTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/AllUserPointSummaryTest.swift
@@ -5,13 +5,15 @@
 //  Created by Taichi Sato on 2026/04/29.
 //
 
-import Testing
-import HometeDomain
 @testable import ContributionFeature
+import HometeDomain
+import Testing
 
 // swiftlint:disable:next convenience_type
-struct AllUserPointSummaryTest {
+enum AllUserPointSummaryTest {
+
     struct MakeRankingCase {}
+
 }
 
 extension AllUserPointSummaryTest.MakeRankingCase {
@@ -19,7 +21,6 @@ extension AllUserPointSummaryTest.MakeRankingCase {
     @Test("ポイント降順でランク付けされ、自分のユーザーIDと一致するアイテムは自分自身のアイテムであるフラグが立つ")
     // swiftlint:disable:next function_body_length
     func makeRanking_assignsRanksInDescendingPointOrder() {
-
         // Arrange
         let summary = AllUserPointSummary(items: [
             UserPointSummary(
@@ -42,7 +43,7 @@ extension AllUserPointSummaryTest.MakeRankingCase {
                 isMe: false,
                 monthlyPoint: .init(value: 80),
                 achievedCount: 3
-            )
+            ),
         ])
 
         // Act
@@ -73,14 +74,13 @@ extension AllUserPointSummaryTest.MakeRankingCase {
                 isMe: true,
                 monthlyPoint: .init(value: 40),
                 achievedCount: 2
-            )
+            ),
         ]
         #expect(result == expected)
     }
 
     @Test("アイテムが空の場合はランキングも空になる")
     func makeRanking_returnsEmptyRanking_whenNoItems() {
-
         // Arrange
         let summary = AllUserPointSummary()
 
@@ -90,4 +90,5 @@ extension AllUserPointSummaryTest.MakeRankingCase {
         // Assert
         #expect(result == [])
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/AllUserViewablePointListTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/AllUserViewablePointListTest.swift
@@ -5,22 +5,25 @@
 //  Created by Taichi Sato on 2026/05/01.
 //
 
+@testable import ContributionFeature
 import Foundation
 import Testing
-@testable import ContributionFeature
 
 // swiftlint:disable:next convenience_type
-struct AllUserViewablePointListTest {
+enum AllUserViewablePointListTest {
+
     struct NearestDateCase {
+
         private let calendar = Calendar.japanese
+
     }
+
 }
 
 extension AllUserViewablePointListTest.NearestDateCase {
 
     @Test("タップ日付に最も近いデータの日付が返る")
-    func nearestDate_returnsClosestDataDate() throws {
-
+    func nearestDate_returnsClosestDataDate() {
         // Arrange
         let april20 = Date.previewDate(year: 2026, month: 4, day: 20)
         let april23 = Date.previewDate(year: 2026, month: 4, day: 23)
@@ -33,7 +36,7 @@ extension AllUserViewablePointListTest.NearestDateCase {
                     total: .init(value: 0),
                     elements: [
                         .init(point: .init(value: 10), date: april20),
-                        .init(point: .init(value: 20), date: april26)
+                        .init(point: .init(value: 20), date: april26),
                     ]
                 ),
                 .init(
@@ -41,9 +44,9 @@ extension AllUserViewablePointListTest.NearestDateCase {
                     userName: "ユーザー2",
                     total: .init(value: 0),
                     elements: [
-                        .init(point: .init(value: 5), date: april23)
+                        .init(point: .init(value: 5), date: april23),
                     ]
-                )
+                ),
             ],
             displayPeriod: .week
         )
@@ -57,8 +60,7 @@ extension AllUserViewablePointListTest.NearestDateCase {
     }
 
     @Test("複数ユーザー間でも全データから最も近い日付が返る")
-    func nearestDate_picksAcrossUsers() throws {
-
+    func nearestDate_picksAcrossUsers() {
         // Arrange
         let april20 = Date.previewDate(year: 2026, month: 4, day: 20)
         let april25 = Date.previewDate(year: 2026, month: 4, day: 25)
@@ -75,7 +77,7 @@ extension AllUserViewablePointListTest.NearestDateCase {
                     userName: "ユーザー2",
                     total: .init(value: 0),
                     elements: [.init(point: .init(value: 5), date: april25)]
-                )
+                ),
             ],
             displayPeriod: .week
         )
@@ -89,12 +91,11 @@ extension AllUserViewablePointListTest.NearestDateCase {
     }
 
     @Test("データが空の場合はnilが返る")
-    func nearestDate_returnsNilWhenNoData() throws {
-
+    func nearestDate_returnsNilWhenNoData() {
         // Arrange
         let sut = AllUserViewablePointList(
             list: [
-                .init(userId: "u1", userName: "ユーザー1", total: .init(value: 0), elements: [])
+                .init(userId: "u1", userName: "ユーザー1", total: .init(value: 0), elements: []),
             ],
             displayPeriod: .week
         )
@@ -106,4 +107,5 @@ extension AllUserViewablePointListTest.NearestDateCase {
         // Assert
         #expect(result == nil)
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/ContributionAnalyticsRankingTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/ContributionAnalyticsRankingTest.swift
@@ -5,22 +5,21 @@
 //  Created by Taichi Sato on 2026/05/08.
 //
 
-import Foundation
-import Testing
-import HometeDomain
 @testable import ContributionFeature
+import Foundation
+import HometeDomain
+import Testing
 
 extension ContributionAnalyticsTest.RankingCase {
 
     @Test("displayPeriod.type=.weekで作ったanalyticsを、anchor固定でmonthへ切り替えるとmonth期間のランキングが返る")
-    func ranking_afterTypeSwitchKeepingAnchor_usesNewPeriodPointList() async throws {
-
+    func ranking_afterTypeSwitchKeepingAnchor_usesNewPeriodPointList() async {
         // Arrange: 月間範囲には含まれるが週間範囲には含まれない日付にデータを置く
         let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
         let dateOutsideWeek = Date.previewDate(year: 2026, month: 4, day: 10)
         let contribution = HouseworkContribution.makeForTest(
             list: [
-                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))]
+                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))],
             ],
             calendar: calendar
         )
@@ -60,14 +59,13 @@ extension ContributionAnalyticsTest.RankingCase {
                 isMe: true,
                 totalValue: 50,
                 averageValue: 50.0 / Double(monthDayCount)
-            )
+            ),
         ]
         #expect(result == expected)
     }
 
     @Test("criterion=.point の場合はtotalポイント降順でランキングが返る")
-    func ranking_byPoint_returnsDescendingOrder() throws {
-
+    func ranking_byPoint_returnsDescendingOrder() {
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 26)
         let weekStart = Date.previewDate(year: 2026, month: 4, day: 20)
@@ -88,7 +86,7 @@ extension ContributionAnalyticsTest.RankingCase {
                 totalAchievementCount: 14,
                 elements: [],
                 startDate: weekStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: weekList,
@@ -117,14 +115,13 @@ extension ContributionAnalyticsTest.RankingCase {
                 isMe: true,
                 totalValue: 14,
                 averageValue: 2.0
-            )
+            ),
         ]
         #expect(result == expected)
     }
 
     @Test("criterion=.achievement の場合は達成数降順でランキングが返る")
-    func ranking_byAchievement_returnsDescendingOrder() throws {
-
+    func ranking_byAchievement_returnsDescendingOrder() {
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 26)
         let weekStart = Date.previewDate(year: 2026, month: 4, day: 20)
@@ -145,7 +142,7 @@ extension ContributionAnalyticsTest.RankingCase {
                 totalAchievementCount: 7,
                 elements: [],
                 startDate: weekStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: weekList,
@@ -174,14 +171,13 @@ extension ContributionAnalyticsTest.RankingCase {
                 isMe: false,
                 totalValue: 7,
                 averageValue: 1.0
-            )
+            ),
         ]
         #expect(result == expected)
     }
 
     @Test("週表示の平均値はトータル / 7日 で算出される")
-    func ranking_weekPeriod_dividesByDays() throws {
-
+    func ranking_weekPeriod_dividesByDays() {
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 26)
         let weekStart = Date.previewDate(year: 2026, month: 4, day: 20)
@@ -194,7 +190,7 @@ extension ContributionAnalyticsTest.RankingCase {
                 totalAchievementCount: 14,
                 elements: [],
                 startDate: weekStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: weekList,
@@ -215,14 +211,13 @@ extension ContributionAnalyticsTest.RankingCase {
                 isMe: true,
                 totalValue: 70,
                 averageValue: 10.0
-            )
+            ),
         ]
         #expect(result == expected)
     }
 
     @Test("年表示の平均値はトータル / 12ヶ月 で算出される")
-    func ranking_yearPeriod_dividesByMonths() throws {
-
+    func ranking_yearPeriod_dividesByMonths() {
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 12, day: 31)
         let period = DisplayPointPeriod(type: .year, anchor: anchor)
@@ -233,7 +228,7 @@ extension ContributionAnalyticsTest.RankingCase {
                 total: .init(value: 240),
                 totalAchievementCount: 24,
                 elements: []
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: [],
@@ -254,14 +249,13 @@ extension ContributionAnalyticsTest.RankingCase {
                 isMe: true,
                 totalValue: 240,
                 averageValue: 20.0
-            )
+            ),
         ]
         #expect(result == expected)
     }
 
     @Test("myUserIdに合致したユーザーのisMeがtrueになる")
-    func ranking_marksMyUser_isMeTrue() throws {
-
+    func ranking_marksMyUser_isMeTrue() {
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 26)
         let weekStart = Date.previewDate(year: 2026, month: 4, day: 20)
@@ -282,7 +276,7 @@ extension ContributionAnalyticsTest.RankingCase {
                 totalAchievementCount: 0,
                 elements: [],
                 startDate: weekStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: weekList,
@@ -311,8 +305,9 @@ extension ContributionAnalyticsTest.RankingCase {
                 isMe: false,
                 totalValue: 14,
                 averageValue: 2.0
-            )
+            ),
         ]
         #expect(result == expected)
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/ContributionAnalyticsTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/ContributionAnalyticsTest.swift
@@ -7,26 +7,40 @@
 
 // swiftlint:disable file_length
 
-import Foundation
-import Testing
-import HometeDomain
 @testable import ContributionFeature
+import Foundation
+import HometeDomain
+import Testing
 
 // swiftlint:disable:next convenience_type
-struct ContributionAnalyticsTest {
+enum ContributionAnalyticsTest {
+
     struct MakeCase {
+
         let calendar = Calendar.japanese
+
     }
+
     struct UpdatePeriodCase {
+
         private let calendar = Calendar.japanese
+
     }
+
     struct CurrentListCase {
+
         private let calendar = Calendar.japanese
+
     }
+
     struct RankingCase {
+
         let calendar = Calendar.japanese
+
     }
+
     struct IsEmptyCase {}
+
 }
 
 // MARK: - make
@@ -34,14 +48,13 @@ struct ContributionAnalyticsTest {
 extension ContributionAnalyticsTest.MakeCase {
 
     @Test("displayPeriod.type=.monthで作ったanalyticsでも、week期間に切り替えると週間範囲のデータのみが集計される")
-    func make_typeMonth_thenSwitchToWeek_usesWeekDates() async throws {
-
+    func make_typeMonth_thenSwitchToWeek_usesWeekDates() async {
         // Arrange: 月間範囲には含まれるが週間範囲には含まれない日付にデータを置く
         let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
         let dateOutsideWeek = Date.previewDate(year: 2026, month: 4, day: 10)
         let contribution = HouseworkContribution.makeForTest(
             list: [
-                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))]
+                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))],
             ],
             calendar: calendar
         )
@@ -68,20 +81,19 @@ extension ContributionAnalyticsTest.MakeCase {
 
         // Assert: 週間範囲には04-10が含まれないので達成数0
         let expected: [UserHouseworkAchieved] = [
-            .init(userId: "u1", userName: "ユーザー1", achievedCount: 0)
+            .init(userId: "u1", userName: "ユーザー1", achievedCount: 0),
         ]
         #expect(result.achieved() == expected)
     }
 
     @Test("displayPeriod.type=.weekで作ったanalyticsでも、month期間に切り替えると月間範囲のデータが集計される")
-    func make_typeWeek_thenSwitchToMonth_usesMonthDates() async throws {
-
+    func make_typeWeek_thenSwitchToMonth_usesMonthDates() async {
         // Arrange: 月間範囲には含まれるが週間範囲には含まれない日付にデータを置く
         let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
         let dateOutsideWeek = Date.previewDate(year: 2026, month: 4, day: 10)
         let contribution = HouseworkContribution.makeForTest(
             list: [
-                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))]
+                "u1": [.init(indexedDay: dateOutsideWeek, point: .init(value: 50))],
             ],
             calendar: calendar
         )
@@ -108,20 +120,19 @@ extension ContributionAnalyticsTest.MakeCase {
 
         // Assert: 月間範囲には04-10が含まれるので達成数1
         let expected: [UserHouseworkAchieved] = [
-            .init(userId: "u1", userName: "ユーザー1", achievedCount: 1)
+            .init(userId: "u1", userName: "ユーザー1", achievedCount: 1),
         ]
         #expect(result.achieved() == expected)
     }
 
     @Test("displayPeriod.type=.monthで作ったanalyticsでも、year期間に切り替えると年間範囲のデータが集計される")
-    func make_typeMonth_thenSwitchToYear_usesYearDates() async throws {
-
+    func make_typeMonth_thenSwitchToYear_usesYearDates() async {
         // Arrange: 年間範囲には含まれるが月間範囲には含まれない日付にデータを置く
         let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
         let dateOutsideMonth = Date.previewDate(year: 2025, month: 8, day: 15)
         let contribution = HouseworkContribution.makeForTest(
             list: [
-                "u1": [.init(indexedDay: dateOutsideMonth, point: .init(value: 50))]
+                "u1": [.init(indexedDay: dateOutsideMonth, point: .init(value: 50))],
             ],
             calendar: calendar
         )
@@ -148,10 +159,11 @@ extension ContributionAnalyticsTest.MakeCase {
 
         // Assert: 年間範囲には2025-08-15が含まれるので達成数1
         let expected: [UserHouseworkAchieved] = [
-            .init(userId: "u1", userName: "ユーザー1", achievedCount: 1)
+            .init(userId: "u1", userName: "ユーザー1", achievedCount: 1),
         ]
         #expect(result.achieved() == expected)
     }
+
 }
 
 // MARK: - updatePeriod
@@ -159,8 +171,7 @@ extension ContributionAnalyticsTest.MakeCase {
 extension ContributionAnalyticsTest.UpdatePeriodCase {
 
     @Test("anchorが同じ場合はpointListを再計算せずdisplayPeriodだけ更新される")
-    func updatePeriod_sameAnchor_keepsExistingPointLists() async throws {
-
+    func updatePeriod_sameAnchor_keepsExistingPointLists() async {
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 26)
         let weekPeriod = DisplayPointPeriod(type: .week, anchor: anchor)
@@ -175,14 +186,21 @@ extension ContributionAnalyticsTest.UpdatePeriodCase {
                 totalAchievementCount: 0,
                 elements: [],
                 startDate: weekStart
-            )
+            ),
         ]
         let existingMonthList: [PointOfMonth] = [
             // swiftlint:disable:next line_length
-            .init(userId: "u1", userName: "ユーザー1", total: .init(value: 200), totalAchievementCount: 0, elements: [], startDate: weekStart)
+            .init(
+                userId: "u1",
+                userName: "ユーザー1",
+                total: .init(value: 200),
+                totalAchievementCount: 0,
+                elements: [],
+                startDate: weekStart
+            ),
         ]
         let existingYearList: [PointOfYear] = [
-            .init(userId: "u1", userName: "ユーザー1", total: .init(value: 300), totalAchievementCount: 0, elements: [])
+            .init(userId: "u1", userName: "ユーザー1", total: .init(value: 300), totalAchievementCount: 0, elements: []),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: existingWeekList,
@@ -212,8 +230,7 @@ extension ContributionAnalyticsTest.UpdatePeriodCase {
     }
 
     @Test("anchorが異なる場合はpointListが再計算される")
-    func updatePeriod_differentAnchor_recalculatesPointLists() async throws {
-
+    func updatePeriod_differentAnchor_recalculatesPointLists() async {
         // Arrange
         let oldAnchor = Date.previewDate(year: 2026, month: 4, day: 26)
         let newAnchor = Date.previewDate(year: 2026, month: 5, day: 3)
@@ -229,7 +246,7 @@ extension ContributionAnalyticsTest.UpdatePeriodCase {
                 totalAchievementCount: 0,
                 elements: [],
                 startDate: oldStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: sentinelList,
@@ -258,6 +275,7 @@ extension ContributionAnalyticsTest.UpdatePeriodCase {
         )
         #expect(result == expected)
     }
+
 }
 
 // MARK: - currentList
@@ -265,12 +283,11 @@ extension ContributionAnalyticsTest.UpdatePeriodCase {
 extension ContributionAnalyticsTest.CurrentListCase {
 
     @Test("week表示のときweekPointListに基づくAllUserViewablePointListが返る")
-    func currentList_weekPeriod_returnsWeekBasedList() throws {
-
+    func currentList_weekPeriod_returnsWeekBasedList() {
         // Arrange
-        let anchor   = Date.previewDate(year: 2026, month: 4, day: 26)
+        let anchor = Date.previewDate(year: 2026, month: 4, day: 26)
         let weekStart = Date.previewDate(year: 2026, month: 4, day: 20)
-        let period   = DisplayPointPeriod(type: .week, anchor: anchor)
+        let period = DisplayPointPeriod(type: .week, anchor: anchor)
         let weekList: [PointOfWeek] = [
             .init(
                 userId: "u1",
@@ -279,7 +296,7 @@ extension ContributionAnalyticsTest.CurrentListCase {
                 totalAchievementCount: 0,
                 elements: [],
                 startDate: weekStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: weekList,
@@ -300,12 +317,11 @@ extension ContributionAnalyticsTest.CurrentListCase {
     }
 
     @Test("month表示のときmonthPointListに基づくAllUserViewablePointListが返る")
-    func currentList_monthPeriod_returnsMonthBasedList() throws {
-
+    func currentList_monthPeriod_returnsMonthBasedList() {
         // Arrange
-        let anchor      = Date.previewDate(year: 2026, month: 4, day: 30)
-        let monthStart  = Date.previewDate(year: 2026, month: 3, day: 31)
-        let period      = DisplayPointPeriod(type: .month, anchor: anchor)
+        let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
+        let monthStart = Date.previewDate(year: 2026, month: 3, day: 31)
+        let period = DisplayPointPeriod(type: .month, anchor: anchor)
         let monthList: [PointOfMonth] = [
             .init(
                 userId: "u1",
@@ -314,7 +330,7 @@ extension ContributionAnalyticsTest.CurrentListCase {
                 totalAchievementCount: 0,
                 elements: [],
                 startDate: monthStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: [],
@@ -335,11 +351,10 @@ extension ContributionAnalyticsTest.CurrentListCase {
     }
 
     @Test("year表示のときyearPointListに基づくAllUserViewablePointListが返る")
-    func currentList_yearPeriod_returnsYearBasedList() throws {
-
+    func currentList_yearPeriod_returnsYearBasedList() {
         // Arrange
-        let anchor    = Date.previewDate(year: 2026, month: 12, day: 31)
-        let period    = DisplayPointPeriod(type: .year, anchor: anchor)
+        let anchor = Date.previewDate(year: 2026, month: 12, day: 31)
+        let period = DisplayPointPeriod(type: .year, anchor: anchor)
         let yearList: [PointOfYear] = [
             .init(
                 userId: "u1",
@@ -347,7 +362,7 @@ extension ContributionAnalyticsTest.CurrentListCase {
                 total: .init(value: 500),
                 totalAchievementCount: 0,
                 elements: []
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: [],
@@ -366,6 +381,7 @@ extension ContributionAnalyticsTest.CurrentListCase {
         )
         #expect(result == expected)
     }
+
 }
 
 // MARK: - isEmpty
@@ -374,7 +390,6 @@ extension ContributionAnalyticsTest.IsEmptyCase {
 
     @Test("週表示で全メンバーのtotalAchievementCountが0ならisEmptyはtrue")
     func isEmpty_week_allZero_returnsTrue() {
-
         // Arrange
         let weekStart = Date.previewDate(year: 2026, month: 4, day: 20)
         let weekList: [PointOfWeek] = [
@@ -393,7 +408,7 @@ extension ContributionAnalyticsTest.IsEmptyCase {
                 totalAchievementCount: 0,
                 elements: [],
                 startDate: weekStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: weekList,
@@ -408,7 +423,6 @@ extension ContributionAnalyticsTest.IsEmptyCase {
 
     @Test("週表示でいずれかのメンバーが家事を達成していればisEmptyはfalse")
     func isEmpty_week_someAchieved_returnsFalse() {
-
         // Arrange
         let weekStart = Date.previewDate(year: 2026, month: 4, day: 20)
         let weekList: [PointOfWeek] = [
@@ -427,7 +441,7 @@ extension ContributionAnalyticsTest.IsEmptyCase {
                 totalAchievementCount: 1,
                 elements: [],
                 startDate: weekStart
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: weekList,
@@ -442,7 +456,6 @@ extension ContributionAnalyticsTest.IsEmptyCase {
 
     @Test("月表示で全メンバーのtotalAchievementCountが0ならisEmptyはtrue")
     func isEmpty_month_allZero_returnsTrue() {
-
         // Arrange
         let startDate = Date.previewDate(year: 2026, month: 4, day: 1)
         let monthList: [PointOfMonth] = [
@@ -453,7 +466,7 @@ extension ContributionAnalyticsTest.IsEmptyCase {
                 totalAchievementCount: 0,
                 elements: [],
                 startDate: startDate
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: [],
@@ -468,7 +481,6 @@ extension ContributionAnalyticsTest.IsEmptyCase {
 
     @Test("月表示でいずれかのメンバーが家事を達成していればisEmptyはfalse")
     func isEmpty_month_someAchieved_returnsFalse() {
-
         // Arrange
         let startDate = Date.previewDate(year: 2026, month: 4, day: 1)
         let monthList: [PointOfMonth] = [
@@ -479,7 +491,7 @@ extension ContributionAnalyticsTest.IsEmptyCase {
                 totalAchievementCount: 2,
                 elements: [],
                 startDate: startDate
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: [],
@@ -494,7 +506,6 @@ extension ContributionAnalyticsTest.IsEmptyCase {
 
     @Test("年表示で全メンバーのtotalAchievementCountが0ならisEmptyはtrue")
     func isEmpty_year_allZero_returnsTrue() {
-
         // Arrange
         let yearList: [PointOfYear] = [
             .init(
@@ -503,7 +514,7 @@ extension ContributionAnalyticsTest.IsEmptyCase {
                 total: .init(value: 0),
                 totalAchievementCount: 0,
                 elements: []
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: [],
@@ -518,7 +529,6 @@ extension ContributionAnalyticsTest.IsEmptyCase {
 
     @Test("年表示でいずれかのメンバーが家事を達成していればisEmptyはfalse")
     func isEmpty_year_someAchieved_returnsFalse() {
-
         // Arrange
         let yearList: [PointOfYear] = [
             .init(
@@ -527,7 +537,7 @@ extension ContributionAnalyticsTest.IsEmptyCase {
                 total: .init(value: 100),
                 totalAchievementCount: 5,
                 elements: []
-            )
+            ),
         ]
         let analytics = ContributionAnalytics(
             weekPointList: [],
@@ -542,7 +552,6 @@ extension ContributionAnalyticsTest.IsEmptyCase {
 
     @Test("メンバーがいない（pointListが空）ならisEmptyはtrue")
     func isEmpty_noMembers_returnsTrue() {
-
         // Arrange
         let analytics = ContributionAnalytics(
             weekPointList: [],
@@ -554,4 +563,5 @@ extension ContributionAnalyticsTest.IsEmptyCase {
         // Act & Assert
         #expect(analytics.isEmpty == true)
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/ContributionStoreTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/ContributionStoreTest.swift
@@ -5,29 +5,29 @@
 //  Created by Taichi Sato on 2026/04/27.
 //
 
-import Foundation
-import Testing
-import HometeDomain
 @testable import ContributionFeature
+import Foundation
+import HometeDomain
+import Testing
 
 @MainActor
 struct ContributionStoreTest {
 
     private let inputCohabitantId = "cohabitantId"
     private let calendar = Calendar.japanese
+
 }
 
 extension ContributionStoreTest {
 
     @Test("HouseworkManagerがフェッチしたアイテムを流すと完了済みのみcontributionに反映される")
     func startObserving_updatesContributionWithOnlyCompletedItems() async {
-
         // Arrange
         let now = Date()
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let items: [HouseworkItem] = [
             .makeForTest(id: 1, indexedDate: jan10, point: 30, state: .completed, executorId: "alice"),
-            .makeForTest(id: 2, indexedDate: jan10, point: 20, state: .incomplete, executorId: "alice")
+            .makeForTest(id: 2, indexedDate: jan10, point: 20, state: .incomplete, executorId: "alice"),
         ]
         let (stream, _) = AsyncStream<[HouseworkItem]>.makeStream()
 
@@ -61,4 +61,5 @@ extension ContributionStoreTest {
         )
         #expect(store.contiribution == expectedContribution)
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/DisplayPointPeriodTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/DisplayPointPeriodTest.swift
@@ -5,25 +5,31 @@
 //  Created by Taichi Sato on 2026/05/01.
 //
 
+@testable import ContributionFeature
 import Foundation
 import Testing
-@testable import ContributionFeature
 
 // swiftlint:disable:next convenience_type
-struct DisplayPointPeriodTest {
+enum DisplayPointPeriodTest {
+
     struct CalcDateRangeCase {
+
         private let calendar = Calendar.japanese
+
     }
+
     struct ShiftPeriodCase {
+
         private let calendar = Calendar.japanese
+
     }
+
 }
 
 extension DisplayPointPeriodTest.CalcDateRangeCase {
 
     @Test("週モードのとき直近7日間のdateRangeが返る")
     func calcDateRange_week_returnsLastSevenDays() throws {
-
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 26)
         let period = DisplayPointPeriod(type: .week, anchor: anchor)
@@ -33,13 +39,12 @@ extension DisplayPointPeriodTest.CalcDateRangeCase {
 
         // Assert
         let expectedStart = Date.previewDate(year: 2026, month: 4, day: 20)
-        let expectedEnd   = Date.previewDate(year: 2026, month: 4, day: 26)
-        #expect(result == expectedStart...expectedEnd)
+        let expectedEnd = Date.previewDate(year: 2026, month: 4, day: 26)
+        #expect(result == expectedStart ... expectedEnd)
     }
 
     @Test("月モードのとき直近1ヶ月間のdateRangeが返る")
     func calcDateRange_month_returnsLastOneMonth() throws {
-
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
         let period = DisplayPointPeriod(type: .month, anchor: anchor)
@@ -50,12 +55,11 @@ extension DisplayPointPeriodTest.CalcDateRangeCase {
         // Assert
         let expectedStart = Date.previewDate(year: 2026, month: 3, day: 31)
         let expectedEnd = Date.previewDate(year: 2026, month: 4, day: 30)
-        #expect(result == expectedStart...expectedEnd)
+        #expect(result == expectedStart ... expectedEnd)
     }
 
     @Test("年モードのとき直近1年間のdateRangeが返る")
     func calcDateRange_year_returnsLastOneYear() throws {
-
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 12, day: 31)
         let period = DisplayPointPeriod(type: .year, anchor: anchor)
@@ -66,15 +70,15 @@ extension DisplayPointPeriodTest.CalcDateRangeCase {
         // Assert
         let expectedStart = Date.previewDate(year: 2026, month: 1, day: 31)
         let expectedEnd = Date.previewDate(year: 2026, month: 12, day: 31)
-        #expect(result == expectedStart...expectedEnd)
+        #expect(result == expectedStart ... expectedEnd)
     }
+
 }
 
 extension DisplayPointPeriodTest.ShiftPeriodCase {
 
     @Test("週モードで+1したとき1週間後がanchorになる")
     func shiftPeriod_week_forwardByOne_movesAnchorOneWeekLater() {
-
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 20)
         let period = DisplayPointPeriod(type: .week, anchor: anchor)
@@ -89,7 +93,6 @@ extension DisplayPointPeriodTest.ShiftPeriodCase {
 
     @Test("月モードで-1したとき1ヶ月前がanchorになる")
     func shiftPeriod_month_backByOne_movesAnchorOneMonthEarlier() {
-
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 4, day: 30)
         let period = DisplayPointPeriod(type: .month, anchor: anchor)
@@ -104,7 +107,6 @@ extension DisplayPointPeriodTest.ShiftPeriodCase {
 
     @Test("年モードで+1したとき1年後がanchorになる")
     func shiftPeriod_year_forwardByOne_movesAnchorOneYearLater() {
-
         // Arrange
         let anchor = Date.previewDate(year: 2026, month: 12, day: 31)
         let period = DisplayPointPeriod(type: .year, anchor: anchor)
@@ -116,4 +118,5 @@ extension DisplayPointPeriodTest.ShiftPeriodCase {
         let expectedAnchor = Date.previewDate(year: 2027, month: 12, day: 31)
         #expect(result == DisplayPointPeriod(type: .year, anchor: expectedAnchor))
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/HouseworkContributionTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/HouseworkContributionTest.swift
@@ -5,29 +5,38 @@
 //  Created by Taichi Sato on 2026/04/25.
 //
 
-import Foundation
-import Testing
-import HometeDomain
 @testable import ContributionFeature
+import Foundation
+import HometeDomain
+import Testing
 
 // swiftlint:disable:next convenience_type
-struct HouseworkContributionTest {
+enum HouseworkContributionTest {
+
     struct MakeCase {
+
         private let calendar = Calendar.japanese
+
     }
+
     struct CalculatePointSummariesCase {
+
         private let calendar = Calendar.japanese
+
     }
+
     struct LatestAchievedDateCase {
+
         let calendar = Calendar.japanese
+
     }
+
 }
 
 extension HouseworkContributionTest.MakeCase {
 
     @Test("完了した家事のみ獲得ポイントとして集計される")
     func make_onlyCompletedItemsAreIncluded() {
-
         // Arrange
         let inputFirstDate = Date.previewDate(year: 2026, month: 1, day: 1)
         let inputSecondDate = Date.previewDate(year: 2026, month: 1, day: 2)
@@ -35,7 +44,7 @@ extension HouseworkContributionTest.MakeCase {
         let items: [HouseworkItem] = [
             .makeForTest(id: 1, indexedDate: inputFirstDate, point: 30, state: .completed, executorId: "alice"),
             .makeForTest(id: 2, indexedDate: inputSecondDate, point: 50, state: .incomplete, executorId: "alice"),
-            .makeForTest(id: 3, indexedDate: inputThirdDate, point: 20, state: .completed, executorId: "alice")
+            .makeForTest(id: 3, indexedDate: inputThirdDate, point: 20, state: .completed, executorId: "alice"),
         ]
 
         // Act
@@ -46,8 +55,8 @@ extension HouseworkContributionTest.MakeCase {
             list: [
                 "alice": [
                     .init(indexedDay: inputFirstDate, point: .init(value: 30)),
-                    .init(indexedDay: inputThirdDate, point: .init(value: 20))
-                ]
+                    .init(indexedDay: inputThirdDate, point: .init(value: 20)),
+                ],
             ],
             calendar: calendar
         )
@@ -56,7 +65,6 @@ extension HouseworkContributionTest.MakeCase {
 
     @Test("家事が空の場合は空のリストが返る")
     func make_emptyInput_returnsEmptyList() {
-
         // Arrange
         let items: [HouseworkItem] = []
 
@@ -66,25 +74,25 @@ extension HouseworkContributionTest.MakeCase {
         // Assert
         #expect(result == .init(list: [:]))
     }
+
 }
 
 extension HouseworkContributionTest.CalculatePointSummariesCase {
 
     @Test("対象月の完了家事のポイントがユーザー毎に集計される")
     func calculatePointSummaries_returnsMonthlyPointPerUser() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let jan20 = Date.previewDate(year: 2026, month: 1, day: 20)
         let items: [HouseworkItem] = [
             .makeForTest(id: 1, indexedDate: jan10, point: 30, state: .completed, executorId: "alice"),
-            .makeForTest(id: 2, indexedDate: jan20, point: 50, state: .completed, executorId: "bob")
+            .makeForTest(id: 2, indexedDate: jan20, point: 50, state: .completed, executorId: "bob"),
         ]
         let contribution = HouseworkContribution.make(by: items, calendar: calendar)
         let members = CohabitantMemberList(
             value: [
                 .init(id: "alice", userName: "アリス"),
-                .init(id: "bob", userName: "ボブ")
+                .init(id: "bob", userName: "ボブ"),
             ],
             ownId: "alice"
         )
@@ -112,20 +120,19 @@ extension HouseworkContributionTest.CalculatePointSummariesCase {
                 isMe: false,
                 monthlyPoint: .init(value: 50),
                 achievedCount: 1
-            )
+            ),
         ]
         #expect(result.items.sorted(by: { $0.userId < $1.userId }) == expected.sorted(by: { $0.userId < $1.userId }))
     }
 
     @Test("対象月外の家事は集計から除外される")
     func calculatePointSummaries_excludesItemsOutsideTargetMonth() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let feb10 = Date.previewDate(year: 2026, month: 2, day: 10)
         let items: [HouseworkItem] = [
             .makeForTest(id: 1, indexedDate: jan10, point: 30, state: .completed, executorId: "alice"),
-            .makeForTest(id: 2, indexedDate: feb10, point: 50, state: .completed, executorId: "alice")
+            .makeForTest(id: 2, indexedDate: feb10, point: 50, state: .completed, executorId: "alice"),
         ]
         let contribution = HouseworkContribution.make(by: items, calendar: calendar)
         let members = CohabitantMemberList(value: [.init(id: "alice", userName: "アリス")], ownId: "alice")
@@ -146,14 +153,13 @@ extension HouseworkContributionTest.CalculatePointSummariesCase {
                 isMe: true,
                 monthlyPoint: .init(value: 30),
                 achievedCount: 1
-            )
+            ),
         ])
         #expect(result == expected)
     }
 
     @Test("対象月に達成した家事の数がachievedCountに反映される")
     func calculatePointSummaries_includesAchievedCount() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let items: [HouseworkItem] = [
@@ -179,7 +185,7 @@ extension HouseworkContributionTest.CalculatePointSummariesCase {
                 state: .completed,
                 executorId: "alice",
                 reviewerId: "bob"
-            )
+            ),
         ]
         let contribution = HouseworkContribution.make(by: items, calendar: calendar)
         let members = CohabitantMemberList(value: [.init(id: "alice", userName: "アリス")], ownId: "alice")
@@ -200,14 +206,13 @@ extension HouseworkContributionTest.CalculatePointSummariesCase {
                 isMe: true,
                 monthlyPoint: .init(value: 90),
                 achievedCount: 3
-            )
+            ),
         ])
         #expect(result == expected)
     }
 
     @Test("対象月外の達成家事はachievedCountに含まれない")
     func calculatePointSummaries_excludesAchievedItemsOutsideTargetMonth() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let feb10 = Date.previewDate(year: 2026, month: 2, day: 10)
@@ -227,7 +232,7 @@ extension HouseworkContributionTest.CalculatePointSummariesCase {
                 state: .completed,
                 executorId: "alice",
                 reviewerId: "bob"
-            )
+            ),
         ]
         let contribution = HouseworkContribution.make(by: items, calendar: calendar)
         let members = CohabitantMemberList(value: [.init(id: "alice", userName: "アリス")], ownId: "alice")
@@ -248,14 +253,13 @@ extension HouseworkContributionTest.CalculatePointSummariesCase {
                 isMe: true,
                 monthlyPoint: .init(value: 30),
                 achievedCount: 1
-            )
+            ),
         ])
         #expect(result == expected)
     }
 
     @Test("対象ユーザーに家事が存在しない場合はゼロのPointSummaryが返る")
     func calculatePointSummaries_noItemsForUser_returnsZeroSummary() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let contribution = HouseworkContribution.make(by: [], calendar: calendar)
@@ -277,19 +281,18 @@ extension HouseworkContributionTest.CalculatePointSummariesCase {
                 isMe: true,
                 monthlyPoint: .init(value: 0),
                 achievedCount: 0
-            )
+            ),
         ])
         #expect(result == expected)
     }
 
     @Test("membersに存在しないユーザーの貢献データは集計結果に含まれない")
     func calculatePointSummaries_excludesUsersNotInMembers() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let items: [HouseworkItem] = [
             .makeForTest(id: 1, indexedDate: jan10, point: 30, state: .completed, executorId: "alice"),
-            .makeForTest(id: 2, indexedDate: jan10, point: 50, state: .completed, executorId: "unknown")
+            .makeForTest(id: 2, indexedDate: jan10, point: 50, state: .completed, executorId: "unknown"),
         ]
         let contribution = HouseworkContribution.make(by: items, calendar: calendar)
         let members = CohabitantMemberList(value: [.init(id: "alice", userName: "アリス")], ownId: "alice")
@@ -310,10 +313,11 @@ extension HouseworkContributionTest.CalculatePointSummariesCase {
                 isMe: true,
                 monthlyPoint: .init(value: 30),
                 achievedCount: 1
-            )
+            ),
         ])
         #expect(result == expected)
     }
+
 }
 
 // MARK: - latestAchievedDate
@@ -322,7 +326,6 @@ extension HouseworkContributionTest.LatestAchievedDateCase {
 
     @Test("完了家事が複数ある場合は最新の日付が返る")
     func latestAchievedDate_multipleItems_returnsLatest() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let feb20 = Date.previewDate(year: 2026, month: 2, day: 20)
@@ -330,7 +333,7 @@ extension HouseworkContributionTest.LatestAchievedDateCase {
         let items: [HouseworkItem] = [
             .makeForTest(id: 1, indexedDate: jan10, point: 30, state: .completed, executorId: "alice"),
             .makeForTest(id: 2, indexedDate: feb20, point: 20, state: .completed, executorId: "alice"),
-            .makeForTest(id: 3, indexedDate: mar5, point: 15, state: .completed, executorId: "alice")
+            .makeForTest(id: 3, indexedDate: mar5, point: 15, state: .completed, executorId: "alice"),
         ]
         let contribution = HouseworkContribution.make(by: items, calendar: calendar)
 
@@ -343,11 +346,10 @@ extension HouseworkContributionTest.LatestAchievedDateCase {
 
     @Test("完了家事が1件の場合はその日付が返る")
     func latestAchievedDate_singleItem_returnsThatDate() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let items: [HouseworkItem] = [
-            .makeForTest(id: 1, indexedDate: jan10, point: 30, state: .completed, executorId: "alice")
+            .makeForTest(id: 1, indexedDate: jan10, point: 30, state: .completed, executorId: "alice"),
         ]
         let contribution = HouseworkContribution.make(by: items, calendar: calendar)
 
@@ -360,7 +362,6 @@ extension HouseworkContributionTest.LatestAchievedDateCase {
 
     @Test("完了家事がない場合はnilが返る")
     func latestAchievedDate_empty_returnsNil() {
-
         // Arrange
         let contribution = HouseworkContribution.make(by: [], calendar: calendar)
 
@@ -373,7 +374,6 @@ extension HouseworkContributionTest.LatestAchievedDateCase {
 
     @Test("複数ユーザーがいる場合は全体での最新日が返る")
     func latestAchievedDate_multipleUsers_returnsOverallLatest() {
-
         // Arrange
         let jan10 = Date.previewDate(year: 2026, month: 1, day: 10)
         let feb20 = Date.previewDate(year: 2026, month: 2, day: 20)
@@ -381,7 +381,7 @@ extension HouseworkContributionTest.LatestAchievedDateCase {
         let items: [HouseworkItem] = [
             .makeForTest(id: 1, indexedDate: jan10, point: 30, state: .completed, executorId: "alice"),
             .makeForTest(id: 2, indexedDate: mar5, point: 20, state: .completed, executorId: "bob"),
-            .makeForTest(id: 3, indexedDate: feb20, point: 15, state: .completed, executorId: "alice")
+            .makeForTest(id: 3, indexedDate: feb20, point: 15, state: .completed, executorId: "alice"),
         ]
         let contribution = HouseworkContribution.make(by: items, calendar: calendar)
 
@@ -391,4 +391,5 @@ extension HouseworkContributionTest.LatestAchievedDateCase {
         // Assert
         #expect(result == calendar.startOfDay(for: mar5))
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/PointOfMonthTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/PointOfMonthTest.swift
@@ -5,27 +5,33 @@
 //  Created by Taichi Sato on 2026/04/25.
 //
 
+@testable import ContributionFeature
 import Foundation
 import Testing
-@testable import ContributionFeature
 
 // swiftlint:disable:next convenience_type
-struct PointOfMonthTest {
+enum PointOfMonthTest {
+
     struct MakeCase {
+
         private let calendar = Calendar.japanese
+
     }
+
     struct MakeWithSeparatedCase {
+
         private let calendar = Calendar.japanese
+
     }
+
 }
 
 extension PointOfMonthTest.MakeCase {
 
     @Test("指定月以外のPointOfDayは除外され、指定月のみ集計される")
-    func make_excludesItemsOutsideTargetMonth() throws {
-
+    func make_excludesItemsOutsideTargetMonth() {
         // Arrange
-        let aprilDates: [Date] = (1...30).map { day in
+        let aprilDates: [Date] = (1 ... 30).map { day in
             Date.previewDate(year: 2026, month: 4, day: day)
         }
         let aprilStart = Date.previewDate(year: 2026, month: 4, day: 1)
@@ -36,7 +42,7 @@ extension PointOfMonthTest.MakeCase {
         let dayOfPoints: [Date: PointOfDay] = [
             april10: PointOfDay(indexedDay: april10, point: Point(value: 30)),
             april20: PointOfDay(indexedDay: april20, point: Point(value: 50)),
-            may10: PointOfDay(indexedDay: may10, point: Point(value: 50))
+            may10: PointOfDay(indexedDay: may10, point: Point(value: 50)),
         ]
 
         // Act
@@ -56,13 +62,13 @@ extension PointOfMonthTest.MakeCase {
         #expect(result.elements.contains { $0.indexedDay == april20 && $0.point.value == 50 })
         #expect(!result.elements.contains { $0.indexedDay == may10 })
     }
+
 }
 
 extension PointOfMonthTest.MakeWithSeparatedCase {
 
     @Test("同じ月のPointOfDayが1つのPointOfMonthにまとめられる")
     func makeWithSeparated_sameMonthItemsAreGroupedTogether() throws {
-
         // Arrange
         var comps = DateComponents()
         comps.year = 2026; comps.month = 4; comps.day = 10
@@ -75,7 +81,7 @@ extension PointOfMonthTest.MakeWithSeparatedCase {
         let dayOfPoints: [Date: PointOfDay] = [
             april10: PointOfDay(indexedDay: april10, point: Point(value: 30)),
             april20: PointOfDay(indexedDay: april20, point: Point(value: 50)),
-            may10: PointOfDay(indexedDay: may10, point: Point(value: 20))
+            may10: PointOfDay(indexedDay: may10, point: Point(value: 20)),
         ]
 
         // Act
@@ -97,7 +103,7 @@ extension PointOfMonthTest.MakeWithSeparatedCase {
                 totalAchievementCount: 2,
                 elements: [
                     PointOfDay(indexedDay: april10, point: Point(value: 30)),
-                    PointOfDay(indexedDay: april20, point: Point(value: 50))
+                    PointOfDay(indexedDay: april20, point: Point(value: 50)),
                 ],
                 startDate: aprilStart
             ),
@@ -107,14 +113,15 @@ extension PointOfMonthTest.MakeWithSeparatedCase {
                 total: .init(value: 20),
                 totalAchievementCount: 1,
                 elements: [
-                    PointOfDay(indexedDay: may10, point: Point(value: 20))
+                    PointOfDay(indexedDay: may10, point: Point(value: 20)),
                 ],
                 startDate: mayStart
-            )
+            ),
         ]
         #expect(result.count == expected.count)
         for item in result {
             #expect(expected.contains { $0.elements == item.elements && $0.total == item.total })
         }
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/PointOfWeekTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/PointOfWeekTest.swift
@@ -5,25 +5,28 @@
 //  Created by Taichi Sato on 2026/04/25.
 //
 
+@testable import ContributionFeature
 import Foundation
 import Testing
-@testable import ContributionFeature
 
 // swiftlint:disable:next convenience_type
-struct PointOfWeekTest {
+enum PointOfWeekTest {
+
     struct MakeCase {
+
         private let calendar = Calendar.japanese
+
     }
+
 }
 
 extension PointOfWeekTest.MakeCase {
 
     @Test("指定週以外のPointOfDayは除外され、指定週のポイントが合算される")
-    func make_onlyTargetWeekItemsAreIncludedAndSummed() throws {
-
+    func make_onlyTargetWeekItemsAreIncludedAndSummed() {
         // Arrange
         // 2026-04-20(月)〜2026-04-26(日) の週、2026-04-27(月) は翌週
-        let weekDates: [Date] = (20...26).map { day in
+        let weekDates: [Date] = (20 ... 26).map { day in
             Date.previewDate(year: 2026, month: 4, day: day)
         }
         let april20 = Date.previewDate(year: 2026, month: 4, day: 20)
@@ -33,7 +36,7 @@ extension PointOfWeekTest.MakeCase {
         let dayOfPoints: [Date: PointOfDay] = [
             april20: PointOfDay(indexedDay: april20, point: Point(value: 30)),
             april21: PointOfDay(indexedDay: april21, point: Point(value: 50)),
-            april27: PointOfDay(indexedDay: april27, point: Point(value: 20))
+            april27: PointOfDay(indexedDay: april27, point: Point(value: 20)),
         ]
 
         // Act
@@ -56,4 +59,5 @@ extension PointOfWeekTest.MakeCase {
             #expect(result.elements.contains { $0.indexedDay == date && $0.point.value == 0 })
         }
     }
+
 }

--- a/LocalPackage/Tests/ContributionFeatureTests/PointOfYearTest.swift
+++ b/LocalPackage/Tests/ContributionFeatureTests/PointOfYearTest.swift
@@ -5,24 +5,27 @@
 //  Created by Taichi Sato on 2026/04/25.
 //
 
+@testable import ContributionFeature
 import Foundation
 import Testing
-@testable import ContributionFeature
 
 // swiftlint:disable:next convenience_type
-struct PointOfYearTest {
+enum PointOfYearTest {
+
     struct MakeCase {
+
         private let calendar = Calendar.japanese
+
     }
+
 }
 
 extension PointOfYearTest.MakeCase {
 
     @Test("指定年以外のPointOfDayは除外される")
-    func make_excludesItemsOutsideTargetYear() throws {
-
+    func make_excludesItemsOutsideTargetYear() {
         // Arrange
-        let yearDates2026: [Date] = (1...12).map { month in
+        let yearDates2026: [Date] = (1 ... 12).map { month in
             Date.previewDate(year: 2026, month: month, day: 1)
         }
         let april2026 = Date.previewDate(year: 2026, month: 4, day: 10)
@@ -30,7 +33,7 @@ extension PointOfYearTest.MakeCase {
 
         let dayOfPoints: [Date: PointOfDay] = [
             april2026: PointOfDay(indexedDay: april2026, point: Point(value: 30)),
-            april2025: PointOfDay(indexedDay: april2025, point: Point(value: 50))
+            april2025: PointOfDay(indexedDay: april2025, point: Point(value: 50)),
         ]
 
         // Act
@@ -47,10 +50,9 @@ extension PointOfYearTest.MakeCase {
     }
 
     @Test("指定年の家事が月ごとにグループ化される")
-    func make_elementsAreGroupedByMonth() throws {
-
+    func make_elementsAreGroupedByMonth() {
         // Arrange
-        let yearDates2026: [Date] = (1...12).map { month in
+        let yearDates2026: [Date] = (1 ... 12).map { month in
             Date.previewDate(year: 2026, month: month, day: 1)
         }
         let april2026 = Date.previewDate(year: 2026, month: 4, day: 10)
@@ -58,7 +60,7 @@ extension PointOfYearTest.MakeCase {
 
         let dayOfPoints: [Date: PointOfDay] = [
             april2026: PointOfDay(indexedDay: april2026, point: Point(value: 30)),
-            may2026: PointOfDay(indexedDay: may2026, point: Point(value: 50))
+            may2026: PointOfDay(indexedDay: may2026, point: Point(value: 50)),
         ]
 
         // Act
@@ -77,10 +79,9 @@ extension PointOfYearTest.MakeCase {
     }
 
     @Test("指定年に含まれる全月のポイントが合算される")
-    func make_totalIsSumOfAllTargetYearItemPoints() throws {
-
+    func make_totalIsSumOfAllTargetYearItemPoints() {
         // Arrange
-        let yearDates2026: [Date] = (1...12).map { month in
+        let yearDates2026: [Date] = (1 ... 12).map { month in
             Date.previewDate(year: 2026, month: month, day: 1)
         }
         let april2026 = Date.previewDate(year: 2026, month: 4, day: 10)
@@ -88,7 +89,7 @@ extension PointOfYearTest.MakeCase {
 
         let dayOfPoints: [Date: PointOfDay] = [
             april2026: PointOfDay(indexedDay: april2026, point: Point(value: 30)),
-            may2026: PointOfDay(indexedDay: may2026, point: Point(value: 50))
+            may2026: PointOfDay(indexedDay: may2026, point: Point(value: 50)),
         ]
 
         // Act
@@ -103,4 +104,5 @@ extension PointOfYearTest.MakeCase {
         // Assert
         #expect(result.total.value == 80)
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/AccountAuthStoreTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/AccountAuthStoreTest.swift
@@ -5,25 +5,22 @@
 //  Created by 佐藤汰一 on 2025/08/09.
 //
 
-import Testing
 @testable import HometeDomain
+import Testing
 
 @MainActor
 struct AccountAuthStoreTest {
 
     @Test("ログイン処理ではサーバー側でサインイン後、成功したらログを送信する")
     func test_login() async throws {
-        
         let inputTokenId = "testId"
         let inputNonce = "testNonce"
         let outputAccount = AccountAuthResult(id: "testAccountId")
-        
+
         try await confirmation(expectedCount: 4) { confirmation in
-            
             let store = AccountAuthStore(
                 accountAuthClient: .init(
                     signIn: { tokenId, nonce in
-                        
                         confirmation()
                         #expect(tokenId == inputTokenId)
                         #expect(nonce == inputNonce)
@@ -31,54 +28,45 @@ struct AccountAuthStoreTest {
                     },
                     signOut: { confirmation() },
                     makeListener: {
-                        
                         confirmation()
                         return .defaultValue()
                     }
                 ),
                 analyticsClient: .init(
                     setId: { id in
-                        
                         confirmation()
                         #expect(id == outputAccount.id)
                     }, log: { event in
-                        
                         confirmation()
                         #expect(event == .login(isSuccess: true))
                     }
                 )
             )
-            
+
             try await store.login(.init(tokenId: inputTokenId, nonce: inputNonce, authorizationCode: "code"))
         }
     }
-    
+
     @Test("ログアウト時はローカルのログイン状態をログアウトにしてログアウト処理を行い、イベントログを送信する")
     func test_logout() async {
-
         await confirmation(expectedCount: 3) { confirmation in
-
             let store = AccountAuthStore(
                 accountAuthClient: .init(
                     signIn: { _, _ in
-
                         Issue.record()
                         return .init(id: "")
                     },
                     signOut: { confirmation() },
                     makeListener: {
-
                         confirmation()
                         return .defaultValue()
                     }
                 ),
                 analyticsClient: .init(
                     setId: { _ in
-
                         Issue.record()
                     },
                     log: { event in
-
                         confirmation()
                         #expect(event == .logout())
                     }
@@ -91,10 +79,9 @@ struct AccountAuthStoreTest {
             #expect(store.currentAuth == .init(result: nil, alreadyLoadedAtInitiate: true))
         }
     }
-    
+
     @Test("再認証を行った後にアカウントを削除し認証トークンの無効化を行いログアウト状態にすることで、退会処理を完了させる")
     func deleteAccount() async throws {
-        
         // Arrange
         let inputNonce = SignInWithAppleNonce(original: "originalTestNonce", sha256: "sha256TestNonce")
         let inputSignInWithAppleResult = SignInWithAppleResult(
@@ -102,52 +89,46 @@ struct AccountAuthStoreTest {
             nonce: inputNonce.sha256,
             authorizationCode: "testCode"
         )
-        
+
         try await confirmation(expectedCount: 6) { confirmation in
-            
             let store = AccountAuthStore(
                 accountAuthClient: .init(
                     reauthenticateWithApple: { result in
-                        
                         confirmation()
                         #expect(result == inputSignInWithAppleResult)
                     },
                     revokeAppleToken: { code in
-                        
                         confirmation()
                         #expect(code == inputSignInWithAppleResult.authorizationCode)
                     },
                     deleteAccount: {
-                        
                         confirmation()
-                    },
+                    }
                 ),
                 analyticsClient: .init(
                     log: { event in
-                        
                         confirmation()
                         #expect(event == .deleteAccount())
                     }
                 ),
                 signInWithAppleClient: .init { nonce in
-                    
                     confirmation()
                     #expect(nonce == inputNonce)
                     return inputSignInWithAppleResult
                 },
                 nonceGenerationClient: .init {
-                    
                     confirmation()
                     return inputNonce
                 },
                 currentAuth: .init(result: .init(id: "test"), alreadyLoadedAtInitiate: true)
             )
-            
+
             // Act
             try await store.deleteAccount()
-            
+
             // Assert
             #expect(store.currentAuth == .init(result: nil, alreadyLoadedAtInitiate: true))
         }
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/AccountStoreTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/AccountStoreTest.swift
@@ -5,15 +5,14 @@
 //  Created by 佐藤汰一 on 2025/08/09.
 //
 
-import Testing
 @testable import HometeDomain
+import Testing
 
 @MainActor
 struct AccountStoreTest {
 
     @Test("アカウント情報をロードし、アカウントがある場合はアカウント情報を返す")
-    func load() async throws {
-        
+    func load() async {
         // Arrange
         let inputAccountId = "test"
         let inputAccount = Account(
@@ -22,31 +21,27 @@ struct AccountStoreTest {
             fcmToken: "testToken",
             cohabitantId: nil
         )
-        
+
         await confirmation(expectedCount: 1) { confirmation in
-            
             let inputAuthResult = AccountAuthResult(id: "test")
             let accountInfoClient = AccountInfoClient(fetch: {
-                
                 confirmation()
                 #expect($0 == inputAuthResult.id)
                 return inputAccount
             })
             let store = AccountStore(accountInfoClient: accountInfoClient)
-            
+
             // Act
             let actual = await store.load(inputAuthResult)
-            
+
             // Assert
             #expect(actual == inputAccount)
         }
     }
-    
+
     @Test("サーバーにログイン情報がありFCMトークンが更新されている場合アカウントに紐づくFCMトークンを更新")
     func updateFcmTokenIfNeeded() async {
-        
         await confirmation(expectedCount: 1) { confirmation in
-            
             // Arrange
             let inputFcmToken = "token"
             let initialAccount = Account(id: "testId", userName: "testUser", fcmToken: nil, cohabitantId: nil)
@@ -57,7 +52,6 @@ struct AccountStoreTest {
                 cohabitantId: nil
             )
             let accountInfoClient = AccountInfoClient(insertOrUpdate: {
-                
                 confirmation()
                 #expect($0 == expectedAccount)
             })
@@ -65,20 +59,18 @@ struct AccountStoreTest {
                 accountInfoClient: accountInfoClient,
                 account: initialAccount
             )
-            
+
             // Act
             await store.updateFcmTokenIfNeeded(inputFcmToken)
-            
+
             // Assert
             #expect(store.account == expectedAccount)
         }
     }
-    
+
     @Test("パートナーの登録で保持しているアカウントにパートナーグループIDの情報を更新する")
     func registerCohabitantId() async throws {
-        
         try await confirmation(expectedCount: 1) { confirmation in
-            
             // Arrange
             let inputCohabitantId = "testCohabitantId"
             let initialAccount = Account(
@@ -94,7 +86,6 @@ struct AccountStoreTest {
                 cohabitantId: inputCohabitantId
             )
             let accountInfoClient = AccountInfoClient(insertOrUpdate: {
-                
                 confirmation()
                 #expect($0 == expectedAccount)
             })
@@ -102,12 +93,13 @@ struct AccountStoreTest {
                 accountInfoClient: accountInfoClient,
                 account: initialAccount
             )
-            
+
             // Act
             try await store.registerCohabitantId(inputCohabitantId)
-            
+
             // Assert
             #expect(store.account == expectedAccount)
         }
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/CohabitantRegistration/CohabitantRegistrationMessageTests.swift
+++ b/LocalPackage/Tests/HometeDomainTests/CohabitantRegistration/CohabitantRegistrationMessageTests.swift
@@ -6,24 +6,23 @@
 //
 
 import Foundation
-import Testing
 @testable import HometeDomain
+import Testing
 
 struct CohabitantRegistrationMessageTests {
-        
+
     @Test(
         "メンバー確認のメッセージの場合、メンバー確定するかどうかが取得できること",
         arguments: [true, false]
     )
     func isFixedMember_typeIsFixedMember(input: Bool) {
-        
         let message = CohabitantRegistrationMessage(type: .fixedMember(isOK: input))
-        
+
         let actual = message.isFixedMember
-        
+
         #expect(actual == input)
     }
-    
+
     @Test(
         "メンバー確認のメッセージ以外の場合、nilを返す",
         arguments: [
@@ -36,14 +35,13 @@ struct CohabitantRegistrationMessageTests {
     func isFixedMember_typeIsNotFixedMember(
         inputMessageType: CohabitantRegistrationMessage.CommunicateType
     ) {
-        
         let message = CohabitantRegistrationMessage(type: inputMessageType)
-        
+
         let actual = message.isFixedMember
-        
+
         #expect(actual == nil)
     }
-    
+
     @Test(
         "登録処理開始前のメッセージの場合、送信者の役割を取得できる",
         arguments: [
@@ -52,14 +50,13 @@ struct CohabitantRegistrationMessageTests {
         ]
     )
     func memberRole_typeIsPreRegistration(inputRole: CohabitantRegistrationRole) {
-        
         let message = CohabitantRegistrationMessage(type: .preRegistration(role: inputRole))
-        
+
         let actual = message.memberRole
-        
+
         #expect(actual == inputRole)
     }
-    
+
     @Test(
         "登録処理開始前のメッセージ以外の場合、nilを返す",
         arguments: [
@@ -71,25 +68,23 @@ struct CohabitantRegistrationMessageTests {
     func memberRole_typeIsNotPreRegistration(
         inputMessageType: CohabitantRegistrationMessage.CommunicateType
     ) {
-        
         let message = CohabitantRegistrationMessage(type: inputMessageType)
-        
+
         let actual = message.memberRole
-        
+
         #expect(actual == nil)
     }
-    
+
     @Test("同居人ID共有メッセージの場合、共有された同居人IDを取得できる")
     func cohabitantId_typeIsShareCohabitantId() {
-        
         let inputId = "test_id"
         let message = CohabitantRegistrationMessage(type: .shareCohabitantId(id: inputId))
-        
+
         let actual = message.cohabitantId
-        
+
         #expect(actual == inputId)
     }
-    
+
     @Test(
         "同居人ID共有メッセージ以外の場合、nilを返す",
         arguments: [
@@ -102,23 +97,22 @@ struct CohabitantRegistrationMessageTests {
     func cohabitantId_typeIsNotShareCohabitantId(
         inputMessageType: CohabitantRegistrationMessage.CommunicateType
     ) {
-        
         let message = CohabitantRegistrationMessage(type: inputMessageType)
-        
+
         let actual = message.cohabitantId
-        
+
         #expect(actual == nil)
     }
-    
+
     @Test("登録処理完了メッセージの場合、完了かどうかを取得する")
     func isComplete_typeIsComplete() {
         let message = CohabitantRegistrationMessage(type: .complete)
-        
+
         let actual = message.isComplete
-        
+
         #expect(actual == true)
     }
-    
+
     @Test(
         "登録処理完了メッセージ以外の場合、nilを返す",
         arguments: [
@@ -131,14 +125,13 @@ struct CohabitantRegistrationMessageTests {
     func isComplete_typeIsNotComplete_returnsNil(
         inputMessageType: CohabitantRegistrationMessage.CommunicateType
     ) {
-        
         let message = CohabitantRegistrationMessage(type: inputMessageType)
-        
+
         let actual = message.isComplete
-        
+
         #expect(actual == nil)
     }
-    
+
     @Test(
         "同居人登録のメッセージはJSONエンコードされたDataが送信されること",
         arguments: [
@@ -151,15 +144,14 @@ struct CohabitantRegistrationMessageTests {
         ]
     )
     func encodeDecode(type: CohabitantRegistrationMessage.CommunicateType) throws {
-        
         let message = CohabitantRegistrationMessage(type: type)
-        
+
         let actual = message.encodedData()
-        
+
         let expected = try JSONEncoder().encode(message)
         #expect(actual == expected)
     }
-    
+
     @Test(
         "JSONエンコードされた同居人登録のメッセージを元の形式のでコードできること",
         arguments: [
@@ -168,16 +160,16 @@ struct CohabitantRegistrationMessageTests {
             .fixedMember(isOK: false),
             .preRegistration(role: .lead),
             .preRegistration(role: .follower(accountId: "id")),
-            .shareCohabitantId(id: "id")
+            .shareCohabitantId(id: "id"),
         ]
     )
     func init_withValidData(type: CohabitantRegistrationMessage.CommunicateType) throws {
-        
         let message = CohabitantRegistrationMessage(type: type)
         let encodedData = try JSONEncoder().encode(message)
-        
+
         let actual = CohabitantRegistrationMessage(encodedData)
-        
+
         #expect(actual == message)
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/CohabitantStoreTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/CohabitantStoreTest.swift
@@ -5,9 +5,9 @@
 //  Created by Taichi Sato on 2026/01/12.
 //
 
-import Testing
-import Observation
 @testable import HometeDomain
+import Observation
+import Testing
 
 @MainActor
 struct CohabitantStoreTest {
@@ -16,8 +16,7 @@ struct CohabitantStoreTest {
     private let inputListenerId = "cohabitantListenerKey"
 
     @Test("パートナーの監視中に、まだキャッシュしていないメンバーの場合はパートナーのリストにキャッシュとして追加する")
-    func addSnapshotListenerIfNeeded_add_member_case() async throws {
-
+    func addSnapshotListenerIfNeeded_add_member_case() async {
         // Arrange
 
         let selfId = "selfId"
@@ -41,14 +40,12 @@ struct CohabitantStoreTest {
             ownId: selfId,
             cohabitantClient: .init(
                 addSnapshotListener: { listenerId, cohabitantId in
-
                     #expect(listenerId == inputListenerId)
                     #expect(cohabitantId == inputCohabitantId)
                     return stream
                 }
             ),
             accountInfoClient: .init(fetch: { userId in
-
                 // Assert
 
                 #expect(userId == newMemberId)
@@ -80,4 +77,5 @@ struct CohabitantStoreTest {
         #expect(store.members.value.count == 2)
         #expect(store.members.value.contains(.init(id: newMemberId, userName: newMemberUserName)))
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkHistoryListTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkHistoryListTest.swift
@@ -5,21 +5,21 @@
 //  Created by 佐藤汰一 on 2025/09/07.
 //
 
-import Testing
 @testable import HometeDomain
+import Testing
 
 // swiftlint:disable:next convenience_type
-struct HouseworkHistoryListTest {
-    
+enum HouseworkHistoryListTest {
+
     struct MoveToFrontIfExistsCase {}
     struct AddNewHistoryCase {}
+
 }
 
 extension HouseworkHistoryListTest.MoveToFrontIfExistsCase {
-    
+
     @Test("存在する要素を指定すると先頭へ移動する")
     func moveExistingItemToFront() {
-        
         // Arrange
         var list = HouseworkHistoryList(items: ["1", "2", "3"])
         let target = "2"
@@ -34,7 +34,6 @@ extension HouseworkHistoryListTest.MoveToFrontIfExistsCase {
 
     @Test("既に先頭の要素を指定しても変更されない")
     func noChangeWhenItemAlreadyAtFront() {
-        
         // Arrange
         let initial = HouseworkHistoryList(items: ["a", "b", "c"])
         var list = initial
@@ -49,7 +48,6 @@ extension HouseworkHistoryListTest.MoveToFrontIfExistsCase {
 
     @Test("存在しない要素を指定しても変更されない")
     func noChangeWhenItemDoesNotExist() {
-        
         // Arrange
         let initial = HouseworkHistoryList(items: ["x", "y", "z"])
         var list = initial
@@ -61,44 +59,44 @@ extension HouseworkHistoryListTest.MoveToFrontIfExistsCase {
         // Assert
         #expect(list == initial)
     }
+
 }
 
 extension HouseworkHistoryListTest.AddNewHistoryCase {
-    
+
     @Test(
         "履歴に存在しない要素を追加する場合、その要素が先頭に追加される",
         arguments: [
             ["洗濯", "皿洗い"],
-            []
+            [],
         ]
     )
     func addNewItem(initialList: [String]) {
-        
         // Arrange
         let value = "掃除"
         var list = HouseworkHistoryList(items: initialList)
         let expected = HouseworkHistoryList(items: ["掃除"] + initialList)
-        
+
         // Act
         list.addNewHistory(value)
-        
+
         // Assert
         #expect(list == expected)
     }
-    
+
     @Test("既に存在する要素を追加する場合、リストは変更されない")
     func addValueAlreadyAtFrontDoesNotChange() {
-        
         // Arrange
         let initial = HouseworkHistoryList(items: ["洗濯", "掃除", "皿洗い"])
         var list = initial
         let value = "掃除"
-        
+
         // Act
         list.addNewHistory(value)
-        
+
         // Assert
         let expected = HouseworkHistoryList(items: ["掃除", "洗濯", "皿洗い"])
         #expect(list == expected)
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkIndexedDate.swift
+++ b/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkIndexedDate.swift
@@ -6,13 +6,14 @@
 //
 
 import Foundation
-import Testing
 @testable import HometeDomain
+import Testing
 
 enum HouseworkIndexedDateTest {
 
     struct InitCase {}
     struct CalcTargetPeriodCase {}
+
 }
 
 // MARK: - CalcTargetPeriodCase
@@ -21,7 +22,6 @@ extension HouseworkIndexedDateTest.CalcTargetPeriodCase {
 
     @Test("指定の日付から指定の期間の日付情報を返す")
     func calcTargetPeriod() {
-
         // Arrange
         let calendar = Calendar.japanese
 
@@ -38,14 +38,13 @@ extension HouseworkIndexedDateTest.CalcTargetPeriodCase {
             .previewDate(year: 2026, month: 1, day: 31),
             .previewDate(year: 2026, month: 2, day: 1),
             .previewDate(year: 2026, month: 2, day: 2),
-            .previewDate(year: 2026, month: 2, day: 3)
+            .previewDate(year: 2026, month: 2, day: 3),
         ]
         #expect(result == expected)
     }
 
     @Test("指定の期間が0以下の場合、基準日付のみ返す")
     func calcTargetPeriod_zero_offset() {
-
         // Arrange
         let calendar = Calendar.japanese
 
@@ -60,4 +59,5 @@ extension HouseworkIndexedDateTest.CalcTargetPeriodCase {
         let expected = [Date.previewDate(year: 2026, month: 1, day: 15)]
         #expect(result == expected)
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkItemTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkItemTest.swift
@@ -6,14 +6,14 @@
 //
 
 import Foundation
-import Testing
-
 @testable import HometeDomain
+import Testing
 
 enum HouseworkItemTest {
 
     struct CanReviewCase {}
     struct UpdateStateCase {}
+
 }
 
 extension HouseworkItemTest.CanReviewCase {
@@ -23,7 +23,6 @@ extension HouseworkItemTest.CanReviewCase {
         arguments: [HouseworkState.incomplete, .pendingApproval]
     )
     func canReview_notOwnUserAndNotCompleted_returnsTrue(state: HouseworkState) {
-
         // Arrange
         let item = HouseworkItem.makeForTest(
             id: 1,
@@ -43,7 +42,6 @@ extension HouseworkItemTest.CanReviewCase {
         arguments: ["otherUserId", nil]
     )
     func canReview_completedState_returnsFalse(executorId: String?) {
-
         // Arrange
         let item = HouseworkItem.makeForTest(
             id: 1,
@@ -63,7 +61,6 @@ extension HouseworkItemTest.CanReviewCase {
         arguments: HouseworkState.allCases
     )
     func canReview_ownUser_returnsFalse(state: HouseworkState) {
-
         // Arrange
         let ownUserId = "ownUserId"
         let item = HouseworkItem.makeForTest(
@@ -78,6 +75,7 @@ extension HouseworkItemTest.CanReviewCase {
         // Assert
         #expect(result == false)
     }
+
 }
 
 // MARK: - UpdateStateCase
@@ -86,7 +84,6 @@ extension HouseworkItemTest.UpdateStateCase {
 
     @Test("承認待ち状態に更新すると、state・executorId・executedAtが更新される")
     func updatePendingApproval_updatesStateAndExecutorInfo() {
-
         // Arrange
         let indexedDate = Date()
         let expiredAt = Date().addingTimeInterval(3600)
@@ -117,10 +114,9 @@ extension HouseworkItemTest.UpdateStateCase {
         )
         #expect(result == expected)
     }
-    
+
     @Test("承認すると、state・reviewerId・approvedAt・reviewerCommentが更新される")
     func updateApproved_updatesStateAndReviewerInfo() {
-
         // Arrange
         let indexedDate = Date()
         let expiredAt = Date().addingTimeInterval(3600)
@@ -159,10 +155,9 @@ extension HouseworkItemTest.UpdateStateCase {
         )
         #expect(result == expected)
     }
-    
+
     @Test("未完了状態に戻すと、stateがincompleteになり実行者・承認者情報がクリアされる")
     func updateIncomplete_clearsExecutorAndReviewerInfo() {
-
         // Arrange
         let indexedDate = Date()
         let expiredAt = Date().addingTimeInterval(3600)
@@ -194,4 +189,5 @@ extension HouseworkItemTest.UpdateStateCase {
         )
         #expect(result == expected)
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkManagerTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/Housework/HouseworkManagerTest.swift
@@ -6,9 +6,8 @@
 //
 
 import Foundation
-import Testing
-
 @testable import HometeDomain
+import Testing
 
 @MainActor
 struct HouseworkManagerTest {
@@ -16,8 +15,7 @@ struct HouseworkManagerTest {
     private let inputCohabitantId = "cohabitantId"
 
     @Test("setupObserverを呼び出すと直近1年分をフェッチしリスナーを起動してallItemsに反映する")
-    func setupObserver() async throws {
-
+    func setupObserver() async {
         // Arrange
 
         let now = Date()
@@ -30,13 +28,13 @@ struct HouseworkManagerTest {
             houseworkClient: .init(
                 snapshotListenerHandler: { id, cohabitantId, anchorDate, offset in
                     #expect(id == "houseworkObserveKey")
-                    #expect(cohabitantId == self.inputCohabitantId)
+                    #expect(cohabitantId == inputCohabitantId)
                     #expect(anchorDate == now)
                     #expect(offset == 3)
                     return stream
                 },
                 fetchItemsHandler: { cohabitantId, from, to in
-                    #expect(cohabitantId == self.inputCohabitantId)
+                    #expect(cohabitantId == inputCohabitantId)
                     #expect(from == expectedFrom)
                     #expect(to == now)
                     return [fetchedItem]
@@ -51,7 +49,7 @@ struct HouseworkManagerTest {
         await manager.setupObserver(
             currentTime: now,
             cohabitantId: inputCohabitantId,
-            calendar: calendar,
+            calendar: calendar
         )
 
         // Assert
@@ -69,8 +67,7 @@ struct HouseworkManagerTest {
     }
 
     @Test("リアルタイムリスナーの更新がallItemsにupsertマージされオブザーバーに通知される")
-    func streamUpdateIsUpserted() async throws {
-
+    func streamUpdateIsUpserted() async {
         // Arrange
 
         let now = Date()
@@ -90,11 +87,13 @@ struct HouseworkManagerTest {
         await manager.setupObserver(
             currentTime: now,
             cohabitantId: inputCohabitantId,
-            calendar: calendar,
+            calendar: calendar
         )
 
         // フェッチ結果の通知を消費
-        for await _ in observerStream { break }
+        for await _ in observerStream {
+            break
+        }
 
         // Act
 
@@ -117,4 +116,5 @@ struct HouseworkManagerTest {
         #expect(allItems.contains(where: { $0.id == newItem.id }))
         #expect(receivedItems.count == 2)
     }
+
 }

--- a/LocalPackage/Tests/HometeDomainTests/TestHelper/AccountListenerStreamCreater.swift
+++ b/LocalPackage/Tests/HometeDomainTests/TestHelper/AccountListenerStreamCreater.swift
@@ -1,5 +1,5 @@
 //
-//  Account.swift
+//  AccountListenerStreamCreater.swift
 //  homete
 //
 //  Created by 佐藤汰一 on 2025/08/09.
@@ -9,10 +9,10 @@ import Foundation
 @testable import HometeDomain
 
 extension AccountListenerStream {
-    
+
     static func defaultValue() -> Self {
-        
         let (stream, continuation) = AsyncStream<AccountAuthResult?>.makeStream()
         return .init(values: stream, listenerToken: NSObject(), continuation: continuation)
     }
+
 }

--- a/LocalPackage/Tests/HouseworkFeatureTests/DailyHouseworkListTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/DailyHouseworkListTest.swift
@@ -6,99 +6,100 @@
 //
 
 import Foundation
-import Testing
 import HometeDomain
 @testable import HouseworkFeature
+import Testing
 
 // swiftlint:disable:next convenience_type
-struct DailyHouseworkListTest {
-    
+enum DailyHouseworkListTest {
+
     struct MakeInitialValueCase {}
     struct IsRegisteredCase {}
     struct IsAlreadyRegisteredCase {}
+
 }
 
 extension DailyHouseworkListTest.MakeInitialValueCase {
-    
+
     @Test("一日の家事情報の保持期限は1年後になる")
     func makeInitialValue() throws {
-
         // Arrange
         let calendar = Calendar.japanese
         let selectedDate = Date()
         let selectedDay = calendar.startOfDay(for: selectedDate)
         let expectedIndexedDate = HouseworkIndexedDate(value: selectedDay)
         let expectedExpiredAt = try #require(calendar.date(byAdding: .year, value: 1, to: selectedDay))
-        
+
         let expectedList = DailyHouseworkList(
             items: [],
             metaData: .init(indexedDate: expectedIndexedDate, expiredAt: expectedExpiredAt)
         )
-        
+
         // Act
         let list = DailyHouseworkList.makeInitialValue(
             selectedDate: selectedDate,
             items: [],
             calendar: calendar
         )
-        
+
         // Assert
         #expect(list == expectedList)
     }
+
 }
 
 extension DailyHouseworkListTest.IsRegisteredCase {
-        
+
     @Test(
         "登録されている家事がない場合は、その日付の家事レコードが登録されていない",
         arguments: [
             [HouseworkItem.makeForTest(id: 1, title: "洗濯", point: 1)],
-            []
+            [],
         ]
     )
     func isRegistered(inputItems: [HouseworkItem]) {
-        
         // Arrange
         let list = DailyHouseworkList(
             items: inputItems,
             metaData: .init(indexedDate: .init(value: .now), expiredAt: .now)
         )
-        
+
         // Act
         let result = list.isRegistered
-        
+
         // Assert
         #expect(result == !inputItems.isEmpty)
     }
+
 }
 
 extension DailyHouseworkListTest.IsAlreadyRegisteredCase {
-    
+
     @Test(
         "同じタイトルの家事が含まれていれば登録済みの家事とみなす",
         arguments: [
             HouseworkItem.makeForTest(id: 1, title: "洗濯", point: 1),
             .makeForTest(id: 3, title: "洗濯", point: 1),
-            .makeForTest(id: 1, title: "掃除", point: 1)
+            .makeForTest(id: 1, title: "掃除", point: 1),
         ]
     )
     func alreadyRegistered_trueWhenSameTitleExists(inputItem: HouseworkItem) {
-        
         // Arrange
         let items: [HouseworkItem] = [
             .makeForTest(id: 1, title: "洗濯", point: 1),
-            .makeForTest(id: 2, title: "ゴミ捨て", point: 1, state: .completed)
+            .makeForTest(id: 2, title: "ゴミ捨て", point: 1, state: .completed),
         ]
         let list = DailyHouseworkList(
             items: items,
             metaData: .init(indexedDate: .init(value: .now), expiredAt: .now)
         )
-        
+
         // Act
         let result = list.isAlreadyRegistered(inputItem)
-        
+
         // Assert
         let expected = items.contains { $0.title == inputItem.title }
         #expect(result == expected)
     }
+
 }

--- a/LocalPackage/Tests/HouseworkFeatureTests/HouseworkBoardEmptyReasonTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/HouseworkBoardEmptyReasonTest.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-import Testing
 import HometeDomain
 @testable import HouseworkFeature
+import Testing
 
 enum HouseworkBoardEmptyReasonTest {
 
@@ -19,7 +19,6 @@ enum HouseworkBoardEmptyReasonTest {
             arguments: HouseworkState.allCases
         )
         func returns_noHouseworkRegistered_when_items_is_empty(state: HouseworkState) {
-
             // Arrange
             let list = HouseworkBoardList(items: [])
 
@@ -29,16 +28,16 @@ enum HouseworkBoardEmptyReasonTest {
             // Assert
             #expect(actual == .noHouseworkRegistered)
         }
+
     }
 
     struct InitWithIncompleteState {
 
         @Test("フィルタ結果が空でない場合はnilを返す")
         func returns_nil_when_filtered_items_is_not_empty() {
-
             // Arrange
             let list = HouseworkBoardList(items: [
-                .makeForTest(id: 1, state: .incomplete)
+                .makeForTest(id: 1, state: .incomplete),
             ])
 
             // Act
@@ -50,11 +49,10 @@ enum HouseworkBoardEmptyReasonTest {
 
         @Test("未完了タブが空で家事が登録されている場合はallCompletedOrPendingを返す")
         func returns_allCompletedOrPending_when_incomplete_is_empty_but_items_exist() {
-
             // Arrange
             let list = HouseworkBoardList(items: [
                 .makeForTest(id: 1, state: .pendingApproval),
-                .makeForTest(id: 2, state: .completed)
+                .makeForTest(id: 2, state: .completed),
             ])
 
             // Act
@@ -63,17 +61,17 @@ enum HouseworkBoardEmptyReasonTest {
             // Assert
             #expect(actual == .allCompletedOrPending)
         }
+
     }
 
     struct InitWithPendingApprovalState {
 
         @Test("承認待ちタブが空で未完了の家事がある場合はnoPendingApproval(hasIncomplete: true)を返す")
         func returns_noPendingApproval_hasIncomplete_true_when_incomplete_exists() {
-
             // Arrange
             let list = HouseworkBoardList(items: [
                 .makeForTest(id: 1, state: .incomplete),
-                .makeForTest(id: 2, state: .completed)
+                .makeForTest(id: 2, state: .completed),
             ])
 
             // Act
@@ -85,10 +83,9 @@ enum HouseworkBoardEmptyReasonTest {
 
         @Test("承認待ちタブが空で未完了の家事もない場合はnoPendingApproval(hasIncomplete: false)を返す")
         func returns_noPendingApproval_hasIncomplete_false_when_incomplete_not_exists() {
-
             // Arrange
             let list = HouseworkBoardList(items: [
-                .makeForTest(id: 1, state: .completed)
+                .makeForTest(id: 1, state: .completed),
             ])
 
             // Act
@@ -97,17 +94,17 @@ enum HouseworkBoardEmptyReasonTest {
             // Assert
             #expect(actual == .noPendingApproval(hasIncomplete: false))
         }
+
     }
 
     struct InitWithCompletedState {
 
         @Test("完了タブが空で自身が承認できる承認待ち家事がある場合はcanReviewPendingApprovalを返す")
         func returns_canReviewPendingApproval_when_reviewable_pending_exists() {
-
             // Arrange
             // executorId が ownUserId と異なる → canReview = true
             let list = HouseworkBoardList(items: [
-                .makeForTest(id: 1, state: .pendingApproval, executorId: "other")
+                .makeForTest(id: 1, state: .pendingApproval, executorId: "other"),
             ])
 
             // Act
@@ -119,12 +116,11 @@ enum HouseworkBoardEmptyReasonTest {
 
         @Test("完了タブが空で承認待ち家事が全て自分が実行したものの場合はallPendingApprovalByOthersを返す")
         func returns_allPendingApprovalByOthers_when_all_pending_are_own() {
-
             // Arrange
             // executorId が ownUserId と同じ → canReview = false
             let list = HouseworkBoardList(items: [
                 .makeForTest(id: 1, state: .pendingApproval, executorId: "user1"),
-                .makeForTest(id: 2, state: .pendingApproval, executorId: "user1")
+                .makeForTest(id: 2, state: .pendingApproval, executorId: "user1"),
             ])
 
             // Act
@@ -136,10 +132,9 @@ enum HouseworkBoardEmptyReasonTest {
 
         @Test("完了タブが空で承認待ちがなく未完了家事がある場合はhasIncompleteHouseworkを返す")
         func returns_hasIncompleteHousework_when_no_pending_but_incomplete_exists() {
-
             // Arrange
             let list = HouseworkBoardList(items: [
-                .makeForTest(id: 1, state: .incomplete)
+                .makeForTest(id: 1, state: .incomplete),
             ])
 
             // Act
@@ -151,11 +146,10 @@ enum HouseworkBoardEmptyReasonTest {
 
         @Test("完了タブが空で承認待ちと未完了が混在する場合はcanReviewPendingApprovalが優先される")
         func returns_canReviewPendingApproval_when_both_pending_and_incomplete_exist() {
-
             // Arrange
             let list = HouseworkBoardList(items: [
                 .makeForTest(id: 1, state: .pendingApproval, executorId: "other"),
-                .makeForTest(id: 2, state: .incomplete)
+                .makeForTest(id: 2, state: .incomplete),
             ])
 
             // Act
@@ -164,5 +158,7 @@ enum HouseworkBoardEmptyReasonTest {
             // Assert
             #expect(actual == .canReviewPendingApproval)
         }
+
     }
+
 }

--- a/LocalPackage/Tests/HouseworkFeatureTests/HouseworkBoardListTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/HouseworkBoardListTest.swift
@@ -6,12 +6,12 @@
 //
 
 import Foundation
-import Testing
 import HometeDomain
 @testable import HouseworkFeature
+import Testing
 
 struct HouseworkBoardListTest {
-    
+
     private static let calendar = Calendar.autoupdatingCurrent
 
     @Test(
@@ -19,66 +19,65 @@ struct HouseworkBoardListTest {
         arguments: [
             Date.now,
             Date.distantFuture,
-            Date.distantPast
+            Date.distantPast,
         ]
     )
-    func initialize(selectTime: Date) async throws {
-        
+    func initialize(selectTime: Date) {
         // Arrange
         let inputSelectedDateItemList: [HouseworkItem] = [
             .makeForTest(id: 1, indexedDate: selectTime),
-            .makeForTest(id: 2, indexedDate: selectTime)
+            .makeForTest(id: 2, indexedDate: selectTime),
         ]
         let inputUnselectedDateItemList: [HouseworkItem] = [
             .makeForTest(
                 id: 1,
                 indexedDate: Self.calendar.date(bySetting: .day, value: -3, of: .now) ?? .now
-            )
+            ),
         ]
         let inputList: [DailyHouseworkList] = [
             .makeForTest(items: inputSelectedDateItemList),
-            .makeForTest(items: inputUnselectedDateItemList)
+            .makeForTest(items: inputUnselectedDateItemList),
         ]
-        
+
         // Act
         let actual = HouseworkBoardList(
             dailyList: inputList,
-            selectedDate: selectTime,
+            selectedDate: selectTime
         )
-        
+
         // Assert
         let expected = HouseworkBoardList(items: inputSelectedDateItemList)
         #expect(actual == expected)
     }
-    
+
     @Test(
         "指定した状態にマッチする家事を取得する",
         arguments: HouseworkState.allCases
     )
-    func items_match_state(expectedState: HouseworkState) async throws {
-        
+    func items_match_state(expectedState: HouseworkState) {
         // Arrange
         let targetDate = Date.previewDate(year: 2026, month: 1, day: 1)
         let inputHouseworkItem = makeHouseworkItemListWithAllState(targetDate)
         let houseworkBoardList = HouseworkBoardList(
             dailyList: [.makeForTest(items: inputHouseworkItem)],
-            selectedDate: targetDate,
+            selectedDate: targetDate
         )
-        
+
         // Act
         let actual = houseworkBoardList.items(matching: expectedState)
-        
+
         // Assert
         let expected = inputHouseworkItem.filter { $0.state == expectedState }
         #expect(actual == expected)
     }
+
 }
 
 private extension HouseworkBoardListTest {
-    
+
     func makeHouseworkItemListWithAllState(_ date: Date) -> [HouseworkItem] {
         HouseworkState.allCases.enumerated().flatMap { index, state in
-            (1...3).map {
+            (1 ... 3).map {
                 HouseworkItem.makeForTest(
                     id: index + 1 + $0,
                     indexedDate: date,
@@ -87,4 +86,5 @@ private extension HouseworkBoardListTest {
             }
         }
     }
+
 }

--- a/LocalPackage/Tests/HouseworkFeatureTests/HouseworkDateListTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/HouseworkDateListTest.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import Testing
 @testable import HouseworkFeature
+import Testing
 
 struct HouseworkDateListTest {
 
@@ -63,7 +63,7 @@ struct HouseworkDateListTest {
         arguments: [
             Date.previewDate(year: 2026, month: 4, day: 15), // anchor当日
             Date.previewDate(year: 2026, month: 4, day: 12), // anchor-3（selectable範囲内）
-            Date.previewDate(year: 2026, month: 4, day: 18)  // anchor+3（selectable範囲内）
+            Date.previewDate(year: 2026, month: 4, day: 18) // anchor+3（selectable範囲内）
         ]
     )
     func state_returns_selected(selectedDate: Date) {
@@ -78,7 +78,7 @@ struct HouseworkDateListTest {
         "anchorDate±7の範囲かつselected以外のアイテム状態はselectableを返す",
         arguments: [-7, -5, -3, -1, 1, 3, 5, 7] // 0はanchor=selectedなのでselectedになる
     )
-    func state_returns_selectable(offsetFromAnchor: Int) async throws {
+    func state_returns_selectable(offsetFromAnchor: Int) throws {
         let sut = makeSut(selectedDate: Self.anchorDate) // selectedDate = anchorDate（offset=0）
         let targetDate = try #require(Self.calendar.date(byAdding: .day, value: offsetFromAnchor, to: Self.anchorDate))
         let actual = sut.items.first { Self.calendar.isDate($0.date, inSameDayAs: targetDate) }?.state
@@ -91,7 +91,7 @@ struct HouseworkDateListTest {
         "anchorDate±7の範囲外のアイテム状態はunselectableを返す",
         arguments: [-10, -9, -8, 8, 9, 10]
     )
-    func state_returns_unselectable(offsetFromAnchor: Int) async throws {
+    func state_returns_unselectable(offsetFromAnchor: Int) throws {
         let sut = makeSut(selectedDate: Self.anchorDate)
         let targetDate = try #require(Self.calendar.date(byAdding: .day, value: offsetFromAnchor, to: Self.anchorDate))
         let actual = sut.items.first { Self.calendar.isDate($0.date, inSameDayAs: targetDate) }?.state
@@ -104,7 +104,7 @@ struct HouseworkDateListTest {
         "selectableな日付を選択するとselectedDateが更新されその日付のアイテム状態がselectedになる",
         arguments: [-7, -3, -1, 1, 3, 7]
     )
-    func selectDate_selectable(offsetFromAnchor: Int) async throws {
+    func selectDate_selectable(offsetFromAnchor: Int) throws {
         var sut = makeSut(selectedDate: Self.anchorDate)
         let targetDate = try #require(Self.calendar.date(byAdding: .day, value: offsetFromAnchor, to: Self.anchorDate))
         sut.selectDate(targetDate, calendar: Self.calendar)
@@ -118,7 +118,7 @@ struct HouseworkDateListTest {
         "selectableな日付を選択すると旧selectedDateのアイテム状態がselectableに変わる",
         arguments: [-7, -3, -1, 1, 3, 7]
     )
-    func selectDate_previousSelected_becomes_selectable(offsetFromAnchor: Int) async throws {
+    func selectDate_previousSelected_becomes_selectable(offsetFromAnchor: Int) throws {
         var sut = makeSut(selectedDate: Self.anchorDate)
         let targetDate = try #require(Self.calendar.date(byAdding: .day, value: offsetFromAnchor, to: Self.anchorDate))
         sut.selectDate(targetDate, calendar: Self.calendar)
@@ -130,13 +130,14 @@ struct HouseworkDateListTest {
         "unselectableな日付を選択してもselectedDateとitemsは変更されない",
         arguments: [-10, -9, -8, 8, 9, 10]
     )
-    func selectDate_unselectable(offsetFromAnchor: Int) async throws {
+    func selectDate_unselectable(offsetFromAnchor: Int) throws {
         var sut = makeSut(selectedDate: Self.anchorDate)
         let originalSut = sut
         let targetDate = try #require(Self.calendar.date(byAdding: .day, value: offsetFromAnchor, to: Self.anchorDate))
         sut.selectDate(targetDate, calendar: Self.calendar)
         #expect(sut == originalSut)
     }
+
 }
 
 private extension HouseworkDateListTest {
@@ -148,4 +149,5 @@ private extension HouseworkDateListTest {
             calendar: Self.calendar
         )
     }
+
 }

--- a/LocalPackage/Tests/HouseworkFeatureTests/HouseworkListStoreTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/HouseworkListStoreTest.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-import Testing
 import HometeDomain
 @testable import HouseworkFeature
+import Testing
 
 @MainActor
 struct HouseworkListStoreTest {
@@ -21,11 +21,11 @@ struct HouseworkListStoreTest {
 
         private let inputId = "houseworkObserveKey"
         private let inputCohabitantId = "cohabitantId"
+
     }
 
     @Test("新しい家事の登録すると、パートナーに通知を送信する")
-    func register() async throws {
-
+    func register() async {
         // Arrange
 
         let inputHouseworkItem = HouseworkItem.makeForTest(id: 1)
@@ -35,12 +35,9 @@ struct HouseworkListStoreTest {
         )
 
         await confirmation(expectedCount: 2) { confirmation in
-
             let _: Void = await withCheckedContinuation { continuation in
-
                 let store = HouseworkListStore(
                     houseworkClient: .init(insertOrUpdateItemHandler: { item, cohabitantId in
-
                         // Assert
 
                         #expect(item == inputHouseworkItem)
@@ -48,7 +45,6 @@ struct HouseworkListStoreTest {
                         confirmation()
                     }),
                     cohabitantPushNotificationClient: .init { id, content in
-
                         // Assert
 
                         #expect(id == inputCohabitantId)
@@ -61,19 +57,18 @@ struct HouseworkListStoreTest {
                 // Act
 
                 Task {
-
                     try await store.register(newItem: inputHouseworkItem, cohabitantId: inputCohabitantId)
                 }
             }
         }
     }
+
 }
 
 extension HouseworkListStoreTest.UpdateStatusCase {
 
     @Test("家事の完了確認を依頼すると、パートナーにその旨Push通知を送信する")
-    func requestReview() async throws {
-
+    func requestReview() async {
         // Arrange
 
         let inputHouseworkItem = HouseworkItem.makeForTest(id: 1)
@@ -90,13 +85,10 @@ extension HouseworkListStoreTest.UpdateStatusCase {
         )
 
         await confirmation(expectedCount: 2) { confirmation in
-
             let _: Void = await withCheckedContinuation { continuation in
-
                 let store = HouseworkListStore(
                     houseworkClient: .init(
                         insertOrUpdateItemHandler: { item, cohabitantId in
-
                             // Assert
 
                             #expect(item == updatedHouseworkItem)
@@ -105,7 +97,6 @@ extension HouseworkListStoreTest.UpdateStatusCase {
                         }
                     ),
                     cohabitantPushNotificationClient: .init { id, content in
-
                         // Assert
 
                         #expect(id == inputCohabitantId)
@@ -113,13 +104,12 @@ extension HouseworkListStoreTest.UpdateStatusCase {
                         confirmation()
                         continuation.resume()
                     },
-                    items: [.makeForTest(items: [inputHouseworkItem])],
+                    items: [.makeForTest(items: [inputHouseworkItem])]
                 )
 
                 // Act
 
                 Task {
-
                     try await store.requestReview(
                         target: inputHouseworkItem,
                         now: requestedAt,
@@ -133,7 +123,6 @@ extension HouseworkListStoreTest.UpdateStatusCase {
 
     @Test("実施者、実施日をクリアして家事のステータスを未完了に戻す")
     func returnToIncomplete() async throws {
-
         // Arrange
 
         let inputHouseworkItem = HouseworkItem.makeForTest(
@@ -149,11 +138,9 @@ extension HouseworkListStoreTest.UpdateStatusCase {
         )
 
         try await confirmation(expectedCount: 1) { confirmation in
-
             let store = HouseworkListStore(
                 houseworkClient: .init(
                     insertOrUpdateItemHandler: { item, cohabitantId in
-
                         // Assert
 
                         #expect(item == updatedHouseworkItem)
@@ -162,10 +149,9 @@ extension HouseworkListStoreTest.UpdateStatusCase {
                     }
                 ),
                 cohabitantPushNotificationClient: .init { _, _ in
-
                     Issue.record()
                 },
-                items: [.makeForTest(items: [inputHouseworkItem])],
+                items: [.makeForTest(items: [inputHouseworkItem])]
             )
 
             // Act
@@ -176,16 +162,13 @@ extension HouseworkListStoreTest.UpdateStatusCase {
 
     @Test("家事削除時は家事を削除するAPIを実行する")
     func remove() async throws {
-
         // Arrange
 
         let inputHouseworkItem = HouseworkItem.makeForTest(id: 1)
 
         try await confirmation { confirmation in
-
             let store = HouseworkListStore(
                 houseworkClient: .init(removeItemHandler: { item, cohabitantId in
-
                     // Assert
 
                     #expect(item == inputHouseworkItem)
@@ -193,7 +176,7 @@ extension HouseworkListStoreTest.UpdateStatusCase {
                     confirmation()
                 }),
                 cohabitantPushNotificationClient: .previewValue,
-                items: [.makeForTest(items: [inputHouseworkItem])],
+                items: [.makeForTest(items: [inputHouseworkItem])]
             )
 
             // Act
@@ -204,8 +187,7 @@ extension HouseworkListStoreTest.UpdateStatusCase {
 
     @Test("家事を承認すると、承認情報を更新しパートナーに通知を送信する")
     // swiftlint:disable:next function_body_length
-    func approved() async throws {
-
+    func approved() async {
         // Arrange
 
         let inputHouseworkItem = HouseworkItem.makeForTest(
@@ -234,13 +216,10 @@ extension HouseworkListStoreTest.UpdateStatusCase {
         )
 
         await confirmation(expectedCount: 2) { confirmation in
-
             let _: Void = await withCheckedContinuation { continuation in
-
                 let store = HouseworkListStore(
                     houseworkClient: .init(
                         insertOrUpdateItemHandler: { item, cohabitantId in
-
                             // Assert
 
                             #expect(item == updatedHouseworkItem)
@@ -249,7 +228,6 @@ extension HouseworkListStoreTest.UpdateStatusCase {
                         }
                     ),
                     cohabitantPushNotificationClient: .init { id, content in
-
                         // Assert
 
                         #expect(id == inputCohabitantId)
@@ -257,13 +235,12 @@ extension HouseworkListStoreTest.UpdateStatusCase {
                         confirmation()
                         continuation.resume()
                     },
-                    items: [.makeForTest(items: [inputHouseworkItem])],
+                    items: [.makeForTest(items: [inputHouseworkItem])]
                 )
 
                 // Act
 
                 Task {
-
                     try await store.approved(
                         target: inputHouseworkItem,
                         now: approvedAt,
@@ -278,8 +255,7 @@ extension HouseworkListStoreTest.UpdateStatusCase {
 
     @Test("家事を却下すると、却下情報を更新しパートナーに通知を送信する")
     // swiftlint:disable:next function_body_length
-    func rejected() async throws {
-
+    func rejected() async {
         // Arrange
 
         let inputHouseworkItem = HouseworkItem.makeForTest(
@@ -308,13 +284,10 @@ extension HouseworkListStoreTest.UpdateStatusCase {
         )
 
         await confirmation(expectedCount: 2) { confirmation in
-
             let _: Void = await withCheckedContinuation { continuation in
-
                 let store = HouseworkListStore(
                     houseworkClient: .init(
                         insertOrUpdateItemHandler: { item, cohabitantId in
-
                             // Assert
 
                             #expect(item == updatedHouseworkItem)
@@ -323,7 +296,6 @@ extension HouseworkListStoreTest.UpdateStatusCase {
                         }
                     ),
                     cohabitantPushNotificationClient: .init { id, content in
-
                         // Assert
 
                         #expect(id == inputCohabitantId)
@@ -331,13 +303,12 @@ extension HouseworkListStoreTest.UpdateStatusCase {
                         confirmation()
                         continuation.resume()
                     },
-                    items: [.makeForTest(items: [inputHouseworkItem])],
+                    items: [.makeForTest(items: [inputHouseworkItem])]
                 )
 
                 // Act
 
                 Task {
-
                     try await store.rejected(
                         target: inputHouseworkItem,
                         now: rejectedAt,
@@ -349,4 +320,5 @@ extension HouseworkListStoreTest.UpdateStatusCase {
             }
         }
     }
+
 }

--- a/LocalPackage/Tests/HouseworkFeatureTests/StoredAllHouseworkListTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/StoredAllHouseworkListTest.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-import Testing
 import HometeDomain
 @testable import HouseworkFeature
+import Testing
 
 struct StoredAllHouseworkListTest {
 
@@ -19,12 +19,11 @@ struct StoredAllHouseworkListTest {
 
     @Test("家事リストは家事の日付毎に保持される")
     func makeMultiDateList() {
-
-        let inputFirstHouseworkGroup  = makeAllCasesItems(
+        let inputFirstHouseworkGroup = makeAllCasesItems(
             at: Self.inputFirstDate,
             offset: 0
         )
-        let inputSecondHouseworkGroup  = makeAllCasesItems(
+        let inputSecondHouseworkGroup = makeAllCasesItems(
             at: Self.inputSecondDate,
             offset: inputFirstHouseworkGroup.count
         )
@@ -41,14 +40,13 @@ struct StoredAllHouseworkListTest {
         let sortedActual = StoredAllHouseworkList(value: sortedActualValue)
         let expected = StoredAllHouseworkList(value: [
             .makeForTest(items: inputFirstHouseworkGroup),
-            .makeForTest(items: inputSecondHouseworkGroup)
+            .makeForTest(items: inputSecondHouseworkGroup),
         ])
         #expect(sortedActual == expected)
     }
 
     @Test("リスナー範囲外の家事は保持しない")
     func makeMultiDateList_filtersOutOfRangeItems() {
-
         let inRangeItems = makeAllCasesItems(at: Self.inputFirstDate, offset: 0)
         let outOfRangeDate = Date.previewDate(year: 2024, month: 12, day: 1)
         let outOfRangeItems = makeAllCasesItems(at: outOfRangeDate, offset: inRangeItems.count)
@@ -72,8 +70,7 @@ struct StoredAllHouseworkListTest {
         ]
     )
     func items(expectedItem: HouseworkItem) {
-
-        let inputFirstHouseworkGroup  = makeAllCasesItems(
+        let inputFirstHouseworkGroup = makeAllCasesItems(
             at: Self.inputFirstDate,
             offset: 0
         )
@@ -88,16 +85,18 @@ struct StoredAllHouseworkListTest {
 
         #expect(actual == expectedItem)
     }
+
 }
 
 private extension StoredAllHouseworkListTest {
-    
+
     func makeAllCasesItems(at indexedDate: Date, offset: Int) -> [HouseworkItem] {
-        return [
+        [
             .makeForTest(id: offset + 1, indexedDate: indexedDate),
             .makeForTest(id: offset + 2, indexedDate: indexedDate, state: .pendingApproval),
             .makeForTest(id: offset + 3, indexedDate: indexedDate, state: .completed),
-            .makeForTest(id: offset + 4, indexedDate: indexedDate, executorId: "dummy", executedAt: .now)
+            .makeForTest(id: offset + 4, indexedDate: indexedDate, executorId: "dummy", executedAt: .now),
         ]
     }
+
 }

--- a/LocalPackage/Tests/HouseworkFeatureTests/TestHelper/DailyHouseworkListHelper.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/TestHelper/DailyHouseworkListHelper.swift
@@ -9,11 +9,11 @@ import HometeDomain
 @testable import HouseworkFeature
 
 extension DailyHouseworkList {
-    
+
     static func makeForTest(items: [HouseworkItem]) -> Self {
-        
         let indexedDate = items[0].indexedDate
         let expiredAt = items[0].expiredAt
         return .init(items: items, metaData: .init(indexedDate: indexedDate, expiredAt: expiredAt))
     }
+
 }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint deploy emulator test-e2e build-local-package test-packages setup-project
+.PHONY: help lint deploy emulator test-e2e build-local-package test-packages setup-project install-hooks
 
 .DEFAULT_GOAL := setup-project
 
@@ -23,6 +23,10 @@ build-local-package: ## LocalPackageをiOSシミュレーター向けにビル�
 test-packages: ## LocalPackageのテストを実行
 	swift test --package-path LocalPackage --enable-code-coverage
 
+install-hooks: ## git hooks（pre-commitでSwiftFormat実行）を有効化
+	git config core.hooksPath scripts/git-hooks
+	@echo "✅ git hooksを scripts/git-hooks に設定しました"
+
 setup-project: ## iOSプロジェクトのセットアップ
 	@bash scripts/setup_ruby.sh
 	@echo "Bundler依存関係をインストール中..."
@@ -34,4 +38,5 @@ setup-project: ## iOSプロジェクトのセットアップ
 	rbenv exec bundle exec fastlane install_dev_profile
 	@echo "本番用プロビジョニングプロファイルを取得中..."
 	rbenv exec bundle exec fastlane install_prod_profile
+	@$(MAKE) install-hooks
 	@echo "✅ セットアップ完了！"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint deploy emulator test-e2e build-local-package test-packages setup-project install-hooks
+.PHONY: help lint deploy emulator test-e2e build-local-package test-packages setup-project install-hooks format
 
 .DEFAULT_GOAL := setup-project
 
@@ -26,6 +26,13 @@ test-packages: ## LocalPackageのテストを実行
 install-hooks: ## git hooks（pre-commitでSwiftFormat実行）を有効化
 	git config core.hooksPath scripts/git-hooks
 	@echo "✅ git hooksを scripts/git-hooks に設定しました"
+
+format: ## プロダクション+テストコード全体にSwiftFormatを実行
+	swift package --package-path ProjectTools plugin \
+		--allow-writing-to-package-directory \
+		--allow-writing-to-directory $(CURDIR) \
+		swiftformat --config .swiftformat \
+		homete hometeSnapshotTests LocalPackage
 
 setup-project: ## iOSプロジェクトのセットアップ
 	@bash scripts/setup_ruby.sh

--- a/ProjectTools/Package.resolved
+++ b/ProjectTools/Package.resolved
@@ -1,5 +1,15 @@
 {
+  "originHash" : "64c9e941c7e97acb093d30378f048b695b1650705f62a765d1eb2dd9bcda9420",
   "pins" : [
+    {
+      "identity" : "swiftformat",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/nicklockwood/swiftformat",
+      "state" : {
+        "revision" : "a5fa7a6a57abeb834df1b3fa43ea9133137d5ade",
+        "version" : "0.61.1"
+      }
+    }
   ],
   "version" : 3
 }

--- a/ProjectTools/Package.swift
+++ b/ProjectTools/Package.swift
@@ -16,6 +16,9 @@ let package = Package(
             targets: ["ProjectToolsDummy"]
         ),
     ],
+    dependencies: [
+        .package(url: "https://github.com/nicklockwood/swiftformat", exact: "0.61.1")
+    ],
     targets: [
         .target(
             name: "ProjectToolsDummy"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 homete の iOS アプリリポジトリ
 
+## ドキュメント
+
+- [コードスタイル統一: SwiftFormat & SwiftLint](doc/tech/code-style.md) — フォーマッタ/リンタの役割分担と使い方
+- [マルチモジュール構成](doc/multimodules_structure.md) — SPM モジュール構成
+
 ## 証明書・プロビジョニングプロファイルの管理
 
 証明書管理には [Fastlane Match](https://docs.fastlane.tools/actions/match/) を使用しています。

--- a/doc/tech/code-style.md
+++ b/doc/tech/code-style.md
@@ -1,0 +1,166 @@
+# コードスタイル統一: SwiftFormat & SwiftLint
+
+本プロジェクトでは Swift コードの品質を統一するために、役割の異なる 2 つのツールを併用しています。
+
+| ツール | 役割 | 実行タイミング |
+|---|---|---|
+| **SwiftFormat** | コードの**自動整形**（インデント・改行・ラップなど機械的に修正可能なスタイル） | pre-commit hook / 手動 |
+| **SwiftLint** | 静的解析による**品質チェック**（自動修正できない規約違反やコードスメル） | CI（Danger 経由）/ 手動 |
+
+設定ファイルは双方ともリポジトリルートに配置しています。
+
+- `.swiftformat` — SwiftFormat 設定
+- `.swiftlint.yml` — SwiftLint 設定
+
+両ツールの除外パス・行長などは互いに整合するよう設定してあります（`.swiftformat` の `--exclude` と `.swiftlint.yml` の `excluded` が一致、`--max-width 120` が SwiftLint の `line_length` 警告閾値と一致）。
+
+---
+
+## SwiftFormat
+
+### 提供方法
+
+SwiftFormat は `ProjectTools/Package.swift` に SwiftPM 依存として組み込まれており、SwiftPM プラグイン経由で実行します。
+
+```swift
+// ProjectTools/Package.swift
+.package(url: "https://github.com/nicklockwood/swiftformat", exact: "0.61.1")
+```
+
+### 自動実行（pre-commit hook）
+
+`scripts/git-hooks/pre-commit` がステージ済みの Swift ファイルに SwiftFormat を適用し、整形結果を自動で再ステージします。
+
+**初回セットアップ:**
+
+```bash
+make install-hooks
+# または
+git config core.hooksPath scripts/git-hooks
+```
+
+`make setup-project` 内でも自動的に呼ばれます。
+
+**動作:**
+
+1. `git diff --cached` でステージ済み Swift ファイルを取得
+2. `.swiftformat` の `--exclude` 設定で除外されているパスをスキップ
+3. SwiftFormat を実行
+4. 整形後のファイルを `git add` で再ステージ
+
+### 手動実行
+
+プロジェクト全体（`homete/` / `hometeSnapshotTests/` / `LocalPackage/` 配下）に一括で整形を適用するには:
+
+```bash
+make format
+```
+
+内部では以下を実行しています。
+
+```bash
+swift package --package-path ProjectTools plugin \
+    --allow-writing-to-package-directory \
+    --allow-writing-to-directory $(pwd) \
+    swiftformat --config .swiftformat \
+    homete hometeSnapshotTests LocalPackage
+```
+
+> `--allow-writing-to-directory` は SwiftPM プラグインのサンドボックスがパッケージ外への書き込みをブロックするため必要。
+
+### 主要なルール（`.swiftformat`）
+
+| 設定 | 内容 |
+|---|---|
+| `--swift-version 6` | Swift 6 構文を前提に整形 |
+| `--max-width 120` | SwiftLint の `line_length.warning` と一致 |
+| `--type-blank-lines insert` | 型宣言の `{` 直後に空行を挿入 |
+| `--wrap-arguments before-first` | 複数行に分割される引数を `(` の次行から開始 |
+| `--wrap-parameters before-first` | 関数呼び出しパラメータも同様 |
+| `--wrap-collections before-first` | 配列/辞書リテラルも同様 |
+| `--closing-paren balanced` | 閉じ `)` を独立行に配置 |
+
+**before-first スタイルの例:**
+
+```swift
+init(
+    hoge: String,
+    huga: Int
+)
+```
+
+**無効化しているルール（既存コードへの影響が大きいため）:**
+
+- `organizeDeclarations` — 宣言の並び替え
+- `markTypes` — `// MARK:` 自動挿入
+- `acronyms` — 識別子内の頭字語の大文字化
+- `wrapMultilineStatementBraces` — `{` の改行配置変更
+- `blockComments` — ブロックコメントの整形
+
+---
+
+## SwiftLint
+
+### 提供方法
+
+SwiftLint は `ProjectTools/Package.swift` にバイナリターゲットとして組み込まれています。
+
+```swift
+.binaryTarget(
+    name: "SwiftLintPluginBinary",
+    url: "https://github.com/realm/SwiftLint/releases/download/0.59.1/SwiftLintBinary.artifactbundle.zip",
+    ...
+)
+```
+
+### 自動実行（CI / Danger）
+
+PR 作成時に GitHub Actions の `ci.yml` から Danger 経由で実行されます。`ProjectTools/Dangerfile.swift` で `homete/` 配下の変更ファイルに対して SwiftLint を実行し、PR コメントとして結果を投稿します。
+
+### 手動実行
+
+ローカルで全体を Lint するには:
+
+```bash
+ProjectTools/.build/arm64-apple-macosx/debug/swiftlint lint --config .swiftlint.yml
+```
+
+> CI と異なり SwiftLint をスタンドアロンで呼ぶケースは限定的です（基本は Danger 経由）。
+
+### 主要な設定（`.swiftlint.yml`）
+
+**有効化している opt-in ルール（抜粋）:**
+
+- `force_unwrapping` — 強制アンラップを警告
+- `multiline_arguments` — 複数行引数の整形
+- `trailing_closure` — トレーリングクロージャ推奨
+- `convenience_type` — `static` メンバのみの型を `enum` 化
+
+**無効化しているルール（抜粋）:**
+
+- `trailing_comma` — SwiftFormat が複数行末尾にカンマを付与する挙動と衝突するため無効化
+- `identifier_name` — 識別子名の長さ・命名規則
+- `statement_position` — `else` などの位置
+
+---
+
+## SwiftFormat と SwiftLint の住み分け
+
+両ツールはルールが一部重複しますが、本プロジェクトでは以下の方針で住み分けています。
+
+- **整形できることは SwiftFormat に任せる**: インデント、改行、引数ラップ、空行など機械的に決定できるルールは SwiftFormat が pre-commit で自動修正するため、SwiftLint 側で同じ警告を出してもノイズになる
+- **SwiftLint は構造的な品質に集中**: 強制アンラップ、未使用宣言、関数の複雑度など「人間の判断が必要な指摘」を担当
+- **衝突するルールは SwiftLint 側を無効化**: `trailing_comma` のように両者で挙動が異なるものは、自動修正される SwiftFormat の挙動を優先
+
+新たに SwiftFormat ルールを追加して SwiftLint と衝突するようになった場合は、`.swiftlint.yml` 側で当該ルールを `disabled_rules` に追加してください。
+
+---
+
+## 関連ファイル
+
+- `.swiftformat` — SwiftFormat 設定
+- `.swiftlint.yml` — SwiftLint 設定
+- `ProjectTools/Package.swift` — 両ツールの依存定義
+- `ProjectTools/Dangerfile.swift` — CI 上の SwiftLint 呼び出し
+- `scripts/git-hooks/pre-commit` — pre-commit hook 実装
+- `Makefile` — `format` / `install-hooks` ターゲット

--- a/homete/Views/HometeApp.swift
+++ b/homete/Views/HometeApp.swift
@@ -13,75 +13,73 @@ import HometeInfrastructure
 import SwiftUI
 
 final class AppDelegate: NSObject, UIApplicationDelegate {
-    
+
     let isXcodePreview = ProcessInfo.processInfo.environment["XCODE_RUNNING_FOR_PREVIEWS"] != nil
     let isUnitTestMode = ProcessInfo.processInfo.arguments.contains("isUnitTestMode")
-        
+
     func application(
-        _ application: UIApplication,
+        _: UIApplication,
         // swiftlint:disable:next discouraged_optional_collection
-        didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
+        didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        
         #if DEBUG
-        if !isXcodePreview && !isUnitTestMode {
-            
-            guard let devPlistFilePath = (
-                Bundle.main.url(
-                    forResource: "GoogleService-Info-dev",
-                    withExtension: "plist"
-                )?
-                    .path()
-            ),
-                  let firebaseOption = FirebaseOptions(contentsOfFile: devPlistFilePath) else { return true }
-            FirebaseApp.configure(options: firebaseOption)
-        }
+            if !isXcodePreview, !isUnitTestMode {
+                guard let devPlistFilePath = (
+                    Bundle.main.url(
+                        forResource: "GoogleService-Info-dev",
+                        withExtension: "plist"
+                    )?
+                        .path()
+                ),
+                    let firebaseOption = FirebaseOptions(contentsOfFile: devPlistFilePath) else { return true }
+                FirebaseApp.configure(options: firebaseOption)
+            }
         #else
-        FirebaseApp.configure()
+            FirebaseApp.configure()
         #endif
-        
+
         UNUserNotificationCenter.current().delegate = self
         Messaging.messaging().delegate = self
-        
+
         return true
     }
-    
-    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        
+
+    func application(_: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
         guard Messaging.messaging().apnsToken != deviceToken else { return }
         Messaging.messaging().setAPNSToken(deviceToken, type: .unknown)
     }
+
 }
 
 extension AppDelegate: MessagingDelegate {
-    
-    nonisolated func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
-        
+
+    nonisolated func messaging(_: Messaging, didReceiveRegistrationToken fcmToken: String?) {
         print("didReceiveRegistrationToken: \(fcmToken ?? "nil")")
         DispatchQueue.main.async {
-            
             NotificationCenter.default.post(name: .didReceiveFcmToken, object: fcmToken)
         }
     }
+
 }
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
-    
+
     nonisolated func userNotificationCenter(
-        _ center: UNUserNotificationCenter,
-        willPresent notification: UNNotification
+        _: UNUserNotificationCenter,
+        willPresent _: UNNotification
     ) async -> UNNotificationPresentationOptions {
-        return [.sound]
+        [.sound]
     }
+
 }
 
 @main
 struct HometeApp: App {
-    
+
     @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
-    
+
     @State var fcmToken: String?
-    
+
     var body: some Scene {
         WindowGroup {
             if delegate.isUnitTestMode {
@@ -91,4 +89,5 @@ struct HometeApp: App {
             }
         }
     }
+
 }

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# pre-commit hook: ステージ済みのSwiftファイルをSwiftFormatで整形し、再ステージする。
+#
+# 有効化:
+#   git config core.hooksPath scripts/git-hooks
+#   （または `make install-hooks`）
+
+set -e
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+# ステージ済みのSwiftファイル一覧（フォーマット対象外ディレクトリを除外）
+STAGED_FILES=$(git diff --cached --name-only --diff-filter=ACM \
+    | grep -E '\.swift$' \
+    | grep -vE '^(ProjectTools|DangerTools|vendor|LocalPackage/\.build)/' \
+    || true)
+
+if [ -z "$STAGED_FILES" ]; then
+    exit 0
+fi
+
+echo "🎨 SwiftFormatを実行中..."
+echo "$STAGED_FILES" | sed 's/^/  - /'
+
+# ProjectToolsのSwiftPMプラグイン経由でSwiftFormatを実行
+# （プラグインは自パッケージ内のソースも併せて処理するため
+#   --allow-writing-to-package-directory を付ける必要がある）
+echo "$STAGED_FILES" \
+    | xargs swift package --package-path ProjectTools plugin \
+        --allow-writing-to-package-directory \
+        swiftformat --config "$REPO_ROOT/.swiftformat"
+
+# 整形後のファイルを再ステージ
+echo "$STAGED_FILES" | xargs git add
+
+echo "✅ SwiftFormat完了"

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -25,11 +25,12 @@ echo "🎨 SwiftFormatを実行中..."
 echo "$STAGED_FILES" | sed 's/^/  - /'
 
 # ProjectToolsのSwiftPMプラグイン経由でSwiftFormatを実行
-# （プラグインは自パッケージ内のソースも併せて処理するため
-#   --allow-writing-to-package-directory を付ける必要がある）
+# - --allow-writing-to-package-directory: プラグインが自パッケージ内のソースを処理するため
+# - --allow-writing-to-directory: リポジトリ全体（パッケージ外）を整形対象にするため
 echo "$STAGED_FILES" \
     | xargs swift package --package-path ProjectTools plugin \
         --allow-writing-to-package-directory \
+        --allow-writing-to-directory "$REPO_ROOT" \
         swiftformat --config "$REPO_ROOT/.swiftformat"
 
 # 整形後のファイルを再ステージ

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -36,3 +36,4 @@ echo "$STAGED_FILES" \
 echo "$STAGED_FILES" | xargs git add
 
 echo "✅ SwiftFormat完了"
+


### PR DESCRIPTION
## Summary

- SwiftFormat を `ProjectTools/Package.swift` 経由で導入し、SwiftPM プラグインとして利用
- pre-commit hook（`scripts/git-hooks/pre-commit`）でステージ済み Swift ファイルを自動整形 → 再ステージ
- 手動整形用の `make format` ターゲットを追加し、プロジェクト全体（`homete/` / `hometeSnapshotTests/` / `LocalPackage/`）に整形を一括適用
- SwiftLint 側で SwiftFormat と衝突する `trailing_comma` ルールを無効化
- `doc/tech/code-style.md` に SwiftFormat と SwiftLint の役割分担・使い方を文書化し、README から参照

## 主要な設定（.swiftformat）

- `--swift-version 6`
- `--max-width 120`（SwiftLint の `line_length` 警告閾値と一致）
- `--type-blank-lines insert`（型宣言の `{` 直後に空行）
- `--wrap-arguments` / `--wrap-parameters` / `--wrap-collections` を `before-first` で統一
- 既存コードへの影響が大きい 4 ルール（`organizeDeclarations` / `markTypes` / `acronyms` / `wrapMultilineStatementBraces` / `blockComments`）は無効化

## 補足

- 既存コードへの整形コミット（`bdfdb4d`）は 225 ファイルを対象としていますが、純増減はほぼ 0 でロジック変更はありません
- pre-commit hook は `make install-hooks`（または `make setup-project`）で有効化されます

## Test plan

- [x] CI のビルド / テストが通る
- [x] `make format` がエラーなく完走する
- [x] `make install-hooks` 後、Swift ファイル変更を含む commit 時に hook が自動実行される
- [x] doc/tech/code-style.md のリンクが README から辿れる

🤖 Generated with [Claude Code](https://claude.com/claude-code)