### PR TITLE
feat: テンプレート編集の保存処理を複数曜日一括対応に変更

### DIFF
--- a/LocalPackage/Sources/AppRoot/Dependency/Impl/ImplHouseworkTemplateClient.swift
+++ b/LocalPackage/Sources/AppRoot/Dependency/Impl/ImplHouseworkTemplateClient.swift
@@ -6,9 +6,11 @@ extension HouseworkTemplateClient {
 
     static let liveValue = HouseworkTemplateClient(
         fetchTemplates: { cohabitantId in
-            try await FirestoreService.shared.fetch { firestore in
-                firestore.houseworkTemplatesRef(cohabitantId: cohabitantId)
-            }
+            let documents: [HouseworkTemplateMetaDocument] = try await FirestoreService.shared
+                .fetch { firestore in
+                    firestore.houseworkTemplatesRef(cohabitantId: cohabitantId)
+                }
+            return documents.map { HouseworkTemplateMeta(templateId: $0.templateId, name: $0.name) }
         },
         fetchDays: { cohabitantId, templateId in
             try await FirestoreService.shared.fetch { firestore in
@@ -16,7 +18,12 @@ extension HouseworkTemplateClient {
             }
         },
         upsertTemplate: { meta, cohabitantId in
-            try await FirestoreService.shared.insertOrUpdate(data: meta) { firestore in
+            let document = HouseworkTemplateMetaDocument(
+                templateId: meta.templateId,
+                name: meta.name,
+                version: 0
+            )
+            try await FirestoreService.shared.insertOrUpdate(data: document) { firestore in
                 firestore.houseworkTemplatesRef(cohabitantId: cohabitantId).document(meta.templateId)
             }
         },
@@ -25,20 +32,22 @@ extension HouseworkTemplateClient {
                 let metaRef = Firestore.firestore()
                     .houseworkTemplatesRef(cohabitantId: cohabitantId)
                     .document(templateId)
-                let meta = try transaction.getDocument(metaRef).data(as: HouseworkTemplateMeta.self)
-                guard meta.version == currentVersion else {
+                let metaDocument = try transaction
+                    .getDocument(metaRef)
+                    .data(as: HouseworkTemplateMetaDocument.self)
+                guard metaDocument.version == currentVersion else {
                     throw HouseworkTemplateError.versionConflict
                 }
                 let dayRef = Firestore.firestore()
                     .houseworkTemplateDaysRef(cohabitantId: cohabitantId, templateId: templateId)
                     .document("\(day.dayOfWeek)")
                 try transaction.setData(from: day, forDocument: dayRef)
-                let updatedMeta = HouseworkTemplateMeta(
-                    templateId: meta.templateId,
-                    name: meta.name,
-                    version: meta.version + 1
+                let updatedDocument = HouseworkTemplateMetaDocument(
+                    templateId: metaDocument.templateId,
+                    name: metaDocument.name,
+                    version: metaDocument.version + 1
                 )
-                try transaction.setData(from: updatedMeta, forDocument: metaRef)
+                try transaction.setData(from: updatedDocument, forDocument: metaRef)
             }
         },
         upsertEditor: { editor, templateId, cohabitantId in
@@ -62,6 +71,22 @@ extension HouseworkTemplateClient {
             await FirestoreService.shared.addSnapshotListener(id: id) { firestore in
                 firestore.houseworkTemplateEditorsRef(cohabitantId: cohabitantId, templateId: templateId)
             }
+        },
+        addMetaVersionSnapshotListener: { id, templateId, cohabitantId in
+            let documentStream: AsyncStream<HouseworkTemplateMetaDocument?> = await FirestoreService
+                .shared
+                .addSnapshotListener(id: id) { firestore in
+                    firestore.houseworkTemplatesRef(cohabitantId: cohabitantId).document(templateId)
+                }
+            let (versionStream, continuation) = AsyncStream<Int>.makeStream()
+            Task {
+                for await document in documentStream {
+                    guard let document else { continue }
+                    continuation.yield(document.version)
+                }
+                continuation.finish()
+            }
+            return versionStream
         },
         removeListener: { id in
             await FirestoreService.shared.removeSnapshotListener(id: id)

--- a/LocalPackage/Sources/AppRoot/Dependency/Impl/ImplHouseworkTemplateClient.swift
+++ b/LocalPackage/Sources/AppRoot/Dependency/Impl/ImplHouseworkTemplateClient.swift
@@ -27,7 +27,7 @@ extension HouseworkTemplateClient {
                 firestore.houseworkTemplatesRef(cohabitantId: cohabitantId).document(meta.templateId)
             }
         },
-        updateDay: { day, templateId, cohabitantId, currentVersion in
+        updateDays: { days, templateId, cohabitantId, currentVersion in
             try await FirestoreService.shared.runTransaction { transaction in
                 let metaRef = Firestore.firestore()
                     .houseworkTemplatesRef(cohabitantId: cohabitantId)
@@ -38,10 +38,12 @@ extension HouseworkTemplateClient {
                 guard metaDocument.version == currentVersion else {
                     throw HouseworkTemplateError.versionConflict
                 }
-                let dayRef = Firestore.firestore()
+                let daysRef = Firestore.firestore()
                     .houseworkTemplateDaysRef(cohabitantId: cohabitantId, templateId: templateId)
-                    .document("\(day.dayOfWeek)")
-                try transaction.setData(from: day, forDocument: dayRef)
+                for day in days {
+                    let dayRef = daysRef.document("\(day.dayOfWeek)")
+                    try transaction.setData(from: day, forDocument: dayRef)
+                }
                 let updatedDocument = HouseworkTemplateMetaDocument(
                     templateId: metaDocument.templateId,
                     name: metaDocument.name,

--- a/LocalPackage/Sources/Features/HouseworkTemplateFeature/Stores/HouseworkTemplateEditStore.swift
+++ b/LocalPackage/Sources/Features/HouseworkTemplateFeature/Stores/HouseworkTemplateEditStore.swift
@@ -13,87 +13,78 @@ import Observation
 @Observable
 final class HouseworkTemplateEditStore {
 
-    private(set) var days: [HouseworkTemplateDay]
     private(set) var editors: [HouseworkTemplateEditor]
     private(set) var currentVersion: Int
 
-    private var daysObserveTask: Task<Void, Never>?
     private var editorsObserveTask: Task<Void, Never>?
+    private var metaVersionObserveTask: Task<Void, Never>?
     private var keepaliveTask: Task<Void, Never>?
 
     private let houseworkTemplateClient: HouseworkTemplateClient
 
-    private let daysListenerKey = "houseworkTemplateDaysListener"
     private let editorsListenerKey = "houseworkTemplateEditorsListener"
-    
-    // Editor ドキュメントの TTL（5分）
+    private let metaVersionListenerKey = "houseworkTemplateMetaVersionListener"
+
+    /// Editor ドキュメントの TTL（5分）
     private static let editorTTL: TimeInterval = 5 * 60
 
-    public init(
+    init(
         houseworkTemplateClient: HouseworkTemplateClient = .previewValue,
-        days: [HouseworkTemplateDay] = [],
         editors: [HouseworkTemplateEditor] = [],
         currentVersion: Int = 0
     ) {
-
         self.houseworkTemplateClient = houseworkTemplateClient
-        self.days = days
         self.editors = editors
         self.currentVersion = currentVersion
     }
 
-    /// 編集モードを開始する。Days と Editors の SnapshotListener を張り、自身を Editor として登録する
+    /// 編集モードを開始する。Editors・Meta version の SnapshotListener を張り、自身を Editor として登録する
     /// - Parameters:
-    ///   - meta: 編集対象のテンプレートメタ（version の初期値として使う）
+    ///   - templateId: 編集対象のテンプレートID
     ///   - cohabitantId: 同居人ID
     ///   - userId: 編集中ユーザーID
     ///   - now: 現在時刻
     ///   - keepaliveInterval: Editor の updatedAt を再upsertする周期（nil で無効化、デフォルト1分）
     func startEditing(
-        meta: HouseworkTemplateMeta,
+        templateId: String,
         cohabitantId: String,
         userId: String,
         now: Date,
         keepaliveInterval: TimeInterval = 60
     ) async throws {
-
-        currentVersion = meta.version
-
         let editor = HouseworkTemplateEditor(
             userId: userId,
             updatedAt: now,
             expiredAt: now.addingTimeInterval(Self.editorTTL)
         )
-        try await houseworkTemplateClient.upsertEditor(editor, meta.templateId, cohabitantId)
-
-        let daysStream = await houseworkTemplateClient.addDaysSnapshotListener(
-            daysListenerKey,
-            meta.templateId,
-            cohabitantId
-        )
-        daysObserveTask = Task {
-
-            for await currentDays in daysStream {
-
-                self.days = currentDays
-            }
-        }
+        try await houseworkTemplateClient.upsertEditor(editor, templateId, cohabitantId)
 
         let editorsStream = await houseworkTemplateClient.addEditorsSnapshotListener(
             editorsListenerKey,
-            meta.templateId,
+            templateId,
             cohabitantId
         )
         editorsObserveTask = Task {
 
             for await currentEditors in editorsStream {
-
                 self.editors = currentEditors
             }
         }
 
+        let metaVersionStream = await houseworkTemplateClient.addMetaVersionSnapshotListener(
+            metaVersionListenerKey,
+            templateId,
+            cohabitantId
+        )
+        metaVersionObserveTask = Task {
+
+            for await version in metaVersionStream {
+                self.currentVersion = version
+            }
+        }
+
         startKeepalive(
-            templateId: meta.templateId,
+            templateId: templateId,
             cohabitantId: cohabitantId,
             userId: userId,
             editorTTL: Self.editorTTL,
@@ -107,36 +98,19 @@ final class HouseworkTemplateEditStore {
         cohabitantId: String,
         userId: String
     ) async {
-
-        daysObserveTask?.cancel()
         editorsObserveTask?.cancel()
+        metaVersionObserveTask?.cancel()
         keepaliveTask?.cancel()
-        daysObserveTask = nil
         editorsObserveTask = nil
+        metaVersionObserveTask = nil
         keepaliveTask = nil
 
-        await houseworkTemplateClient.removeListener(daysListenerKey)
         await houseworkTemplateClient.removeListener(editorsListenerKey)
+        await houseworkTemplateClient.removeListener(metaVersionListenerKey)
 
         try? await houseworkTemplateClient.removeEditor(userId, templateId, cohabitantId)
     }
 
-    /// 曜日定義を保存する。version の楽観的ロックで競合が発生した場合は HouseworkTemplateError.versionConflict を throw する。
-    /// 保存成功後の `days` プロパティの更新は Days SnapshotListener による反映に委ねる（ローカルでは更新しない）
-    func saveDay(
-        _ day: HouseworkTemplateDay,
-        templateId: String,
-        cohabitantId: String
-    ) async throws {
-
-        try await houseworkTemplateClient.updateDay(
-            day,
-            templateId,
-            cohabitantId,
-            currentVersion
-        )
-        currentVersion += 1
-    }
 }
 
 private extension HouseworkTemplateEditStore {
@@ -148,14 +122,11 @@ private extension HouseworkTemplateEditStore {
         editorTTL: TimeInterval,
         keepaliveInterval: TimeInterval
     ) {
-
         keepaliveTask = Task {
-
             while !Task.isCancelled {
-
                 try? await Task.sleep(for: .seconds(keepaliveInterval))
                 guard !Task.isCancelled else { break }
-                
+
                 let updatedAt = Date()
                 let updated = HouseworkTemplateEditor(
                     userId: userId,
@@ -163,17 +134,16 @@ private extension HouseworkTemplateEditStore {
                     expiredAt: updatedAt.addingTimeInterval(editorTTL)
                 )
                 do {
-
                     try await houseworkTemplateClient.upsertEditor(
                         updated,
                         templateId,
                         cohabitantId
                     )
                 } catch {
-
                     print("keepalive upsertEditor failed: \(error)")
                 }
             }
         }
     }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
@@ -14,16 +14,20 @@ public final class HouseworkTemplateListStore {
     private(set) var templates: [HouseworkTemplateMeta]
     public private(set) var selectedDays: [HouseworkTemplateDay]
 
+    private var daysObserveTask: Task<Void, Never>?
+
     private let houseworkTemplateClient: HouseworkTemplateClient
-    
-    public var context: HouseworkTemplateContext { .init(houseworkTemplate: selectedDays) }
+    private let daysListenerKey = "houseworkTemplateDaysListener"
+
+    public var context: HouseworkTemplateContext {
+        .init(houseworkTemplate: selectedDays)
+    }
 
     public init(
         houseworkTemplateClient: HouseworkTemplateClient = .previewValue,
         templates: [HouseworkTemplateMeta] = [],
         selectedDays: [HouseworkTemplateDay] = []
     ) {
-
         self.houseworkTemplateClient = houseworkTemplateClient
         self.templates = templates
         self.selectedDays = selectedDays
@@ -31,13 +35,11 @@ public final class HouseworkTemplateListStore {
 
     /// テンプレート一覧をワンショット取得する
     public func loadTemplates(cohabitantId: String) async throws {
-
         templates = try await houseworkTemplateClient.fetchTemplates(cohabitantId)
     }
 
     /// 指定テンプレートの曜日別定義をワンショット取得する
     public func loadDays(templateId: String, cohabitantId: String) async throws {
-
         selectedDays = try await houseworkTemplateClient.fetchDays(cohabitantId, templateId)
     }
 
@@ -47,13 +49,56 @@ public final class HouseworkTemplateListStore {
         name: String,
         cohabitantId: String
     ) async throws {
-
         let newMeta = HouseworkTemplateMeta(
             templateId: templateId,
-            name: name,
-            version: 0
+            name: name
         )
         try await houseworkTemplateClient.upsertTemplate(newMeta, cohabitantId)
         templates.append(newMeta)
     }
+
+    /// 指定テンプレートの Days SnapshotListener を開始する（編集モード中の同期表示用）
+    public func startObservingDays(templateId: String, cohabitantId: String) async {
+        let stream = await houseworkTemplateClient.addDaysSnapshotListener(
+            daysListenerKey,
+            templateId,
+            cohabitantId
+        )
+        daysObserveTask = Task {
+
+            for await currentDays in stream {
+                self.selectedDays = currentDays
+            }
+        }
+    }
+
+    /// Days SnapshotListener を解除する
+    public func stopObservingDays() async {
+        daysObserveTask?.cancel()
+        daysObserveTask = nil
+        await houseworkTemplateClient.removeListener(daysListenerKey)
+    }
+
+    /// 曜日定義を保存する。version の楽観的ロックで競合が発生した場合は `HouseworkTemplateError.versionConflict` を throw する。
+    /// 成功時には `selectedDays` をローカル更新する。
+    public func saveDay(
+        _ day: HouseworkTemplateDay,
+        templateId: String,
+        cohabitantId: String,
+        currentVersion: Int
+    ) async throws {
+        try await houseworkTemplateClient.updateDay(
+            day,
+            templateId,
+            cohabitantId,
+            currentVersion
+        )
+
+        if let index = selectedDays.firstIndex(where: { $0.dayOfWeek == day.dayOfWeek }) {
+            selectedDays[index] = day
+        } else {
+            selectedDays.append(day)
+        }
+    }
+
 }

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
@@ -57,7 +57,7 @@ public final class HouseworkTemplateListStore {
         templates.append(newMeta)
     }
 
-    /// 指定テンプレートの Days SnapshotListener を開始する（編集モード中の同期表示用）
+    /// 指定テンプレートの Days SnapshotListener を開始する
     public func startObservingDays(templateId: String, cohabitantId: String) async {
         let stream = await houseworkTemplateClient.addDaysSnapshotListener(
             daysListenerKey,
@@ -79,25 +79,29 @@ public final class HouseworkTemplateListStore {
         await houseworkTemplateClient.removeListener(daysListenerKey)
     }
 
-    /// 曜日定義を保存する。version の楽観的ロックで競合が発生した場合は `HouseworkTemplateError.versionConflict` を throw する。
-    /// 成功時には `selectedDays` をローカル更新する。
-    public func saveDay(
-        _ day: HouseworkTemplateDay,
+    /// 曜日定義を一括保存する。version の楽観的ロックで競合が発生した場合は `HouseworkTemplateError.versionConflict` を throw する。
+    /// 成功時には `selectedDays` をローカル更新する（既存の dayOfWeek は置換、未登録は追加）。
+    /// 空配列が渡された場合は no-op。
+    public func saveDays(
+        _ days: [HouseworkTemplateDay],
         templateId: String,
         cohabitantId: String,
         currentVersion: Int
     ) async throws {
-        try await houseworkTemplateClient.updateDay(
-            day,
+        guard !days.isEmpty else { return }
+        try await houseworkTemplateClient.updateDays(
+            days,
             templateId,
             cohabitantId,
             currentVersion
         )
 
-        if let index = selectedDays.firstIndex(where: { $0.dayOfWeek == day.dayOfWeek }) {
-            selectedDays[index] = day
-        } else {
-            selectedDays.append(day)
+        for day in days {
+            if let index = selectedDays.firstIndex(where: { $0.dayOfWeek == day.dayOfWeek }) {
+                selectedDays[index] = day
+            } else {
+                selectedDays.append(day)
+            }
         }
     }
 

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateMeta.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateMeta.swift
@@ -2,17 +2,14 @@ public struct HouseworkTemplateMeta: Identifiable, Codable, Sendable, Equatable 
 
     public let templateId: String
     public let name: String
-    /// 楽観的ロック用バージョン
-    public let version: Int
 
     public var id: String {
         templateId
     }
 
-    public init(templateId: String, name: String, version: Int) {
+    public init(templateId: String, name: String) {
         self.templateId = templateId
         self.name = name
-        self.version = version
     }
 
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkTemplateClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkTemplateClient.swift
@@ -51,6 +51,13 @@ public struct HouseworkTemplateClient: Sendable {
         _ cohabitantId: String
     ) async -> AsyncStream<[HouseworkTemplateEditor]>
 
+    /// テンプレートメタの version SnapshotListener（編集中のみ使用、楽観的ロックの currentVersion 取得用）
+    public let addMetaVersionSnapshotListener: @Sendable (
+        _ id: String,
+        _ templateId: String,
+        _ cohabitantId: String
+    ) async -> AsyncStream<Int>
+
     /// SnapshotListener の解除
     public let removeListener: @Sendable (_ id: String) async -> Void
 
@@ -92,6 +99,11 @@ public struct HouseworkTemplateClient: Sendable {
             _ templateId: String,
             _ cohabitantId: String
         ) async -> AsyncStream<[HouseworkTemplateEditor]> = { _, _, _ in .makeStream().stream },
+        addMetaVersionSnapshotListener: @Sendable @escaping (
+            _ id: String,
+            _ templateId: String,
+            _ cohabitantId: String
+        ) async -> AsyncStream<Int> = { _, _, _ in .makeStream().stream },
         removeListener: @Sendable @escaping (_ id: String) async -> Void = { _ in }
     ) {
         self.fetchTemplates = fetchTemplates
@@ -102,6 +114,7 @@ public struct HouseworkTemplateClient: Sendable {
         self.removeEditor = removeEditor
         self.addDaysSnapshotListener = addDaysSnapshotListener
         self.addEditorsSnapshotListener = addEditorsSnapshotListener
+        self.addMetaVersionSnapshotListener = addMetaVersionSnapshotListener
         self.removeListener = removeListener
     }
 
@@ -110,5 +123,21 @@ public struct HouseworkTemplateClient: Sendable {
 public extension HouseworkTemplateClient {
 
     static let previewValue: HouseworkTemplateClient = .init()
+
+}
+
+/// Firestore 上のテンプレートメタドキュメントを表現する内部構造体。
+/// `version` は Infrastructure 層でのみ扱い、Domain には公開しない。
+public struct HouseworkTemplateMetaDocument: Codable, Sendable {
+
+    public let templateId: String
+    public let name: String
+    public let version: Int
+
+    public init(templateId: String, name: String, version: Int) {
+        self.templateId = templateId
+        self.name = name
+        self.version = version
+    }
 
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkTemplateClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkTemplateClient.swift
@@ -15,9 +15,9 @@ public struct HouseworkTemplateClient: Sendable {
         _ cohabitantId: String
     ) async throws -> Void
 
-    /// 曜日定義の更新（楽観的ロック付きトランザクション）
-    public let updateDay: @Sendable (
-        _ day: HouseworkTemplateDay,
+    /// 曜日定義の一括更新（楽観的ロック付きトランザクション）
+    public let updateDays: @Sendable (
+        _ days: [HouseworkTemplateDay],
         _ templateId: String,
         _ cohabitantId: String,
         _ currentVersion: Int
@@ -73,8 +73,8 @@ public struct HouseworkTemplateClient: Sendable {
             _ meta: HouseworkTemplateMeta,
             _ cohabitantId: String
         ) async throws -> Void = { _, _ in },
-        updateDay: @Sendable @escaping (
-            _ day: HouseworkTemplateDay,
+        updateDays: @Sendable @escaping (
+            _ days: [HouseworkTemplateDay],
             _ templateId: String,
             _ cohabitantId: String,
             _ currentVersion: Int
@@ -109,7 +109,7 @@ public struct HouseworkTemplateClient: Sendable {
         self.fetchTemplates = fetchTemplates
         self.fetchDays = fetchDays
         self.upsertTemplate = upsertTemplate
-        self.updateDay = updateDay
+        self.updateDays = updateDays
         self.upsertEditor = upsertEditor
         self.removeEditor = removeEditor
         self.addDaysSnapshotListener = addDaysSnapshotListener

--- a/LocalPackage/Sources/HometeInfrastructure/Firestore/FirestoreService.swift
+++ b/LocalPackage/Sources/HometeInfrastructure/Firestore/FirestoreService.swift
@@ -53,6 +53,33 @@ public final actor FirestoreService {
         return stream
     }
 
+    public func addSnapshotListener<Output: Decodable & Sendable>(
+        id: String,
+        predicate: (Firestore) -> DocumentReference
+    ) -> AsyncStream<Output?> {
+        let (stream, continuation) = AsyncStream.makeStream(
+            of: Output?.self,
+            bufferingPolicy: .bufferingNewest(10)
+        )
+        let listener = predicate(firestore)
+            .addSnapshotListener { snapshot, error in
+                if let error {
+                    print("occurred error at fetchSnapshotListener(type: \(Output.self), error: \(error))")
+                    return
+                }
+
+                guard let snapshot, snapshot.exists else {
+                    continuation.yield(nil)
+                    return
+                }
+                let value = try? snapshot.data(as: Output.self)
+                continuation.yield(value)
+            }
+
+        listeners[id] = FirestoreListener(continuation: continuation, listener: listener)
+        return stream
+    }
+
     public func removeSnapshotListener(id: String) {
         let listener = listeners[id]
         listener?.remove()

--- a/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
@@ -5,26 +5,28 @@
 //  Created by Taichi Sato on 2026/05/09.
 //
 
+import Foundation
 @testable import HometeDomain
 import Testing
 
 @MainActor
 struct HouseworkTemplateListStoreTest {
 
-    private let inputCohabitantId = "cohabitantId"
+    private nonisolated static let inputCohabitantId = "cohabitantId"
+    private nonisolated static let inputTemplateId = "templateId"
 
     @Test("テンプレート一覧の取得を行うと、Clientから受け取ったテンプレート一覧をtemplatesに反映する")
     func loadTemplates() async throws {
         // Arrange
 
         let expectedTemplates: [HouseworkTemplateMeta] = [
-            .init(templateId: "template1", name: "平日テンプレ", version: 0),
-            .init(templateId: "template2", name: "週末テンプレ", version: 3),
+            .init(templateId: "template1", name: "平日テンプレ"),
+            .init(templateId: "template2", name: "週末テンプレ"),
         ]
         let store = HouseworkTemplateListStore(
             houseworkTemplateClient: .init(
                 fetchTemplates: { cohabitantId in
-                    #expect(cohabitantId == inputCohabitantId)
+                    #expect(cohabitantId == Self.inputCohabitantId)
                     return expectedTemplates
                 }
             )
@@ -32,7 +34,7 @@ struct HouseworkTemplateListStoreTest {
 
         // Act
 
-        try await store.loadTemplates(cohabitantId: inputCohabitantId)
+        try await store.loadTemplates(cohabitantId: Self.inputCohabitantId)
 
         // Assert
 
@@ -43,7 +45,6 @@ struct HouseworkTemplateListStoreTest {
     func loadDays() async throws {
         // Arrange
 
-        let inputTemplateId = "templateId"
         let expectedDays: [HouseworkTemplateDay] = [
             .init(
                 dayOfWeek: 1,
@@ -53,8 +54,8 @@ struct HouseworkTemplateListStoreTest {
         let store = HouseworkTemplateListStore(
             houseworkTemplateClient: .init(
                 fetchDays: { cohabitantId, templateId in
-                    #expect(cohabitantId == inputCohabitantId)
-                    #expect(templateId == inputTemplateId)
+                    #expect(cohabitantId == Self.inputCohabitantId)
+                    #expect(templateId == Self.inputTemplateId)
                     return expectedDays
                 }
             )
@@ -62,14 +63,14 @@ struct HouseworkTemplateListStoreTest {
 
         // Act
 
-        try await store.loadDays(templateId: inputTemplateId, cohabitantId: inputCohabitantId)
+        try await store.loadDays(templateId: Self.inputTemplateId, cohabitantId: Self.inputCohabitantId)
 
         // Assert
 
         #expect(store.selectedDays == expectedDays)
     }
 
-    @Test("テンプレートを新規作成すると、version=0で作成しtemplatesにも追加する")
+    @Test("テンプレートを新規作成すると、Clientにメタを書き込みtemplatesにも追加する")
     func createTemplate() async throws {
         // Arrange
 
@@ -77,8 +78,7 @@ struct HouseworkTemplateListStoreTest {
         let inputName = "新しいテンプレ"
         let expectedMeta = HouseworkTemplateMeta(
             templateId: inputTemplateId,
-            name: inputName,
-            version: 0
+            name: inputName
         )
 
         try await confirmation { confirmation in
@@ -88,7 +88,7 @@ struct HouseworkTemplateListStoreTest {
                         // Assert
 
                         #expect(meta == expectedMeta)
-                        #expect(cohabitantId == inputCohabitantId)
+                        #expect(cohabitantId == Self.inputCohabitantId)
                         confirmation()
                     }
                 )
@@ -99,13 +99,212 @@ struct HouseworkTemplateListStoreTest {
             try await store.createTemplate(
                 templateId: inputTemplateId,
                 name: inputName,
-                cohabitantId: inputCohabitantId
+                cohabitantId: Self.inputCohabitantId
             )
 
             // Assert
 
             #expect(store.templates == [expectedMeta])
         }
+    }
+
+    @Test("saveDayが成功すると、updateDayが呼ばれselectedDaysの該当dayOfWeekが置き換えられる")
+    func saveDayReplacesExistingDay() async throws {
+        // Arrange
+
+        let initialDays: [HouseworkTemplateDay] = [
+            .init(
+                dayOfWeek: 1,
+                items: [.init(id: .init(id: "old"), title: "古い家事", point: 1, updatedAt: .now)]
+            ),
+            .init(
+                dayOfWeek: 3,
+                items: [.init(id: .init(id: "wed"), title: "水曜", point: 2, updatedAt: .now)]
+            ),
+        ]
+        let inputDay = HouseworkTemplateDay(
+            dayOfWeek: 1,
+            items: [.init(id: .init(id: "new"), title: "新しい家事", point: 5, updatedAt: .now)]
+        )
+        let inputCurrentVersion = 3
+        let expectedDays: [HouseworkTemplateDay] = [
+            inputDay,
+            initialDays[1],
+        ]
+
+        try await confirmation { confirmation in
+            let store = HouseworkTemplateListStore(
+                houseworkTemplateClient: .init(
+                    updateDay: { day, templateId, cohabitantId, currentVersion in
+                        #expect(day == inputDay)
+                        #expect(templateId == Self.inputTemplateId)
+                        #expect(cohabitantId == Self.inputCohabitantId)
+                        #expect(currentVersion == inputCurrentVersion)
+                        confirmation()
+                    }
+                ),
+                selectedDays: initialDays
+            )
+
+            // Act
+
+            try await store.saveDay(
+                inputDay,
+                templateId: Self.inputTemplateId,
+                cohabitantId: Self.inputCohabitantId,
+                currentVersion: inputCurrentVersion
+            )
+
+            // Assert
+
+            #expect(store.selectedDays == expectedDays)
+        }
+    }
+
+    @Test("saveDayで未登録の曜日定義を渡すと、selectedDaysに追加される")
+    func saveDayAppendsNewDay() async throws {
+        // Arrange
+
+        let initialDays: [HouseworkTemplateDay] = [
+            .init(
+                dayOfWeek: 1,
+                items: [.init(id: .init(id: "mon"), title: "月曜", point: 1, updatedAt: .now)]
+            ),
+        ]
+        let inputDay = HouseworkTemplateDay(
+            dayOfWeek: 5,
+            items: [.init(id: .init(id: "fri"), title: "金曜", point: 3, updatedAt: .now)]
+        )
+        let expectedDays: [HouseworkTemplateDay] = initialDays + [inputDay]
+        let store = HouseworkTemplateListStore(
+            houseworkTemplateClient: .init(updateDay: { _, _, _, _ in }),
+            selectedDays: initialDays
+        )
+
+        // Act
+
+        try await store.saveDay(
+            inputDay,
+            templateId: Self.inputTemplateId,
+            cohabitantId: Self.inputCohabitantId,
+            currentVersion: 0
+        )
+
+        // Assert
+
+        #expect(store.selectedDays == expectedDays)
+    }
+
+    @Test("saveDayでversionConflictが発生すると、エラーがthrowされselectedDaysは変わらない")
+    func saveDayConflictKeepsSelectedDays() async throws {
+        // Arrange
+
+        let initialDays: [HouseworkTemplateDay] = [
+            .init(
+                dayOfWeek: 1,
+                items: [.init(id: .init(id: "mon"), title: "月曜", point: 1, updatedAt: .now)]
+            ),
+        ]
+        let inputDay = HouseworkTemplateDay(
+            dayOfWeek: 1,
+            items: [.init(id: .init(id: "new"), title: "新", point: 9, updatedAt: .now)]
+        )
+        let store = HouseworkTemplateListStore(
+            houseworkTemplateClient: .init(
+                updateDay: { _, _, _, _ in throw HouseworkTemplateError.versionConflict }
+            ),
+            selectedDays: initialDays
+        )
+
+        // Act + Assert
+
+        await #expect(throws: HouseworkTemplateError.self) {
+            try await store.saveDay(
+                inputDay,
+                templateId: Self.inputTemplateId,
+                cohabitantId: Self.inputCohabitantId,
+                currentVersion: 0
+            )
+        }
+        #expect(store.selectedDays == initialDays)
+    }
+
+    @Test("Daysリスナーで受け取った値がselectedDaysに反映される")
+    func startObservingDaysReflectsValues() async {
+        // Arrange
+
+        let expectedDays: [HouseworkTemplateDay] = [
+            .init(
+                dayOfWeek: 2,
+                items: [.init(id: .init(id: "id"), title: "火曜", point: 4, updatedAt: .now)]
+            ),
+        ]
+        let (daysStream, daysContinuation) = AsyncStream<[HouseworkTemplateDay]>.makeStream()
+        let store = HouseworkTemplateListStore(
+            houseworkTemplateClient: .init(
+                addDaysSnapshotListener: { _, _, _ in daysStream }
+            )
+        )
+
+        // Act
+
+        await store.startObservingDays(
+            templateId: Self.inputTemplateId,
+            cohabitantId: Self.inputCohabitantId
+        )
+
+        // Assert
+
+        let waiter = Task {
+            await withCheckedContinuation { continuation in
+                ObservationHelper.continuousObservationTracking {
+                    store.selectedDays
+                } onChange: {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+        daysContinuation.yield(expectedDays)
+        await waiter.value
+        #expect(store.selectedDays == expectedDays)
+
+        // Cleanup
+
+        daysContinuation.finish()
+        await store.stopObservingDays()
+    }
+
+    @Test("stopObservingDaysでDaysリスナーが解除される")
+    func stopObservingDaysRemovesListener() async {
+        // Arrange
+
+        let removedListenerKeys = TestLockedArray<String>()
+        let store = HouseworkTemplateListStore(
+            houseworkTemplateClient: .init(
+                removeListener: { id in
+                    await removedListenerKeys.append(id)
+                }
+            )
+        )
+
+        // Act
+
+        await store.stopObservingDays()
+
+        // Assert
+
+        let keys = await removedListenerKeys.values
+        #expect(keys == ["houseworkTemplateDaysListener"])
+    }
+
+}
+
+private actor TestLockedArray<Element: Sendable> {
+
+    var values: [Element] = []
+
+    func append(_ element: Element) {
+        values.append(element)
     }
 
 }

--- a/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
@@ -108,8 +108,8 @@ struct HouseworkTemplateListStoreTest {
         }
     }
 
-    @Test("saveDayが成功すると、updateDayが呼ばれselectedDaysの該当dayOfWeekが置き換えられる")
-    func saveDayReplacesExistingDay() async throws {
+    @Test("saveDaysが成功すると、updateDaysが呼ばれselectedDaysの該当dayOfWeekが置き換えられ、未登録は追加される")
+    func saveDaysMergesIntoSelectedDays() async throws {
         // Arrange
 
         let initialDays: [HouseworkTemplateDay] = [
@@ -122,21 +122,28 @@ struct HouseworkTemplateListStoreTest {
                 items: [.init(id: .init(id: "wed"), title: "水曜", point: 2, updatedAt: .now)]
             ),
         ]
-        let inputDay = HouseworkTemplateDay(
-            dayOfWeek: 1,
-            items: [.init(id: .init(id: "new"), title: "新しい家事", point: 5, updatedAt: .now)]
-        )
+        let inputDays: [HouseworkTemplateDay] = [
+            .init(
+                dayOfWeek: 1,
+                items: [.init(id: .init(id: "new"), title: "新しい家事", point: 5, updatedAt: .now)]
+            ),
+            .init(
+                dayOfWeek: 5,
+                items: [.init(id: .init(id: "fri"), title: "金曜", point: 3, updatedAt: .now)]
+            ),
+        ]
         let inputCurrentVersion = 3
         let expectedDays: [HouseworkTemplateDay] = [
-            inputDay,
+            inputDays[0],
             initialDays[1],
+            inputDays[1],
         ]
 
         try await confirmation { confirmation in
             let store = HouseworkTemplateListStore(
                 houseworkTemplateClient: .init(
-                    updateDay: { day, templateId, cohabitantId, currentVersion in
-                        #expect(day == inputDay)
+                    updateDays: { days, templateId, cohabitantId, currentVersion in
+                        #expect(days == inputDays)
                         #expect(templateId == Self.inputTemplateId)
                         #expect(cohabitantId == Self.inputCohabitantId)
                         #expect(currentVersion == inputCurrentVersion)
@@ -148,8 +155,8 @@ struct HouseworkTemplateListStoreTest {
 
             // Act
 
-            try await store.saveDay(
-                inputDay,
+            try await store.saveDays(
+                inputDays,
                 templateId: Self.inputTemplateId,
                 cohabitantId: Self.inputCohabitantId,
                 currentVersion: inputCurrentVersion
@@ -161,8 +168,8 @@ struct HouseworkTemplateListStoreTest {
         }
     }
 
-    @Test("saveDayで未登録の曜日定義を渡すと、selectedDaysに追加される")
-    func saveDayAppendsNewDay() async throws {
+    @Test("saveDaysに空配列を渡すと、updateDaysは呼ばれずselectedDaysも変わらない")
+    func saveDaysWithEmptyIsNoop() async throws {
         // Arrange
 
         let initialDays: [HouseworkTemplateDay] = [
@@ -171,20 +178,18 @@ struct HouseworkTemplateListStoreTest {
                 items: [.init(id: .init(id: "mon"), title: "月曜", point: 1, updatedAt: .now)]
             ),
         ]
-        let inputDay = HouseworkTemplateDay(
-            dayOfWeek: 5,
-            items: [.init(id: .init(id: "fri"), title: "金曜", point: 3, updatedAt: .now)]
-        )
-        let expectedDays: [HouseworkTemplateDay] = initialDays + [inputDay]
+        let updateCallCount = TestCounter()
         let store = HouseworkTemplateListStore(
-            houseworkTemplateClient: .init(updateDay: { _, _, _, _ in }),
+            houseworkTemplateClient: .init(
+                updateDays: { _, _, _, _ in await updateCallCount.increment() }
+            ),
             selectedDays: initialDays
         )
 
         // Act
 
-        try await store.saveDay(
-            inputDay,
+        try await store.saveDays(
+            [],
             templateId: Self.inputTemplateId,
             cohabitantId: Self.inputCohabitantId,
             currentVersion: 0
@@ -192,11 +197,13 @@ struct HouseworkTemplateListStoreTest {
 
         // Assert
 
-        #expect(store.selectedDays == expectedDays)
+        let count = await updateCallCount.value
+        #expect(count == 0)
+        #expect(store.selectedDays == initialDays)
     }
 
-    @Test("saveDayでversionConflictが発生すると、エラーがthrowされselectedDaysは変わらない")
-    func saveDayConflictKeepsSelectedDays() async throws {
+    @Test("saveDaysでversionConflictが発生すると、エラーがthrowされselectedDaysは変わらない")
+    func saveDaysConflictKeepsSelectedDays() async throws {
         // Arrange
 
         let initialDays: [HouseworkTemplateDay] = [
@@ -205,13 +212,15 @@ struct HouseworkTemplateListStoreTest {
                 items: [.init(id: .init(id: "mon"), title: "月曜", point: 1, updatedAt: .now)]
             ),
         ]
-        let inputDay = HouseworkTemplateDay(
-            dayOfWeek: 1,
-            items: [.init(id: .init(id: "new"), title: "新", point: 9, updatedAt: .now)]
-        )
+        let inputDays: [HouseworkTemplateDay] = [
+            .init(
+                dayOfWeek: 1,
+                items: [.init(id: .init(id: "new"), title: "新", point: 9, updatedAt: .now)]
+            ),
+        ]
         let store = HouseworkTemplateListStore(
             houseworkTemplateClient: .init(
-                updateDay: { _, _, _, _ in throw HouseworkTemplateError.versionConflict }
+                updateDays: { _, _, _, _ in throw HouseworkTemplateError.versionConflict }
             ),
             selectedDays: initialDays
         )
@@ -219,8 +228,8 @@ struct HouseworkTemplateListStoreTest {
         // Act + Assert
 
         await #expect(throws: HouseworkTemplateError.self) {
-            try await store.saveDay(
-                inputDay,
+            try await store.saveDays(
+                inputDays,
                 templateId: Self.inputTemplateId,
                 cohabitantId: Self.inputCohabitantId,
                 currentVersion: 0
@@ -305,6 +314,16 @@ private actor TestLockedArray<Element: Sendable> {
 
     func append(_ element: Element) {
         values.append(element)
+    }
+
+}
+
+private actor TestCounter {
+
+    var value: Int = 0
+
+    func increment() {
+        value += 1
     }
 
 }

--- a/LocalPackage/Tests/HouseworkTemplateFeatureTests/HouseworkTemplateEditStoreMetaVersionListenerTest.swift
+++ b/LocalPackage/Tests/HouseworkTemplateFeatureTests/HouseworkTemplateEditStoreMetaVersionListenerTest.swift
@@ -1,0 +1,68 @@
+//
+//  HouseworkTemplateEditStoreMetaVersionListenerTest.swift
+//  HouseworkTemplateFeatureTests
+//
+//  Created by Taichi Sato on 2026/05/14.
+//
+
+import Foundation
+@testable import HometeDomain
+@testable import HouseworkTemplateFeature
+import Testing
+
+extension HouseworkTemplateEditStoreTest.MetaVersionListenerCase {
+
+    @Test("編集モード開始後、Meta versionリスナーで受け取った値がcurrentVersionに反映される")
+    func startEditing_reflectsCurrentVersionFromListener() async throws {
+        // Arrange
+
+        let expectedVersion = 7
+        let (versionStream, versionContinuation) = AsyncStream<Int>.makeStream()
+        let store = HouseworkTemplateEditStore(
+            houseworkTemplateClient: .init(
+                addDaysSnapshotListener: { _, _, _ in
+                    AsyncStream { $0.finish() }
+                },
+                addEditorsSnapshotListener: { _, _, _ in
+                    AsyncStream { $0.finish() }
+                },
+                addMetaVersionSnapshotListener: { _, _, _ in versionStream }
+            ),
+            currentVersion: 0
+        )
+
+        // Act
+
+        try await store.startEditing(
+            templateId: HouseworkTemplateEditStoreTest.inputTemplateId,
+            cohabitantId: HouseworkTemplateEditStoreTest.inputCohabitantId,
+            userId: HouseworkTemplateEditStoreTest.inputUserId,
+            now: Date()
+        )
+
+        // Assert
+
+        let waiter = Task {
+            await withCheckedContinuation { continuation in
+                ObservationHelper.continuousObservationTracking {
+                    store.currentVersion
+                } onChange: {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+        versionContinuation.yield(expectedVersion)
+        await waiter.value
+        #expect(store.currentVersion == expectedVersion)
+
+        // Cleanup
+
+        versionContinuation.finish()
+        await store.stopEditing(
+            templateId: HouseworkTemplateEditStoreTest.inputTemplateId,
+            cohabitantId: HouseworkTemplateEditStoreTest.inputCohabitantId,
+            userId: HouseworkTemplateEditStoreTest.inputUserId
+        )
+    }
+
+}

--- a/LocalPackage/Tests/HouseworkTemplateFeatureTests/HouseworkTemplateEditStoreTest.swift
+++ b/LocalPackage/Tests/HouseworkTemplateFeatureTests/HouseworkTemplateEditStoreTest.swift
@@ -26,23 +26,18 @@ enum HouseworkTemplateEditStoreTest {
     struct StopEditingCase {}
 
     @MainActor
-    struct SaveDayCase {}
+    struct MetaVersionListenerCase {}
 
 }
 
 extension HouseworkTemplateEditStoreTest.StartEditingCase {
 
-    @Test("編集モード開始時、Editorをupsertし、initialのversionをcurrentVersionに反映する")
-    func startEditing_upsertsEditorAndSetsCurrentVersion() async throws {
+    @Test("編集モード開始時、Editorをupsertする")
+    func startEditing_upsertsEditor() async throws {
         // Arrange
 
         let now = Date(timeIntervalSince1970: 1_000_000)
         let editorTTL: TimeInterval = 5 * 60
-        let inputMeta = HouseworkTemplateMeta(
-            templateId: HouseworkTemplateEditStoreTest.inputTemplateId,
-            name: "テンプレ",
-            version: 5
-        )
         let expectedEditor = HouseworkTemplateEditor(
             userId: TestCase.inputUserId,
             updatedAt: now,
@@ -56,10 +51,10 @@ extension HouseworkTemplateEditStoreTest.StartEditingCase {
                         .init(editor: editor, templateId: templateId, cohabitantId: cohabitantId)
                     )
                 },
-                addDaysSnapshotListener: { _, _, _ in
+                addEditorsSnapshotListener: { _, _, _ in
                     AsyncStream { $0.finish() }
                 },
-                addEditorsSnapshotListener: { _, _, _ in
+                addMetaVersionSnapshotListener: { _, _, _ in
                     AsyncStream { $0.finish() }
                 }
             )
@@ -68,7 +63,7 @@ extension HouseworkTemplateEditStoreTest.StartEditingCase {
         // Act
 
         try await store.startEditing(
-            meta: inputMeta,
+            templateId: TestCase.inputTemplateId,
             cohabitantId: TestCase.inputCohabitantId,
             userId: TestCase.inputUserId,
             now: now
@@ -76,7 +71,6 @@ extension HouseworkTemplateEditStoreTest.StartEditingCase {
 
         // Assert
 
-        #expect(store.currentVersion == 5)
         let records = await upserts.values
         #expect(records.count == 1)
         #expect(records.first?.editor == expectedEditor)
@@ -92,89 +86,28 @@ extension HouseworkTemplateEditStoreTest.StartEditingCase {
         )
     }
 
-    @Test("編集モード開始後、Daysリスナーで受け取った値がdaysに反映される")
-    func startEditing_reflectsDaysFromListener() async throws {
-        // Arrange
-
-        let inputMeta = HouseworkTemplateMeta(
-            templateId: TestCase.inputTemplateId,
-            name: "テンプレ",
-            version: 0
-        )
-        let expectedDays: [HouseworkTemplateDay] = [
-            .init(dayOfWeek: 1, items: [.init(id: .init(id: "id"), title: "ゴミ出し", point: 5, updatedAt: .now)]),
-        ]
-        let (daysStream, daysContinuation) = AsyncStream<[HouseworkTemplateDay]>.makeStream()
-        let store = HouseworkTemplateEditStore(
-            houseworkTemplateClient: .init(
-                addDaysSnapshotListener: { _, _, _ in daysStream },
-                addEditorsSnapshotListener: { _, _, _ in
-                    AsyncStream { $0.finish() }
-                }
-            )
-        )
-
-        // Act
-
-        try await store.startEditing(
-            meta: inputMeta,
-            cohabitantId: TestCase.inputCohabitantId,
-            userId: TestCase.inputUserId,
-            now: Date()
-        )
-
-        // Assert
-
-        let waiter = Task {
-            await withCheckedContinuation { continuation in
-                ObservationHelper.continuousObservationTracking {
-                    store.days
-                } onChange: {
-                    continuation.resume(returning: ())
-                }
-            }
-        }
-        daysContinuation.yield(expectedDays)
-        await waiter.value
-        #expect(store.days == expectedDays)
-
-        // Cleanup
-
-        daysContinuation.finish()
-        await store.stopEditing(
-            templateId: TestCase.inputTemplateId,
-            cohabitantId: TestCase.inputCohabitantId,
-            userId: TestCase.inputUserId
-        )
-    }
-
     @Test("編集モード開始後、Editorsリスナーで受け取った値がeditorsに反映される")
     func startEditing_reflectsEditorsFromListener() async throws {
         // Arrange
 
         let now = Date()
-        let inputMeta = HouseworkTemplateMeta(
-            templateId: TestCase.inputTemplateId,
-            name: "テンプレ",
-            version: 0
-        )
         let expectedEditors: [HouseworkTemplateEditor] = [
             .init(userId: "otherUser", updatedAt: now, expiredAt: now.addingTimeInterval(300)),
         ]
         let (editorsStream, editorsContinuation) = AsyncStream<[HouseworkTemplateEditor]>.makeStream()
         let store = HouseworkTemplateEditStore(
             houseworkTemplateClient: .init(
-                addDaysSnapshotListener: { _, _, _ in
+                addEditorsSnapshotListener: { _, _, _ in editorsStream },
+                addMetaVersionSnapshotListener: { _, _, _ in
                     AsyncStream { $0.finish() }
-                },
-                addEditorsSnapshotListener: { _, _, _ in editorsStream }
+                }
             )
         )
 
         // Act
 
         try await store.startEditing(
-            meta: inputMeta,
+            templateId: TestCase.inputTemplateId,
             cohabitantId: TestCase.inputCohabitantId,
             userId: TestCase.inputUserId,
             now: now
@@ -240,84 +173,10 @@ extension HouseworkTemplateEditStoreTest.StopEditingCase {
         let listenerKeys = await removedListenerKeys.values
         let editorUserIds = await removedEditorUserIds.values
         #expect(Set(listenerKeys) == Set([
-            "houseworkTemplateDaysListener",
             "houseworkTemplateEditorsListener",
+            "houseworkTemplateMetaVersionListener",
         ]))
         #expect(editorUserIds == [TestCase.inputUserId])
-    }
-
-}
-
-extension HouseworkTemplateEditStoreTest.SaveDayCase {
-
-    @Test("曜日定義の保存に成功すると、currentVersionが+1される")
-    func saveDay_success_incrementsCurrentVersion() async throws {
-        // Arrange
-
-        let inputDay = HouseworkTemplateDay(
-            dayOfWeek: 1,
-            items: [.init(id: .init(id: "id"), title: "洗濯", point: 5, updatedAt: .now)]
-        )
-        let updateCalls = TestLockedArray<TestUpdateDayRecord>()
-        let store = HouseworkTemplateEditStore(
-            houseworkTemplateClient: .init(
-                updateDay: { day, templateId, cohabitantId, currentVersion in
-                    await updateCalls.append(
-                        .init(
-                            day: day,
-                            templateId: templateId,
-                            cohabitantId: cohabitantId,
-                            currentVersion: currentVersion
-                        )
-                    )
-                }
-            ),
-            currentVersion: 3
-        )
-
-        // Act
-
-        try await store.saveDay(
-            inputDay,
-            templateId: TestCase.inputTemplateId,
-            cohabitantId: TestCase.inputCohabitantId
-        )
-
-        // Assert
-
-        #expect(store.currentVersion == 4)
-        let calls = await updateCalls.values
-        #expect(calls.count == 1)
-        #expect(calls.first?.day == inputDay)
-        #expect(calls.first?.templateId == TestCase.inputTemplateId)
-        #expect(calls.first?.cohabitantId == TestCase.inputCohabitantId)
-        #expect(calls.first?.currentVersion == 3)
-    }
-
-    @Test("曜日定義の保存でversionConflictが発生すると、エラーがthrowされcurrentVersionは変わらない")
-    func saveDay_conflict_throwsAndKeepsVersion() async throws {
-        // Arrange
-
-        let inputDay = HouseworkTemplateDay(dayOfWeek: 1, items: [])
-        let store = HouseworkTemplateEditStore(
-            houseworkTemplateClient: .init(
-                updateDay: { _, _, _, _ in
-                    throw HouseworkTemplateError.versionConflict
-                }
-            ),
-            currentVersion: 3
-        )
-
-        // Act + Assert
-
-        await #expect(throws: HouseworkTemplateError.self) {
-            try await store.saveDay(
-                inputDay,
-                templateId: TestCase.inputTemplateId,
-                cohabitantId: TestCase.inputCohabitantId
-            )
-        }
-        #expect(store.currentVersion == 3)
     }
 
 }
@@ -339,14 +198,5 @@ private struct TestUpsertedEditorRecord {
     let editor: HouseworkTemplateEditor
     let templateId: String
     let cohabitantId: String
-
-}
-
-private struct TestUpdateDayRecord {
-
-    let day: HouseworkTemplateDay
-    let templateId: String
-    let cohabitantId: String
-    let currentVersion: Int
 
 }

--- a/doc/strategy/housework_template.md
+++ b/doc/strategy/housework_template.md
@@ -271,11 +271,14 @@ AppRoot
 
 #### コンフリクト発生時
 
-編集モード中は `Days`（`HouseworkTemplateListStore` 側）と `version`（`HouseworkTemplateEditStore` 側）の SnapshotListener が張られているため、コンフリクト後も他メンバーの変更内容と最新の `version` は自動的に流れてくる。追加の再取得は不要で、それぞれのリスナーの最新値でUIを更新してエラーを通知する。`version` の追従によりユーザーが再保存を試みた際は新しい `currentVersion` で再試行できる。
+コンフリクトは以下の2経路で検知し、それぞれユーザーにアラートで通知する。
 
-| タイミング | 対象 | 方法 |
+| 検知経路 | 検知方法 | UI挙動 |
 |---|---|---|
-| 書き込み失敗（version不一致）時 | - | `Days` / `version` リスナーの最新値でUI更新 + エラー表示 |
+| 編集中に他ユーザーがテンプレートを更新（先回り検知） | `HouseworkTemplateEditStore` の `version` SnapshotListener が新しい `version` を受け取る | アラートを表示する。確認後、`HouseworkTemplateListStore` から最新のテンプレート内容を fetch し、View に反映する |
+| 自分の保存処理が version 不一致で失敗 | `HouseworkTemplateListStore.saveDays` が `HouseworkTemplateError.versionConflict` を throw | アラートを表示する |
+
+`version` SnapshotListener により `currentVersion` は常に最新化されているため、コンフリクト後のユーザー操作（再編集・再保存）は新しい `currentVersion` で再試行できる。
 
 #### フロー概要
 
@@ -285,9 +288,10 @@ AppRoot
 編集画面 ─ Days + Editors + version の SnapshotListener 開始
                 ↓ 保存（複数曜日を一括書き込み） / キャンセル
           ─ SnapshotListener 解除
-                ↓ 保存時に version が不一致（コンフリクト）
-          ─ リスナーの最新値でUI更新 + エラー表示
-            （version リスナーで currentVersion が追従するため再保存で復旧可能）
+                ↓ 編集中に version 変化を検知（他ユーザーが更新）
+          ─ アラート表示 + listStore で最新内容を fetch して View に反映
+                ↓ 保存時に versionConflict が throw された
+          ─ アラート表示
 ```
 
 ---

--- a/doc/strategy/housework_template.md
+++ b/doc/strategy/housework_template.md
@@ -85,8 +85,9 @@ Cohabitant/{cohabitantId}
 #### 楽観的ロック（書き込み時の競合検知）
 
 - テンプレートドキュメント（`HouseworkTemplates/{templateId}`）に `version: Int` を持たせる
-- `Days/{dayOfWeek}` の書き込み時に Firestore トランザクションで現在の `version` を確認し、読み取り時と一致すれば `version + 1` して保存。不一致なら書き込みを拒否してUIにエラーを通知する
+- 曜日定義の書き込みは「1回の保存で変更があった複数の `Days/{dayOfWeek}` をまとめて更新する」一括書き込みとし、Firestore トランザクション内で現在の `version` を確認する。読み取り時と一致すれば対象 `Days` ドキュメントを順に書き込み、最後に `version + 1` して保存する。不一致なら書き込みを拒否してUIにエラーを通知する
 - `version` はテンプレートドキュメントに集約することで、どの曜日が更新されても整合性を保つ
+- 編集中クライアントは `HouseworkTemplates/{templateId}` の SnapshotListener を張って `version` をリアルタイムに追従する。これにより、他メンバーの保存後もローカルの `currentVersion` が最新化され、続けて保存しても不必要にコンフリクトを起こさない
 
 #### Presence（編集中ユーザーの表示）
 
@@ -254,32 +255,39 @@ AppRoot
 
 #### 編集画面
 
-編集中に他のメンバーの変更やPresenceをリアルタイムに反映する必要があるため、編集モードに入った時点でSnapshotListenerを開始する。リスナーは編集モードを抜けた時点で解除し、不要なコストを避ける。
+編集中に他のメンバーの変更・Presence・楽観的ロック用バージョンをリアルタイムに反映する必要があるため、編集モードに入った時点でSnapshotListenerを開始する。リスナーは編集モードを抜けた時点で解除し、不要なコストを避ける。
 
 | タイミング | 対象 | 方法 | 目的 |
 |---|---|---|---|
 | 編集モード開始時 | `Days` | SnapshotListener 開始 | 他メンバーの変更をリアルタイムに検知 |
 | 編集モード開始時 | `Editors` | SnapshotListener 開始 | 誰が編集中かをリアルタイム表示 |
-| 編集モード終了時 | `Days`・`Editors` | SnapshotListener 解除 | 不要なリスナーを解放 |
+| 編集モード開始時 | `HouseworkTemplates/{templateId}` の `version` | SnapshotListener 開始 | 楽観的ロック用 `currentVersion` をリアルタイム追従 |
+| 編集モード終了時 | `Days`・`Editors`・`version` | SnapshotListener 解除 | 不要なリスナーを解放 |
+
+**Store の責務分担:**
+
+- `Days` の SnapshotListener と曜日定義の一括保存（`saveDays`）は `HouseworkTemplateListStore` が保持する。閲覧画面でも `Days` を利用するため、編集セッション固有の状態とは切り分ける
+- `Editors` と `version` の SnapshotListener、Editor の keepalive は編集セッション固有のため `HouseworkTemplateEditStore` が保持する
 
 #### コンフリクト発生時
 
-編集モード中はすでに `Days` のSnapshotListenerが張られているため、コンフリクト後も変更は自動的に流れてくる。追加の再取得は不要で、リスナーの最新値でUIを更新してエラーを通知する。
+編集モード中は `Days`（`HouseworkTemplateListStore` 側）と `version`（`HouseworkTemplateEditStore` 側）の SnapshotListener が張られているため、コンフリクト後も他メンバーの変更内容と最新の `version` は自動的に流れてくる。追加の再取得は不要で、それぞれのリスナーの最新値でUIを更新してエラーを通知する。`version` の追従によりユーザーが再保存を試みた際は新しい `currentVersion` で再試行できる。
 
 | タイミング | 対象 | 方法 |
 |---|---|---|
-| 書き込み失敗（version不一致）時 | - | リスナーの最新値でUI更新 + エラー表示 |
+| 書き込み失敗（version不一致）時 | - | `Days` / `version` リスナーの最新値でUI更新 + エラー表示 |
 
 #### フロー概要
 
 ```
 閲覧画面 ─ 表示時ワンショット ─ リスナーなし
                 ↓ 編集ボタンタップ
-編集画面 ─ Days + Editors の SnapshotListener 開始
-                ↓ 保存 / キャンセル
+編集画面 ─ Days + Editors + version の SnapshotListener 開始
+                ↓ 保存（複数曜日を一括書き込み） / キャンセル
           ─ SnapshotListener 解除
                 ↓ 保存時に version が不一致（コンフリクト）
           ─ リスナーの最新値でUI更新 + エラー表示
+            （version リスナーで currentVersion が追従するため再保存で復旧可能）
 ```
 
 ---


### PR DESCRIPTION
## 経緯

関連Issue: #140 

家事週間テンプレート機能（#67）の実装の一環。
これまで `updateDay` は曜日単位での更新しか行えず、画面で複数の曜日をまとめて編集して保存することができなかった。また `HouseworkTemplateMeta` に楽観的ロック用の `version` プロパティが直接生えており、Domain 層が Infrastructure 層の永続化都合を持ってしまっていた。

これらを解消するため、保存処理を複数曜日の一括更新に変更し、`version` を Domain から切り離す形に整理した。

## 実装内容

### 保存処理を複数曜日の一括更新に変更
- `HouseworkTemplateClient.updateDay`（単一曜日）を `updateDays`（複数曜日）に置き換え、Firestore のトランザクション内で複数の `HouseworkTemplateDay` を一括書き込みするよう変更
- 1回の保存操作で「変更があった曜日だけをまとめて反映する」UI 操作と整合させるため、エンドポイント側を複数件対応にした方が呼び出し側の責務がシンプルになると判断

### `HouseworkTemplateMeta` から `version` を分離
- Domain の `HouseworkTemplateMeta` から `version` を削除し、Infrastructure 層に `HouseworkTemplateMetaDocument`（`templateId`/`name`/`version`）を新設して Firestore とのマッピングを担わせた
- 楽観的ロック用の `version` は永続化レイヤー固有の関心事であり、Domain モデルが知るべきではないため切り分けた

### 編集中の version は SnapshotListener で追従
- `addMetaVersionSnapshotListener` を新設し、編集中はメタドキュメントの `version` を購読して `HouseworkTemplateEditStore.currentVersion` を自動更新する構成にした
- 保存時に古い `currentVersion` を持ち続けると他クライアントの更新と必ず衝突してしまうため、Listener で追従させることで楽観的ロックの整合性を担保
- 併せて `FirestoreService` に単一ドキュメント用の `addSnapshotListener` を追加

### Days 監視と保存責務を `HouseworkTemplateListStore` 側に移動
- `HouseworkTemplateEditStore` が持っていた `days` の SnapshotListener / `saveDay` を `HouseworkTemplateListStore` の `startObservingDays` / `stopObservingDays` / `saveDays` に移行
- 一覧側で `selectedDays` を持つことで「表示中のテンプレートの曜日定義」というドメイン状態を一箇所に集約。Edit 側は「編集セッション固有の状態（editors / currentVersion / keepalive）」だけに責務を絞った
- 保存成功時はサーバ反映を待たずに `selectedDays` をローカル更新する（既存の dayOfWeek は置換、未登録は追加）

## 確認内容

- [x] `HouseworkTemplateListStoreTest` / `HouseworkTemplateEditStoreTest` / `HouseworkTemplateEditStoreMetaVersionListenerTest` が通ること
