### PR TITLE
refactor: HouseworkTemplateViewの編集ロジックをドメインモデルに切り出し

### DIFF
--- a/.claude/skills/swift-code-verification/SKILL.md
+++ b/.claude/skills/swift-code-verification/SKILL.md
@@ -19,6 +19,22 @@ Swiftファイル（`*.swift`）を編集・作成・削除した後は、必ず
 
 ## 検証手順
 
+### 0. stale な swift-test プロセスの掃除（必須）
+
+`.build` ディレクトリは SwiftPM が排他ロックを取るため、過去セッションから残っている `swift-test` / `swiftpm-testing-helper` プロセスがあると、新しい `swift test` が "Another instance of SwiftPM ... is already running" で待機状態になり、永遠に進まなくなる。
+
+検証フローを始める前に、必ず以下を実行して掃除する:
+
+```bash
+# このプロジェクトの LocalPackage に紐づく古いプロセスのみを kill する（別worktreeは触らない）
+pkill -f "swift-test --package-path LocalPackage" 2>/dev/null
+pkill -f "/Users/taichisato/work/homete_iOS/LocalPackage/.build" 2>/dev/null
+# 残骸が無くなったか確認
+ps aux | grep -E "swift-test|swiftpm-testing-helper" | grep "/Users/taichisato/work/homete_iOS/LocalPackage" | grep -v grep
+```
+
+最後のチェックで何も出力されなければ OK。残っていた場合は PID を確認して `kill <PID>` する。
+
 ### 1. ビルド確認
 
 **LocalPackage配下のファイルを変更した場合（通常）:**

--- a/LocalPackage/Sources/Features/HouseworkTemplateFeature/Model/HouseworkTemplateDraft.swift
+++ b/LocalPackage/Sources/Features/HouseworkTemplateFeature/Model/HouseworkTemplateDraft.swift
@@ -1,0 +1,90 @@
+//
+//  HouseworkTemplateDraft.swift
+//  LocalPackage
+//
+//  Created by Taichi Sato on 2026/05/16.
+//
+
+import Foundation
+import HometeDomain
+
+/// 家事テンプレート編集中の状態を表すモデル。曜日別のアイテム集合を保持し、編集操作を提供する。
+struct HouseworkTemplateDraft: Equatable {
+
+    private(set) var days: [DayOfWeek: [HouseworkTemplateItem]]
+
+    init(days: [DayOfWeek: [HouseworkTemplateItem]] = [:]) {
+        self.days = days
+    }
+
+    /// 指定された曜日に登録されているアイテム一覧を返す
+    func items(in day: DayOfWeek) -> [HouseworkTemplateItem] {
+        days[day] ?? []
+    }
+
+    /// あるアイテムが登録されている曜日を表示順で返す
+    func registeredDays(for itemId: HouseworkTemplateItem.ItemId) -> [DayOfWeek] {
+        DayOfWeek.displayOrdered.filter { day in
+            days[day]?.contains(where: { $0.id == itemId }) ?? false
+        }
+    }
+
+    /// 初期状態との差分があるか
+    func hasUnsavedChanges(comparedTo initial: HouseworkTemplateDraft) -> Bool {
+        self != initial
+    }
+
+    /// 新規アイテムを指定された曜日それぞれに追加する
+    mutating func addItem(_ item: HouseworkTemplateItem, to targetDays: Set<DayOfWeek>) {
+        for day in targetDays {
+            days[day, default: []].append(item)
+        }
+    }
+
+    /// 既存アイテムを全曜日から削除し、指定された曜日に再登録する
+    mutating func replaceItem(_ item: HouseworkTemplateItem, in targetDays: Set<DayOfWeek>) {
+        removeItem(item.id, from: nil)
+        addItem(item, to: targetDays)
+    }
+
+    /// アイテムを削除する。`day` を指定するとその曜日のみ、`nil` の場合は全曜日から削除する
+    mutating func removeItem(_ itemId: HouseworkTemplateItem.ItemId, from day: DayOfWeek?) {
+        if let day {
+            days[day]?.removeAll { $0.id == itemId }
+        } else {
+            for day in DayOfWeek.allCases {
+                days[day]?.removeAll { $0.id == itemId }
+            }
+        }
+    }
+
+    /// アイテムを指定された曜日に移動する。同じ曜日へのドロップは何もしない。
+    /// 異なる曜日へ移動した場合は `updatedAt` を `now` に更新する。
+    mutating func moveItem(
+        _ itemId: HouseworkTemplateItem.ItemId,
+        to destination: DayOfWeek,
+        now: Date
+    ) {
+        var movingItem: HouseworkTemplateItem?
+        for day in DayOfWeek.allCases {
+            if let index = days[day]?.firstIndex(where: { $0.id == itemId }) {
+                movingItem = days[day]?.remove(at: index)
+                if day == destination {
+                    if let movingItem {
+                        days[day, default: []].insert(movingItem, at: index)
+                    }
+                    return
+                }
+            }
+        }
+        guard let movingItem else { return }
+        let updated = HouseworkTemplateItem(
+            id: movingItem.id,
+            title: movingItem.title,
+            point: movingItem.point,
+            updatedAt: now
+        )
+        days[destination, default: []].append(updated)
+    }
+
+}

