### PR TITLE
fix: SPMプラグイン許可コマンドを全ワークフロー共通で実行する

### DIFF
--- a/ci_scripts/ci_post_clone.sh
+++ b/ci_scripts/ci_post_clone.sh
@@ -2,13 +2,15 @@
 
 set -e
 
+# Xcode CloudでSwift Package Managerプラグインの検証をスキップする
+# SwiftGenPlugin、PrefireTestsPluginなどのBuild Tool Pluginを許可するために必要
+# どのワークフローでも共通で必要なため、switch-caseの外で実行する
+defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
+defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
+
 case "$CI_WORKFLOW" in
     "VRT")
         echo "=== VRT workflow ==="
-
-        # Xcode CloudでSwift Package Managerプラグインの検証をスキップする
-        # PrefireTestsPluginなどのパッケージプラグインを許可するために必要
-        defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
 
         # スナップショット参照ファイルの確認
         SNAPSHOT_DIR="$CI_PRIMARY_REPOSITORY_PATH/hometeSnapshotTests/__Snapshots__/PreviewTests.generated"


### PR DESCRIPTION
## 経緯

Xcode Cloud の `Upload Stg TestFlight` ワークフローでアーカイブが失敗していた。ビルドログを確認したところ、`SwiftGenPlugin` の Build Tool Plugin 検証で失敗しており、その直後に `** ARCHIVE FAILED **` となっていた。

```
Validate plug-in "SwiftGenPlugin" in package "swiftgenplugin"
** ARCHIVE FAILED **
```

原因は `ci_post_clone.sh` の構造にあり、SPM プラグイン検証スキップ用の `defaults write` コマンドが `VRT` ワークフローのケース内にしか存在せず、`Upload Stg TestFlight` / `Upload For AppStore` ワークフローでは実行されていなかった。

## 実装内容

`defaults write IDESkipPackagePluginFingerprintValidatation` を switch-case の外側に移動し、全ワークフロー共通で実行するようにした。

- **switch-case の外に移動した理由**: `SwiftGenPlugin` は `HometeResources` ターゲットで使用されており、`VRT` だけでなく TestFlight / App Store アップロード時のアーカイブビルドにも必要。今後新しいワークフローを追加した際にも漏れなくプラグインが許可されるよう、switch-case の外で必ず実行されるようにした。
- **`IDESkipMacroFingerprintValidation` も追加**: 今後 Macro を使うパッケージが追加された場合にも備えて、Macro の fingerprint 検証もスキップするようにした。

## 確認内容

- [ ] `Upload Stg TestFlight` ワークフローを Xcode Cloud で実行し、`SwiftGenPlugin` の検証で失敗せずアーカイブが完了することを確認する
- [ ] `VRT` ワークフローが従来通り動作することを確認する

🤖 Generated with [Claude Code](https://claude.com/claude-code)