### PR TITLE
Feat: 家事ボード画面でテンプレートも考慮した表示を行うロジックを実装

### DIFF
--- a/LocalPackage/Sources/AppRoot/AppTabView.swift
+++ b/LocalPackage/Sources/AppRoot/AppTabView.swift
@@ -7,6 +7,7 @@ import HomeFeature
 import HometeDomain
 import HometeUI
 import HouseworkFeature
+import HouseworkTemplateFeature
 import SwiftUI
 import UserNotifications
 
@@ -19,6 +20,7 @@ struct AppTabView: View {
     @State var cohabitantStore: CohabitantStore?
     @State var contributionStore: ContributionStore?
     @State var houseworkListStore: HouseworkListStore?
+    @State var houseworkTemplateListStore: HouseworkTemplateListStore?
     @State var type: TabType = .dashboard
 
     var body: some View {
@@ -32,6 +34,10 @@ struct AppTabView: View {
             .environment(
                 \.cohabitantMembers,
                 cohabitantStore?.members ?? .init(value: [], ownId: "")
+            )
+            .environment(
+                \.houseworkTemplateContext,
+                houseworkTemplateListStore?.context ?? .init(houseworkTemplate: [])
             )
     }
 
@@ -50,33 +56,27 @@ private extension AppTabView {
                         systemImage: "list.bullet.clipboard.fill",
                         value: .dashboard
                     ) {
-                        HomeView.make(
-                            contributionStore: contributionStore,
-                            cohabitantStore: cohabitantStore
-                        )
+                        homeScreen
                     }
                     Tab(
                         "家事",
                         systemImage: "person.2.arrow.trianglehead.counterclockwise",
                         value: .homework
                     ) {
-                        HouseworkBoardScreen.make(houseworkListStore: houseworkListStore)
+                        houseworkBoardScreen
                     }
                 }
             } else {
                 TabView(selection: $type) {
-                    HomeView.make(
-                        contributionStore: contributionStore,
-                        cohabitantStore: cohabitantStore
-                    )
-                    .tag(TabType.dashboard)
-                    .tabItem {
-                        Label(
-                            "ダッシュボード",
-                            systemImage: "list.bullet.clipboard.fill"
-                        )
-                    }
-                    HouseworkBoardScreen.make(houseworkListStore: houseworkListStore)
+                    homeScreen
+                        .tag(TabType.dashboard)
+                        .tabItem {
+                            Label(
+                                "ダッシュボード",
+                                systemImage: "list.bullet.clipboard.fill"
+                            )
+                        }
+                    houseworkBoardScreen
                         .tag(TabType.homework)
                         .tabItem {
                             Label(
@@ -87,6 +87,21 @@ private extension AppTabView {
                 }
             }
         }
+    }
+
+    var homeScreen: some View {
+        HomeView.make(
+            contributionStore: contributionStore,
+            cohabitantStore: cohabitantStore,
+            houseworkTemplateListStore: houseworkTemplateListStore
+        )
+    }
+
+    var houseworkBoardScreen: some View {
+        HouseworkBoardScreen.make(
+            houseworkListStore: houseworkListStore,
+            houseworkTemplateListStore: houseworkTemplateListStore
+        )
     }
 
 }
@@ -143,6 +158,9 @@ private extension AppTabView {
             houseworkClient: appDependencies.houseworkClient,
             cohabitantPushNotificationClient: appDependencies.cohabitantPushNotificationClient,
             houseworkManager: appDependencies.houseworkManager
+        )
+        houseworkTemplateListStore = .init(
+            houseworkTemplateClient: appDependencies.houseworkTemplateClient
         )
     }
 