--- a/LocalPackage/Sources/Features/HouseworkTemplateFeature/Template/HouseworkTemplateScreen.swift
+++ b/LocalPackage/Sources/Features/HouseworkTemplateFeature/Template/HouseworkTemplateScreen.swift
@@ -13,7 +13,7 @@ public struct HouseworkTemplateScreen: View {
 
     @Environment(\.houseworkTemplateContext.hasTemplate) var hasTemplate
 
-    @State var initialDays: [DayOfWeek: [HouseworkTemplateItem]] = [:]
+    @State var initialDraft: HouseworkTemplateDraft = .init()
 
     public static func make() -> some View {
         HouseworkTemplateScreen()
@@ -23,7 +23,7 @@ public struct HouseworkTemplateScreen: View {
         NavigationStack {
             HouseworkTemplateView(
                 hasTemplate: hasTemplate,
-                initialDays: initialDays,
+                initialDraft: initialDraft,
                 activeOtherEditorNames: []
             )
         }

--- a/LocalPackage/Sources/Features/HouseworkTemplateFeature/Template/HouseworkTemplateView.swift
+++ b/LocalPackage/Sources/Features/HouseworkTemplateFeature/Template/HouseworkTemplateView.swift
@@ -14,7 +14,7 @@ struct HouseworkTemplateView: View {
     @Environment(\.now) var now
     @Environment(\.dismiss) var dismiss
 
-    @State var editingDays: [DayOfWeek: [HouseworkTemplateItem]] = [:]
+    @State var draft: HouseworkTemplateDraft = .init()
     @State var presentingAddModal = false
     @State var presentingEditModal: HouseworkTemplateItem?
     @State var presentingCancelAlert = false
@@ -22,7 +22,7 @@ struct HouseworkTemplateView: View {
     @State var bannerDismissedInSession = false
 
     let hasTemplate: Bool
-    let initialDays: [DayOfWeek: [HouseworkTemplateItem]]
+    let initialDraft: HouseworkTemplateDraft
     /// 編集中の他ユーザー名（自分以外、アクティブなもの）
     let activeOtherEditorNames: [String]
 
@@ -66,7 +66,7 @@ struct HouseworkTemplateView: View {
             HouseworkTemplateItemEditModal(
                 mode: .edit(before: .init(
                     item: item,
-                    selectedDays: Set(registeredDays(for: item))
+                    selectedDays: Set(draft.registeredDays(for: item.id))
                 ))
             ) { input in
                 tappedEditItemButton(input: input)
@@ -75,7 +75,7 @@ struct HouseworkTemplateView: View {
         .navigationDestination(item: $presentingDetailItem) { item in
             HouseworkTemplateItemDetailView(
                 item: item,
-                registeredDays: registeredDays(for: item),
+                registeredDays: draft.registeredDays(for: item.id),
                 onEdit: { input in
                     tappedEditItemButton(input: input)
                 },
@@ -117,8 +117,8 @@ private extension HouseworkTemplateView {
                 .font(with: .headLineS)
                 .foregroundStyle(.onSubSurface)
             VStack(spacing: .space8) {
-                if let items = editingDays[day],
-                   !items.isEmpty {
+                let items = draft.items(in: day)
+                if !items.isEmpty {
                     ForEach(items, id: \.id) { item in
                         itemRow(item, in: day)
                     }
@@ -196,7 +196,7 @@ private extension HouseworkTemplateView {
         NavigationBarPrimaryActionButton(systemImage: "checkmark") {
             tappedSaveButton()
         }
-        .disabled(!hasUnsavedChanges)
+        .disabled(!draft.hasUnsavedChanges(comparedTo: initialDraft))
     }
 
 }
@@ -205,70 +205,22 @@ private extension HouseworkTemplateView {
 
 private extension HouseworkTemplateView {
 
-    // TODO: ドメインロジックに切り出す
-    var hasUnsavedChanges: Bool {
-        editingDays != initialDays
-    }
-
-    // TODO: ドメインロジックに切り出す
-    func registeredDays(for item: HouseworkTemplateItem) -> [DayOfWeek] {
-        DayOfWeek.displayOrdered.filter { day in
-            editingDays[day]?.contains(where: { $0.id == item.id }) ?? false
-        }
-    }
-
     func tappedCreateItemButton(input: TemplateItemEditInput) {
-        // TODO: ドメインロジックに切り出す
         let item = input.createTemplate(now: now)
-        for day in input.days {
-            editingDays[day, default: []].append(item)
-        }
+        draft.addItem(item, to: input.days)
     }
 
     func tappedEditItemButton(input: TemplateItemEditInput) {
-        // TODO: ドメインロジックに切り出す
-        for day in DayOfWeek.allCases {
-            editingDays[day]?.removeAll { $0.id == input.itemId }
-        }
         let newItem = input.createTemplate(now: now)
-        for day in input.days {
-            editingDays[day, default: []].append(newItem)
-        }
+        draft.replaceItem(newItem, in: input.days)
     }
 
     func tappedDeleteItemButton(itemId: HouseworkTemplateItem.ItemId, from day: DayOfWeek? = nil) {
-        if let day {
-            editingDays[day]?.removeAll { $0.id == itemId }
-        } else {
-            for day in DayOfWeek.allCases {
-                editingDays[day]?.removeAll { $0.id == itemId }
-            }
-        }
+        draft.removeItem(itemId, from: day)
     }
 
     func onDropItem(itemId: HouseworkTemplateItem.ItemId, to destination: DayOfWeek) {
-        // TODO: ドメインロジックに切り出す
-        var movingItem: HouseworkTemplateItem?
-        for day in DayOfWeek.allCases {
-            if let index = editingDays[day]?.firstIndex(where: { $0.id == itemId }) {
-                movingItem = editingDays[day]?.remove(at: index)
-                if day == destination {
-                    // 同じ曜日へのドロップ：何もせず戻す
-                    if let movingItem {
-                        editingDays[day, default: []].insert(movingItem, at: index)
-                    }
-                    return
-                }
-            }
-        }
-        guard let movingItem else { return }
-        let updated = HouseworkTemplateItem(
-            id: movingItem.id,
-            title: movingItem.title,
-            point: movingItem.point,
-            updatedAt: Date()
-        )
-        editingDays[destination, default: []].append(updated)
+        draft.moveItem(itemId, to: destination, now: now)
     }
 
     func tappedCancelButton() {
@@ -277,7 +229,7 @@ private extension HouseworkTemplateView {
 
     func tappedDiscardChangesAlertButton() {
         // コンフリクトしたら、最新のテンプレート内容を再ロードして、編集内容は破棄する
-        editingDays = initialDays
+        draft = initialDraft
     }
 
     func tappedSaveButton() {
@@ -360,9 +312,9 @@ private extension HouseworkTemplateView {
     ]
     NavigationStack {
         HouseworkTemplateView(
-            editingDays: templateData,
+            draft: .init(days: templateData),
             hasTemplate: true,
-            initialDays: templateData,
+            initialDraft: .init(days: templateData),
             activeOtherEditorNames: []
         )
     }
@@ -382,9 +334,9 @@ private extension HouseworkTemplateView {
     ]
     NavigationStack {
         HouseworkTemplateView(
-            editingDays: [:],
+            draft: .init(),
             hasTemplate: true,
-            initialDays: templateData,
+            initialDraft: .init(days: templateData),
             activeOtherEditorNames: ["Aさん", "Bさん"]
         )
     }

--- a/LocalPackage/Tests/HouseworkTemplateFeatureTests/Model/HouseworkTemplateDraftTest.swift
+++ b/LocalPackage/Tests/HouseworkTemplateFeatureTests/Model/HouseworkTemplateDraftTest.swift
@@ -1,0 +1,306 @@
+//
+//  HouseworkTemplateDraftTest.swift
+//  HouseworkTemplateFeatureTests
+//
+//  Created by Taichi Sato on 2026/05/16.
+//
+
+import Foundation
+@testable import HometeDomain
+@testable import HouseworkTemplateFeature
+import Testing
+
+// swiftlint:disable:next convenience_type
+enum HouseworkTemplateDraftTest {
+
+    static func makeItem(
+        id: String,
+        title: String = "title",
+        point: Int = 10,
+        updatedAt: Date = Date(timeIntervalSince1970: 0)
+    ) -> HouseworkTemplateItem {
+        HouseworkTemplateItem(
+            id: .init(id: id),
+            title: title,
+            point: point,
+            updatedAt: updatedAt
+        )
+    }
+
+    struct ItemsInDayCase {}
+    struct RegisteredDaysCase {}
+    struct HasUnsavedChangesCase {}
+    struct AddItemCase {}
+    struct ReplaceItemCase {}
+    struct RemoveItemCase {}
+    struct MoveItemCase {}
+
+}
+
+private typealias TestCase = HouseworkTemplateDraftTest
+
+extension HouseworkTemplateDraftTest.ItemsInDayCase {
+
+    @Test("指定曜日のアイテムを返す")
+    func returnsItemsInDay() {
+        // Arrange
+        let item = TestCase.makeItem(id: "1")
+        let draft = HouseworkTemplateDraft(days: [.monday: [item]])
+
+        // Act
+        let actual = draft.items(in: .monday)
+
+        // Assert
+        #expect(actual == [item])
+    }
+
+    @Test("登録のない曜日では空配列を返す")
+    func returnsEmptyWhenNoItems() {
+        // Arrange
+        let draft = HouseworkTemplateDraft(days: [:])
+
+        // Act
+        let actual = draft.items(in: .friday)
+
+        // Assert
+        #expect(actual == [])
+    }
+
+}
+
+extension HouseworkTemplateDraftTest.RegisteredDaysCase {
+
+    @Test("アイテムが登録されている曜日を表示順で返す")
+    func returnsRegisteredDaysInDisplayOrder() {
+        // Arrange
+        let item = TestCase.makeItem(id: "1")
+        let other = TestCase.makeItem(id: "2")
+        let draft = HouseworkTemplateDraft(days: [
+            .sunday: [item],
+            .tuesday: [item, other],
+            .monday: [other],
+            .friday: [item],
+        ])
+
+        // Act
+        let actual = draft.registeredDays(for: .init(id: "1"))
+
+        // Assert
+        #expect(actual == [.tuesday, .friday, .sunday])
+    }
+
+    @Test("該当アイテムが存在しない場合は空配列を返す")
+    func returnsEmptyWhenItemNotFound() {
+        // Arrange
+        let draft = HouseworkTemplateDraft(days: [
+            .monday: [TestCase.makeItem(id: "1")],
+        ])
+
+        // Act
+        let actual = draft.registeredDays(for: .init(id: "missing"))
+
+        // Assert
+        #expect(actual == [])
+    }
+
+}
+
+extension HouseworkTemplateDraftTest.HasUnsavedChangesCase {
+
+    @Test("内容が同じならfalseを返す")
+    func returnsFalseWhenEqual() {
+        // Arrange
+        let item = TestCase.makeItem(id: "1")
+        let draft = HouseworkTemplateDraft(days: [.monday: [item]])
+        let initial = HouseworkTemplateDraft(days: [.monday: [item]])
+
+        // Act
+        let actual = draft.hasUnsavedChanges(comparedTo: initial)
+
+        // Assert
+        #expect(actual == false)
+    }
+
+    @Test("内容が異なる場合はtrueを返す")
+    func returnsTrueWhenDifferent() {
+        // Arrange
+        let item = TestCase.makeItem(id: "1")
+        let draft = HouseworkTemplateDraft(days: [.monday: [item]])
+        let initial = HouseworkTemplateDraft(days: [:])
+
+        // Act
+        let actual = draft.hasUnsavedChanges(comparedTo: initial)
+
+        // Assert
+        #expect(actual == true)
+    }
+
+}
+
+extension HouseworkTemplateDraftTest.AddItemCase {
+
+    @Test("指定された複数曜日にアイテムを追加する")
+    func addsItemToTargetDays() {
+        // Arrange
+        var draft = HouseworkTemplateDraft(days: [:])
+        let item = TestCase.makeItem(id: "1")
+        let expected = HouseworkTemplateDraft(days: [
+            .monday: [item],
+            .wednesday: [item],
+        ])
+
+        // Act
+        draft.addItem(item, to: [.monday, .wednesday])
+
+        // Assert
+        #expect(draft == expected)
+    }
+
+    @Test("既存のアイテムがある曜日に追加すると末尾に並ぶ")
+    func appendsToExistingDay() {
+        // Arrange
+        let existing = TestCase.makeItem(id: "1")
+        let new = TestCase.makeItem(id: "2")
+        var draft = HouseworkTemplateDraft(days: [.monday: [existing]])
+        let expected = HouseworkTemplateDraft(days: [.monday: [existing, new]])
+
+        // Act
+        draft.addItem(new, to: [.monday])
+
+        // Assert
+        #expect(draft == expected)
+    }
+
+}
+
+extension HouseworkTemplateDraftTest.ReplaceItemCase {
+
+    @Test("全曜日から削除して指定曜日に再登録する")
+    func replacesItemAcrossDays() {
+        // Arrange
+        let oldItem = TestCase.makeItem(id: "1", title: "old")
+        let other = TestCase.makeItem(id: "2")
+        var draft = HouseworkTemplateDraft(days: [
+            .monday: [oldItem, other],
+            .tuesday: [oldItem],
+        ])
+        let newItem = TestCase.makeItem(id: "1", title: "new")
+        let expected = HouseworkTemplateDraft(days: [
+            .monday: [other],
+            .tuesday: [],
+            .wednesday: [newItem],
+            .friday: [newItem],
+        ])
+
+        // Act
+        draft.replaceItem(newItem, in: [.wednesday, .friday])
+
+        // Assert
+        #expect(draft == expected)
+    }
+
+}
+
+extension HouseworkTemplateDraftTest.RemoveItemCase {
+
+    @Test("特定曜日のアイテムだけを削除する")
+    func removesFromSpecificDay() {
+        // Arrange
+        let item = TestCase.makeItem(id: "1")
+        var draft = HouseworkTemplateDraft(days: [
+            .monday: [item],
+            .tuesday: [item],
+        ])
+        let expected = HouseworkTemplateDraft(days: [
+            .monday: [],
+            .tuesday: [item],
+        ])
+
+        // Act
+        draft.removeItem(.init(id: "1"), from: .monday)
+
+        // Assert
+        #expect(draft == expected)
+    }
+
+    @Test("day指定がnilなら全曜日から削除する")
+    func removesFromAllDays() {
+        // Arrange
+        let item = TestCase.makeItem(id: "1")
+        let other = TestCase.makeItem(id: "2")
+        var draft = HouseworkTemplateDraft(days: [
+            .monday: [item, other],
+            .tuesday: [item],
+        ])
+        let expected = HouseworkTemplateDraft(days: [
+            .monday: [other],
+            .tuesday: [],
+        ])
+
+        // Act
+        draft.removeItem(.init(id: "1"), from: nil)
+
+        // Assert
+        #expect(draft == expected)
+    }
+
+}
+
+extension HouseworkTemplateDraftTest.MoveItemCase {
+
+    @Test("異なる曜日に移動するとupdatedAtがnowに更新される")
+    func updatesUpdatedAtOnMove() {
+        // Arrange
+        let baseDate = Date(timeIntervalSince1970: 0)
+        let now = Date(timeIntervalSince1970: 1000)
+        let item = TestCase.makeItem(id: "1", title: "task", point: 5, updatedAt: baseDate)
+        var draft = HouseworkTemplateDraft(days: [.monday: [item]])
+        let movedItem = HouseworkTemplateItem(
+            id: .init(id: "1"),
+            title: "task",
+            point: 5,
+            updatedAt: now
+        )
+        let expected = HouseworkTemplateDraft(days: [
+            .monday: [],
+            .wednesday: [movedItem],
+        ])
+
+        // Act
+        draft.moveItem(.init(id: "1"), to: .wednesday, now: now)
+
+        // Assert
+        #expect(draft == expected)
+    }
+
+    @Test("同じ曜日へのドロップは状態を変えない")
+    func doesNotChangeWhenSameDay() {
+        // Arrange
+        let baseDate = Date(timeIntervalSince1970: 0)
+        let now = Date(timeIntervalSince1970: 1000)
+        let item = TestCase.makeItem(id: "1", updatedAt: baseDate)
+        var draft = HouseworkTemplateDraft(days: [.monday: [item]])
+        let expected = HouseworkTemplateDraft(days: [.monday: [item]])
+
+        // Act
+        draft.moveItem(.init(id: "1"), to: .monday, now: now)
+
+        // Assert
+        #expect(draft == expected)
+    }
+
+    @Test("該当アイテムが存在しない場合は何もしない")
+    func doesNothingWhenItemNotFound() {
+        // Arrange
+        let item = TestCase.makeItem(id: "1")
+        var draft = HouseworkTemplateDraft(days: [.monday: [item]])
+        let expected = HouseworkTemplateDraft(days: [.monday: [item]])
+
+        // Act
+        draft.moveItem(.init(id: "missing"), to: .friday, now: Date(timeIntervalSince1970: 1000))
+
+        // Assert
+        #expect(draft == expected)
+    }
+
+}


### PR DESCRIPTION
## 経緯

`HouseworkTemplateView` 内に `// TODO: ドメインロジックに切り出す` として残っていた編集ロジック（追加・編集・削除・移動・差分検知・登録曜日取得）を、テスト可能なドメインモデルに切り出す。あわせて、Issue #119（テンプレート機能のユニットテスト）に向けた基盤としてユニットテストを追加する。

関連Issue: #116, #119

## 実装内容

- `HouseworkTemplateDraft` を新規追加し、`[DayOfWeek: [HouseworkTemplateItem]]` の編集状態と編集操作（`addItem` / `replaceItem` / `removeItem` / `moveItem` / `registeredDays` / `hasUnsavedChanges` / `items(in:)`）をまとめた
  - View側に散らばっていた `editingDays` 直接操作のロジックを一箇所に集約することで、ロジック単体のテスト可能性を確保するため
  - `moveItem` の `updatedAt` 更新を `now: Date` 引数として外部から渡せる形にしたのは、テスト時に時刻を固定できるようにするため
- `HouseworkTemplateView` / `HouseworkTemplateScreen` の `editingDays` / `initialDays` を `draft` / `initialDraft` に置き換え
  - Viewはドメインモデルの操作呼び出しに専念し、データ構造の詳細を持たないようにする責務分離のため
- `HouseworkTemplateDraftTest` を追加し、各操作の Arrange/Act/Assert スタイルのユニットテストでカバー
  - 1テスト1Actで、戻り値型の全体比較（`#expect(actual == expected)`）でアサーションする規約に準拠
- `.claude/skills/swift-code-verification/SKILL.md` に、検証フロー実行前の stale な `swift-test` プロセス掃除手順を追記
  - 並行作業中のworktreeで `.build` の SwiftPM 排他ロックにより `swift test` が永久待機する事象を防ぐため

## 確認内容

- [x] `swift test --package-path LocalPackage` が成功すること