--- a/LocalPackage/Sources/Features/HomeFeature/HomeView/HomeView.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/HomeView/HomeView.swift
@@ -21,16 +21,19 @@ public struct HomeView: View {
     @State var isShowSetting = false
     let contributionStore: ContributionStore?
     let cohabitantStore: CohabitantStore?
+    let houseworkTemplateListStore: HouseworkTemplateListStore?
 
     public var body: some View {
         NavigationStack {
             ZStack {
                 if loginContext.hasCohabitant,
                    let contributionStore,
-                   let cohabitantStore {
+                   let cohabitantStore,
+                   let houseworkTemplateListStore {
                     RegisteredContent()
                         .environment(contributionStore)
                         .environment(cohabitantStore)
+                        .environment(houseworkTemplateListStore)
                         .task {
                             await didAppearRegisteredContent(cohabitantStore: cohabitantStore)
                         }
@@ -63,11 +66,13 @@ public extension HomeView {
 
     static func make(
         contributionStore: ContributionStore?,
-        cohabitantStore: CohabitantStore?
+        cohabitantStore: CohabitantStore?,
+        houseworkTemplateListStore: HouseworkTemplateListStore?
     ) -> some View {
         HomeView(
             contributionStore: contributionStore,
-            cohabitantStore: cohabitantStore
+            cohabitantStore: cohabitantStore,
+            houseworkTemplateListStore: houseworkTemplateListStore
         )
     }
 

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
@@ -12,12 +12,20 @@ public struct HouseworkBoardScreen: View {
 
     @Environment(\.calendar) var calendar
 
-    @State var houseworkListStore: HouseworkListStore?
     @State var houseworkBoardList: HouseworkBoardList = .init(items: [])
     @State var dateList = HouseworkDateList()
 
-    public static func make(houseworkListStore: HouseworkListStore?) -> some View {
-        HouseworkBoardScreen(houseworkListStore: houseworkListStore)
+    let houseworkListStore: HouseworkListStore?
+    let houseworkTemplateListStore: HouseworkTemplateListStore?
+
+    public static func make(
+        houseworkListStore: HouseworkListStore?,
+        houseworkTemplateListStore: HouseworkTemplateListStore?
+    ) -> some View {
+        HouseworkBoardScreen(
+            houseworkListStore: houseworkListStore,
+            houseworkTemplateListStore: houseworkTemplateListStore
+        )
     }
 
     public var body: some View {
@@ -27,6 +35,7 @@ public struct HouseworkBoardScreen: View {
                 dateList: $dateList
             )
             .environment(houseworkListStore)
+            .environment(houseworkTemplateListStore)
             .onAppear {
                 withAnimation {
                     onAppeare(with: houseworkListStore)

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 public struct HouseworkBoardScreen: View {
 
+    @Environment(\.calendar) var calendar
+
     @State var houseworkListStore: HouseworkListStore?
     @State var houseworkBoardList: HouseworkBoardList = .init(items: [])
     @State var dateList = HouseworkDateList()
@@ -48,7 +50,10 @@ private extension HouseworkBoardScreen {
     func onAppeare(with store: HouseworkListStore) {
         houseworkBoardList = .init(
             dailyList: store.items.value,
-            selectedDate: dateList.selectedDate
+            selectedDateTemplate: .init(dayOfWeek: 1, items: []), // TODO: Storeから現在の日付のテンプレートを取得
+            selectedDate: dateList.selectedDate,
+            calendar: calendar,
+            uuidGenerator: { UUID() }
         )
     }
 

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardScreen.swift
@@ -11,6 +11,7 @@ import SwiftUI
 public struct HouseworkBoardScreen: View {
 
     @Environment(\.calendar) var calendar
+    @Environment(\.houseworkTemplateContext) var templateContext
 
     @State var houseworkBoardList: HouseworkBoardList = .init(items: [])
     @State var dateList = HouseworkDateList()
@@ -33,7 +34,9 @@ public struct HouseworkBoardScreen: View {
             HouseworkBoardView(
                 houseworkBoardList: $houseworkBoardList,
                 dateList: $dateList
-            )
+            ) {
+                updateHouseboardList(with: houseworkListStore)
+            }
             .environment(houseworkListStore)
             .environment(houseworkTemplateListStore)
             .onAppear {
@@ -57,9 +60,14 @@ public struct HouseworkBoardScreen: View {
 private extension HouseworkBoardScreen {
 
     func onAppeare(with store: HouseworkListStore) {
+        updateHouseboardList(with: store)
+    }
+
+    func updateHouseboardList(with store: HouseworkListStore) {
+        let selectedDate = dateList.selectedDate
         houseworkBoardList = .init(
             dailyList: store.items.value,
-            selectedDateTemplate: .init(dayOfWeek: 1, items: []), // TODO: Storeから現在の日付のテンプレートを取得
+            selectedDateTemplate: templateContext.templateOfDay(by: selectedDate, calendar: calendar),
             selectedDate: dateList.selectedDate,
             calendar: calendar,
             uuidGenerator: { UUID() }

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
@@ -14,6 +14,7 @@ struct HouseworkBoardView: View {
     @Environment(\.calendar) var calendar
     @Environment(\.now) var anchorDate
     @Environment(\.routeResolver) var router
+    @Environment(\.houseworkTemplateContext) var templateContext
     @Environment(HouseworkListStore.self) var houseworkListStore
 
     @Binding var houseworkBoardList: HouseworkBoardList
@@ -23,6 +24,8 @@ struct HouseworkBoardView: View {
     @State var selectedHouseworkState = HouseworkState.incomplete
     @State var isPresentingAddHouseworkView = false
     @State var isShowHouseworkTemplate = false
+
+    let onUpdateHouseboardList: () -> Void
 
     var body: some View {
         NavigationStack(path: $navigationPath.path) {
@@ -81,12 +84,12 @@ struct HouseworkBoardView: View {
         }
         .onChange(of: houseworkListStore.items) {
             withAnimation {
-                updateHouseworkBoardList()
+                onUpdateHouseboardList()
             }
         }
         .onChange(of: dateList.selectedDate) {
             withAnimation {
-                updateHouseworkBoardList()
+                onUpdateHouseboardList()
             }
         }
     }
@@ -115,20 +118,6 @@ private extension HouseworkBoardView {
 
 }
 
-private extension HouseworkBoardView {
-
-    func updateHouseworkBoardList() {
-        houseworkBoardList = .init(
-            dailyList: houseworkListStore.items.value,
-            selectedDateTemplate: .init(dayOfWeek: 1, items: []), // TODO: Storeから現在の日付のテンプレートを取得
-            selectedDate: dateList.selectedDate,
-            calendar: calendar,
-            uuidGenerator: { UUID() }
-        )
-    }
-
-}
-
 #if DEBUG
     #Preview {
         let list = HouseworkBoardList(items: [
@@ -148,7 +137,8 @@ private extension HouseworkBoardView {
                 anchorDate: .distantPast,
                 selectedDate: .distantPast,
                 calendar: .japanese
-            ))
+            )),
+            onUpdateHouseboardList: {}
         )
         .apply(theme: .init())
         .setupEnvironmentForPreview()

--- a/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/HouseworkBoardView/HouseworkBoardView.swift
@@ -120,7 +120,10 @@ private extension HouseworkBoardView {
     func updateHouseworkBoardList() {
         houseworkBoardList = .init(
             dailyList: houseworkListStore.items.value,
-            selectedDate: dateList.selectedDate
+            selectedDateTemplate: .init(dayOfWeek: 1, items: []), // TODO: Storeから現在の日付のテンプレートを取得
+            selectedDate: dateList.selectedDate,
+            calendar: calendar,
+            uuidGenerator: { UUID() }
         )
     }
 

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkBoardList.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/HouseworkBoardList.swift
@@ -22,12 +22,28 @@ extension HouseworkBoardList {
 
     init(
         dailyList: [DailyHouseworkList],
-        selectedDate: Date
+        selectedDateTemplate: HouseworkTemplateDay?,
+        selectedDate: Date,
+        calendar: Calendar,
+        uuidGenerator: () -> UUID
     ) {
-        items = dailyList
+        let items = dailyList
             .first {
                 $0.metaData.indexedDate == .init(value: selectedDate)
             }?.items ?? []
+
+        // テンプレートが存在するときは、条件に合ったテンプレートの家事を未完了で追加する
+        guard let selectedDateTemplate else {
+            self.items = items
+            return
+        }
+
+        self.items = selectedDateTemplate.applyTemplate(
+            registeredItems: items,
+            selectedDate: selectedDate,
+            calendar: calendar,
+            uuidGenerator: uuidGenerator
+        )
     }
 
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkItem.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/Housework/HouseworkItem.swift
@@ -162,7 +162,8 @@ public extension HouseworkItem {
         executedAt: Date? = nil,
         reviewerId: String? = nil,
         approvedAt: Date? = nil,
-        reviewerComment: String? = nil
+        reviewerComment: String? = nil,
+        templateHouseworkItemId: HouseworkTemplateItem.ItemId? = nil
     ) {
         self.init(
             id: id,
@@ -176,7 +177,7 @@ public extension HouseworkItem {
             approvedAt: approvedAt,
             reviewerComment: reviewerComment,
             expiredAt: metaData.expiredAt,
-            templateHouseworkItemId: nil
+            templateHouseworkItemId: templateHouseworkItemId
         )
     }
 

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateContext.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateContext.swift
@@ -1,0 +1,30 @@
+//
+//  HouseworkTemplateContext.swift
+//  LocalPackage
+//
+//  Created by Taichi Sato on 2026/05/14.
+//
+
+import Foundation
+
+public struct HouseworkTemplateContext {
+
+    public let houseworkTemplate: [HouseworkTemplateDay]
+
+    /// テンプレートが設定されているかどうか
+    public var hasTemplate: Bool {
+        !houseworkTemplate.isEmpty
+    }
+
+    public init(houseworkTemplate: [HouseworkTemplateDay]) {
+        self.houseworkTemplate = houseworkTemplate
+    }
+
+    /// 指定日付のテンプレートを返す
+    public func templateOfDay(by date: Date, calendar: Calendar) -> HouseworkTemplateDay? {
+        houseworkTemplate.first {
+            calendar.component(.weekday, from: date) == $0.dayOfWeek
+        }
+    }
+
+}

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateDay.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateDay.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public struct HouseworkTemplateDay: Codable, Sendable, Equatable, Hashable {
 
     /// 曜日 (0=日曜, 6=土曜)
@@ -7,6 +9,32 @@ public struct HouseworkTemplateDay: Codable, Sendable, Equatable, Hashable {
     public init(dayOfWeek: Int, items: [HouseworkTemplateItem]) {
         self.dayOfWeek = dayOfWeek
         self.items = items
+    }
+
+    public func applyTemplate(
+        registeredItems: [HouseworkItem],
+        selectedDate: Date,
+        calendar: Calendar,
+        uuidGenerator: () -> UUID
+    ) -> [HouseworkItem] {
+        let incompleteTemplateItems = items.filter { item in
+            // 登録されている家事の中で、すでにテンプレートから生成された家事があれば重複しないように弾く
+            let isNotDistinct = !registeredItems.contains { $0.templateHouseworkItemId == item.id }
+            // テンプレートの家事の更新日付よりも古い日付の場合は表示しない
+            let isNotOldTemplateItem = calendar.startOfDay(for: selectedDate) >= calendar
+                .startOfDay(for: item.updatedAt)
+            return isNotDistinct && isNotOldTemplateItem
+        }
+        .map {
+            HouseworkItem(
+                id: uuidGenerator().uuidString,
+                title: $0.title,
+                point: $0.point,
+                metaData: .init(selectedDate: selectedDate, calendar: calendar),
+                templateHouseworkItemId: $0.id
+            )
+        }
+        return registeredItems + incompleteTemplateItems
     }
 
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
@@ -5,17 +5,18 @@
 //  Created by Taichi Sato on 2026/05/09.
 //
 
-import HometeDomain
 import Observation
 
 @MainActor
 @Observable
-final class HouseworkTemplateListStore {
+public final class HouseworkTemplateListStore {
 
     private(set) var templates: [HouseworkTemplateMeta]
-    private(set) var selectedDays: [HouseworkTemplateDay]
+    public private(set) var selectedDays: [HouseworkTemplateDay]
 
     private let houseworkTemplateClient: HouseworkTemplateClient
+    
+    public var context: HouseworkTemplateContext { .init(houseworkTemplate: selectedDays) }
 
     public init(
         houseworkTemplateClient: HouseworkTemplateClient = .previewValue,
@@ -29,19 +30,19 @@ final class HouseworkTemplateListStore {
     }
 
     /// テンプレート一覧をワンショット取得する
-    func loadTemplates(cohabitantId: String) async throws {
+    public func loadTemplates(cohabitantId: String) async throws {
 
         templates = try await houseworkTemplateClient.fetchTemplates(cohabitantId)
     }
 
     /// 指定テンプレートの曜日別定義をワンショット取得する
-    func loadDays(templateId: String, cohabitantId: String) async throws {
+    public func loadDays(templateId: String, cohabitantId: String) async throws {
 
         selectedDays = try await houseworkTemplateClient.fetchDays(cohabitantId, templateId)
     }
 
     /// 新規テンプレートを作成する
-    func createTemplate(
+    public func createTemplate(
         templateId: String,
         name: String,
         cohabitantId: String

--- a/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/HouseworkItemHelper.swift
+++ b/LocalPackage/Sources/HometeDomain/Utilities/DebugHelper/HouseworkItemHelper.swift
@@ -41,6 +41,36 @@ import Foundation
             )
         }
 
+        static func makeForTest(
+            id: String,
+            indexedDate: Date = .now,
+            title: String = "title",
+            point: Int = 100,
+            state: HouseworkState = .incomplete,
+            executorId: String? = nil,
+            executedAt: Date? = nil,
+            reviewerId: String? = nil,
+            approvedAt: Date? = nil,
+            reviewerComment: String? = nil,
+            expiredAt: Date = .now,
+            templateHouseworkItemId: HouseworkTemplateItem.ItemId? = nil
+        ) -> Self {
+            .init(
+                id: id,
+                indexedDate: .init(value: indexedDate),
+                title: title,
+                point: point,
+                state: state,
+                executorId: executorId,
+                executedAt: executedAt,
+                reviewerId: reviewerId,
+                approvedAt: approvedAt,
+                reviewerComment: reviewerComment,
+                expiredAt: expiredAt,
+                templateHouseworkItemId: templateHouseworkItemId
+            )
+        }
+
         func updateProperties(
             indexedDate: HouseworkIndexedDate? = nil,
             title: String? = nil,

--- a/LocalPackage/Sources/HometeUI/Components/Environment/HouseworkTemplateContext+Environment.swift
+++ b/LocalPackage/Sources/HometeUI/Components/Environment/HouseworkTemplateContext+Environment.swift
@@ -1,0 +1,16 @@
+//
+//  HouseworkTemplateContext+Environment.swift
+//  LocalPackage
+//
+//  Created by Taichi Sato on 2026/05/14.
+//
+
+import HometeDomain
+import SwiftUI
+
+public extension EnvironmentValues {
+
+    /// 現在洗濯中のテンプレートのコンテキスト
+    @Entry var houseworkTemplateContext: HouseworkTemplateContext = .init(houseworkTemplate: [])
+
+}

--- a/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateContextTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateContextTest.swift
@@ -1,0 +1,56 @@
+//
+//  HouseworkTemplateContextTest.swift
+//  LocalPackage
+//
+//  Created by Taichi Sato on 2026/05/14.
+//
+
+import Foundation
+@testable import HometeDomain
+import Testing
+
+struct HouseworkTemplateContextTest {
+
+    @Test(
+        "指定した日付に対応した曜日のテンプレートを返す",
+        arguments: (1 ... 7).map {
+            Date.previewDate(year: 2026, month: 1, day: $0)
+        }
+    )
+    func templateOfDay(inputDate: Date) throws {
+        // Arrange
+        let calendar = Calendar.japanese
+        let context = HouseworkTemplateContext(houseworkTemplate: [
+            .init(dayOfWeek: 1, items: [
+                .init(id: .init(id: "1"), title: "1", point: 1, updatedAt: .now),
+            ]),
+            .init(dayOfWeek: 2, items: [
+                .init(id: .init(id: "2"), title: "2", point: 2, updatedAt: .now),
+            ]),
+            .init(dayOfWeek: 3, items: [
+                .init(id: .init(id: "3"), title: "3", point: 3, updatedAt: .now),
+            ]),
+            .init(dayOfWeek: 4, items: [
+                .init(id: .init(id: "4"), title: "4", point: 4, updatedAt: .now),
+            ]),
+            .init(dayOfWeek: 5, items: [
+                .init(id: .init(id: "5"), title: "5", point: 5, updatedAt: .now),
+            ]),
+            .init(dayOfWeek: 6, items: [
+                .init(id: .init(id: "6"), title: "6", point: 6, updatedAt: .now),
+            ]),
+            .init(dayOfWeek: 7, items: [
+                .init(id: .init(id: "7"), title: "7", point: 7, updatedAt: .now),
+            ]),
+        ])
+
+        // Act
+        let actual = context.templateOfDay(by: inputDate, calendar: calendar)
+
+        // Assert
+        let dayOfWeek = calendar.component(.weekday, from: inputDate)
+        let expected = try #require(context.houseworkTemplate.first { $0.dayOfWeek == dayOfWeek })
+        #expect(actual == expected)
+    }
+
+}

--- a/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateDayTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateDayTest.swift
@@ -1,0 +1,98 @@
+//
+//  HouseworkTemplateDayTest.swift
+//  LocalPackage
+//
+//  Created by Taichi Sato on 2026/05/14.
+//
+
+import Foundation
+@testable import HometeDomain
+import Testing
+
+struct HouseworkTemplateDayTest {
+
+    private let inputTemplateItems: [HouseworkTemplateItem] = [
+        .init(
+            id: .init(id: "id1"),
+            title: "1",
+            point: 10,
+            updatedAt: .previewDate(year: 2026, month: 1, day: 1)
+        ),
+        .init(
+            id: .init(id: "id2"),
+            title: "2",
+            point: 10,
+            updatedAt: .previewDate(year: 2026, month: 1, day: 2)
+        ),
+        .init(
+            id: .init(id: "id3"),
+            title: "3",
+            point: 10,
+            updatedAt: .previewDate(year: 2026, month: 1, day: 3)
+        ),
+        .init(
+            id: .init(id: "id4"),
+            title: "4",
+            point: 10,
+            updatedAt: .previewDate(year: 2026, month: 1, day: 4)
+        ),
+        .init(
+            id: .init(id: "id5"),
+            title: "5",
+            point: 10,
+            updatedAt: .previewDate(year: 2026, month: 1, day: 5)
+        ),
+    ]
+
+    @Test("すでに登録されているテンプレート家事と指定日付より古いテンプレートの家事は表示する家事に適用しない")
+    func applyTemplate() throws {
+        // Arrange
+        let template = HouseworkTemplateDay(
+            dayOfWeek: 1,
+            items: inputTemplateItems
+        )
+
+        let registeredItems: [HouseworkItem] = [
+            .makeForTest(id: 3, state: .completed, templateHouseworkItemId: .init(id: "id3")),
+            .makeForTest(id: 4, state: .completed, templateHouseworkItemId: .init(id: "id4")),
+            .makeForTest(id: 10),
+        ]
+
+        let selectedDate = Date.previewDate(year: 2026, month: 1, day: 4)
+        let uuid = UUID()
+
+        // Act
+        let actual = template.applyTemplate(
+            registeredItems: registeredItems,
+            selectedDate: selectedDate,
+            calendar: .japanese,
+            uuidGenerator: { uuid }
+        )
+
+        // Assert
+        let expectedExpired = try #require(Calendar.japanese.date(byAdding: .year, value: 1, to: selectedDate))
+        let expected: [HouseworkItem] = registeredItems + [
+            .makeForTest(
+                id: uuid.uuidString,
+                indexedDate: selectedDate,
+                title: "1",
+                point: 10,
+                state: .incomplete,
+                expiredAt: expectedExpired,
+                templateHouseworkItemId: .init(id: "id1")
+            ),
+            .makeForTest(
+                id: uuid.uuidString,
+                indexedDate: selectedDate,
+                title: "2",
+                point: 10,
+                state: .incomplete,
+                expiredAt: expectedExpired,
+                templateHouseworkItemId: .init(id: "id2")
+            ),
+        ]
+
+        #expect(actual == expected)
+    }
+
+}

--- a/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
@@ -6,7 +6,6 @@
 //
 
 @testable import HometeDomain
-@testable import HouseworkTemplateFeature
 import Testing
 
 @MainActor

--- a/LocalPackage/Tests/HouseworkFeatureTests/HouseworkBoardListTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/HouseworkBoardListTest.swift
@@ -42,7 +42,10 @@ struct HouseworkBoardListTest {
         // Act
         let actual = HouseworkBoardList(
             dailyList: inputList,
-            selectedDate: selectTime
+            selectedDateTemplate: nil,
+            selectedDate: selectTime,
+            calendar: .japanese,
+            uuidGenerator: { UUID() }
         )
 
         // Assert
@@ -60,7 +63,10 @@ struct HouseworkBoardListTest {
         let inputHouseworkItem = makeHouseworkItemListWithAllState(targetDate)
         let houseworkBoardList = HouseworkBoardList(
             dailyList: [.makeForTest(items: inputHouseworkItem)],
-            selectedDate: targetDate
+            selectedDateTemplate: nil,
+            selectedDate: targetDate,
+            calendar: .japanese,
+            uuidGenerator: { UUID() }
         )
 
         // Act


### PR DESCRIPTION
## 経緯

<!-- PRを作成するに至った経緯や関連のIssueのリンクを記載する -->
関連Issue: #67 

## 実装内容

<!-- なぜそのような実装を行なったかがわかるように、理由に重きを置いて記載する -->
登録されている家事のリストとテンプレートをマージして、ボード画面に表示する家事一覧を取得するロジックを実装

## 確認内容

<!-- 修正した内容が正しく動作していることを確認する方法とその内容を記載する -->
- [x] テストが通ること
