### PR TITLE
feat: TodayHouseworkSummary ドメインモデルの追加

### DIFF
--- a/.claude/skills/swift-test-implementation/SKILL.md
+++ b/.claude/skills/swift-test-implementation/SKILL.md
@@ -271,17 +271,36 @@ let sut = AllUserViewablePointList<PointOfWeek>(
 
 ## Assertion のルール
 
-- **戻り値の型をそのまま比較する**: `ClosedRange<Date>`、`[Date]` など複合型も `#expect(result == expected)` で比較する
+- **Equatable 型はインスタンス同士で比較する**: `ClosedRange<Date>`、`[Date]` などの複合型や独自の Equatable 型は、プロパティ毎に `#expect` を分けず `#expect(result == expected)` で丸ごと比較する
 - **一部プロパティだけの検証は禁止**: `result.count == 2` や `result.total.value == 80` のような部分検証は行わない
+  - 検証漏れが起きやすい（他のプロパティが期待通りでなくても気づけない）
+  - 失敗時に「どのプロパティが違うか」だけ見て全体像を把握しづらい
+- **Equatable な型に memberwise init がない場合**: テスト用の internal memberwise initializer（または DEBUG only の `makeForTest` ヘルパー）を追加して、expected を組み立てる
 
 ```swift
 // OK: 戻り値の型を直接比較
 let expected = [april1, april6, april11, april30]
 #expect(result == expected)
 
+// OK: 独自Equatable型もインスタンス同士で比較
+let expected = TodayHouseworkSummary.makeForTest(
+    allItems: items,
+    incompleteItems: [item1, item2],
+    progress: 0.5,
+    displayState: .hasIncomplete,
+    displayIncompleteItems: [item1, item2],
+    hasMoreIncomplete: false
+)
+#expect(actual == expected)
+
 // NG: 部分プロパティの検証
 #expect(result.count == 4)
 #expect(result.first == april1)
+
+// NG: 独自Equatable型をプロパティ毎に分割検証
+#expect(summary.displayState == .hasIncomplete)
+#expect(summary.progress == 0.5)
+#expect(summary.incompleteItems == [item1, item2])
 ```
 
 ---

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/TodayHouseworkSummary.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/TodayHouseworkSummary.swift
@@ -27,7 +27,11 @@ public struct TodayHouseworkSummary: Equatable, Sendable {
     /// 未完了家事が表示上限を超えるか
     public let hasMoreIncomplete: Bool
 
-    public init(allItems: [HouseworkItem]) {
+}
+
+public extension TodayHouseworkSummary {
+
+    init(allItems: [HouseworkItem]) {
         let incomplete = allItems.filter { item in
             item.state == .incomplete || item.state == .pendingApproval
         }

--- a/LocalPackage/Sources/Features/HouseworkFeature/Model/TodayHouseworkSummary.swift
+++ b/LocalPackage/Sources/Features/HouseworkFeature/Model/TodayHouseworkSummary.swift
@@ -1,0 +1,67 @@
+//
+//  TodayHouseworkSummary.swift
+//  homete
+//
+//  Created by 佐藤汰一 on 2026/05/18.
+//
+
+import Foundation
+import HometeDomain
+
+/// 当日の家事サマリー（進捗・未完了一覧・表示状態）
+public struct TodayHouseworkSummary: Equatable, Sendable {
+
+    /// サマリーに表示する未完了家事の最大件数
+    public static let displayIncompleteLimit = 4
+
+    /// 当日の全家事
+    public let allItems: [HouseworkItem]
+    /// 未完了家事（`incomplete` + `pendingApproval`）
+    public let incompleteItems: [HouseworkItem]
+    /// 達成率（0.0〜1.0）。家事が0件のときは0
+    public let progress: Double
+    /// 表示状態
+    public let displayState: DisplayState
+    /// サマリーに表示する未完了家事（最大 `displayIncompleteLimit` 件）
+    public let displayIncompleteItems: [HouseworkItem]
+    /// 未完了家事が表示上限を超えるか
+    public let hasMoreIncomplete: Bool
+
+    public init(allItems: [HouseworkItem]) {
+        let incomplete = allItems.filter { item in
+            item.state == .incomplete || item.state == .pendingApproval
+        }
+
+        self.allItems = allItems
+        incompleteItems = incomplete
+
+        if allItems.isEmpty {
+            progress = 0
+            displayState = .empty
+        } else {
+            let completedCount = allItems.count - incomplete.count
+            progress = Double(completedCount) / Double(allItems.count)
+            displayState = incomplete.isEmpty ? .allCompleted : .hasIncomplete
+        }
+
+        displayIncompleteItems = Array(incomplete.prefix(Self.displayIncompleteLimit))
+        hasMoreIncomplete = incomplete.count > Self.displayIncompleteLimit
+    }
+
+}
+
+public extension TodayHouseworkSummary {
+
+    /// サマリーの表示状態
+    enum DisplayState: Equatable, Sendable {
+
+        /// 当日の家事が0件
+        case empty
+        /// 全ての家事が完了
+        case allCompleted
+        /// 未完了の家事がある
+        case hasIncomplete
+
+    }
+
+}

--- a/LocalPackage/Tests/HouseworkFeatureTests/TestHelper/TodayHouseworkSummaryHelper.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/TestHelper/TodayHouseworkSummaryHelper.swift
@@ -1,0 +1,31 @@
+//
+//  TodayHouseworkSummaryHelper.swift
+//  homete
+//
+//  Created by 佐藤汰一 on 2026/05/18.
+//
+
+import HometeDomain
+@testable import HouseworkFeature
+
+extension TodayHouseworkSummary {
+
+    static func makeForTest(
+        allItems: [HouseworkItem] = [],
+        incompleteItems: [HouseworkItem] = [],
+        progress: Double = 0,
+        displayState: DisplayState = .empty,
+        displayIncompleteItems: [HouseworkItem] = [],
+        hasMoreIncomplete: Bool = false
+    ) -> Self {
+        .init(
+            allItems: allItems,
+            incompleteItems: incompleteItems,
+            progress: progress,
+            displayState: displayState,
+            displayIncompleteItems: displayIncompleteItems,
+            hasMoreIncomplete: hasMoreIncomplete
+        )
+    }
+
+}

--- a/LocalPackage/Tests/HouseworkFeatureTests/TodayHouseworkSummaryTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/TodayHouseworkSummaryTest.swift
@@ -30,16 +30,19 @@ extension TodayHouseworkSummaryTest.EmptyCase {
 
         // Act
 
-        let summary = TodayHouseworkSummary(allItems: input)
+        let actual = TodayHouseworkSummary(allItems: input)
 
         // Assert
 
-        #expect(summary.displayState == .empty)
-        #expect(summary.progress == 0)
-        #expect(summary.allItems.isEmpty)
-        #expect(summary.incompleteItems.isEmpty)
-        #expect(summary.displayIncompleteItems.isEmpty)
-        #expect(summary.hasMoreIncomplete == false)
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [],
+            incompleteItems: [],
+            progress: 0,
+            displayState: .empty,
+            displayIncompleteItems: [],
+            hasMoreIncomplete: false
+        )
+        #expect(actual == expected)
     }
 
 }
@@ -50,62 +53,79 @@ extension TodayHouseworkSummaryTest.AllCompletedCase {
     func allCompleted_whenAllItemsCompleted() {
         // Arrange
 
-        let input: [HouseworkItem] = [
-            .makeForTest(id: 1, state: .completed),
-            .makeForTest(id: 2, state: .completed),
-            .makeForTest(id: 3, state: .completed),
-        ]
+        let item1 = HouseworkItem.makeForTest(id: 1, state: .completed)
+        let item2 = HouseworkItem.makeForTest(id: 2, state: .completed)
+        let item3 = HouseworkItem.makeForTest(id: 3, state: .completed)
+        let input: [HouseworkItem] = [item1, item2, item3]
 
         // Act
 
-        let summary = TodayHouseworkSummary(allItems: input)
+        let actual = TodayHouseworkSummary(allItems: input)
 
         // Assert
 
-        #expect(summary.displayState == .allCompleted)
-        #expect(summary.progress == 1.0)
-        #expect(summary.incompleteItems.isEmpty)
-        #expect(summary.displayIncompleteItems.isEmpty)
-        #expect(summary.hasMoreIncomplete == false)
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [item1, item2, item3],
+            incompleteItems: [],
+            progress: 1.0,
+            displayState: .allCompleted,
+            displayIncompleteItems: [],
+            hasMoreIncomplete: false
+        )
+        #expect(actual == expected)
     }
 
 }
 
 extension TodayHouseworkSummaryTest.HasIncompleteCase {
 
-    @Test("未完了の家事がある場合、displayStateは.hasIncompleteになる")
+    @Test("incompleteのみの場合、displayStateは.hasIncompleteになり未完了として集計される")
     func hasIncomplete_whenIncompleteItemExists() {
         // Arrange
 
-        let input: [HouseworkItem] = [
-            .makeForTest(id: 1, state: .incomplete),
-            .makeForTest(id: 2, state: .completed),
-        ]
+        let incomplete = HouseworkItem.makeForTest(id: 1, state: .incomplete)
+        let completed = HouseworkItem.makeForTest(id: 2, state: .completed)
+        let input: [HouseworkItem] = [incomplete, completed]
 
         // Act
 
-        let summary = TodayHouseworkSummary(allItems: input)
+        let actual = TodayHouseworkSummary(allItems: input)
 
         // Assert
 
-        #expect(summary.displayState == .hasIncomplete)
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [incomplete, completed],
+            incompleteItems: [incomplete],
+            progress: 0.5,
+            displayState: .hasIncomplete,
+            displayIncompleteItems: [incomplete],
+            hasMoreIncomplete: false
+        )
+        #expect(actual == expected)
     }
 
-    @Test("pendingApprovalのみの場合でもdisplayStateは.hasIncompleteになる")
+    @Test("pendingApprovalのみの場合でもdisplayStateは.hasIncompleteになり未完了として集計される")
     func hasIncomplete_whenOnlyPendingApprovalExists() {
         // Arrange
 
-        let input: [HouseworkItem] = [
-            .makeForTest(id: 1, state: .pendingApproval),
-        ]
+        let pendingApproval = HouseworkItem.makeForTest(id: 1, state: .pendingApproval)
+        let input: [HouseworkItem] = [pendingApproval]
 
         // Act
 
-        let summary = TodayHouseworkSummary(allItems: input)
+        let actual = TodayHouseworkSummary(allItems: input)
 
         // Assert
 
-        #expect(summary.displayState == .hasIncomplete)
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [pendingApproval],
+            incompleteItems: [pendingApproval],
+            progress: 0,
+            displayState: .hasIncomplete,
+            displayIncompleteItems: [pendingApproval],
+            hasMoreIncomplete: false
+        )
+        #expect(actual == expected)
     }
 
     @Test("incompleteとpendingApprovalの両方を未完了として集計する")
@@ -119,40 +139,75 @@ extension TodayHouseworkSummaryTest.HasIncompleteCase {
 
         // Act
 
-        let summary = TodayHouseworkSummary(allItems: input)
+        let actual = TodayHouseworkSummary(allItems: input)
 
         // Assert
 
-        #expect(summary.incompleteItems == [incomplete, pendingApproval])
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [incomplete, pendingApproval, completed],
+            incompleteItems: [incomplete, pendingApproval],
+            progress: 1.0 / 3.0,
+            displayState: .hasIncomplete,
+            displayIncompleteItems: [incomplete, pendingApproval],
+            hasMoreIncomplete: false
+        )
+        #expect(actual == expected)
     }
 
 }
 
 extension TodayHouseworkSummaryTest.ProgressCase {
 
-    @Test(
-        "進捗率は 完了数 / 全数 で算出する",
-        arguments: [
-            (states: [HouseworkState.completed, .completed, .incomplete, .incomplete], expected: 0.5),
-            (states: [HouseworkState.completed, .incomplete, .incomplete, .incomplete], expected: 0.25),
-            (states: [HouseworkState.completed, .pendingApproval], expected: 0.5),
-            (states: [HouseworkState.incomplete, .pendingApproval], expected: 0.0),
-        ]
-    )
-    func progress_iscompletedCountDividedByAllCount(states: [HouseworkState], expected: Double) {
+    @Test("進捗率は 完了数 / 全数 で算出する（2/4 = 0.5）")
+    func progress_twoOfFour() {
         // Arrange
 
-        let input: [HouseworkItem] = states.enumerated().map { index, state in
-            .makeForTest(id: index + 1, state: state)
-        }
+        let item1 = HouseworkItem.makeForTest(id: 1, state: .completed)
+        let item2 = HouseworkItem.makeForTest(id: 2, state: .completed)
+        let item3 = HouseworkItem.makeForTest(id: 3, state: .incomplete)
+        let item4 = HouseworkItem.makeForTest(id: 4, state: .incomplete)
+        let input: [HouseworkItem] = [item1, item2, item3, item4]
 
         // Act
 
-        let summary = TodayHouseworkSummary(allItems: input)
+        let actual = TodayHouseworkSummary(allItems: input)
 
         // Assert
 
-        #expect(summary.progress == expected)
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [item1, item2, item3, item4],
+            incompleteItems: [item3, item4],
+            progress: 0.5,
+            displayState: .hasIncomplete,
+            displayIncompleteItems: [item3, item4],
+            hasMoreIncomplete: false
+        )
+        #expect(actual == expected)
+    }
+
+    @Test("pendingApprovalは未完了として進捗率に含まれない（1/2 = 0.5）")
+    func progress_pendingApprovalIsCountedAsIncomplete() {
+        // Arrange
+
+        let completed = HouseworkItem.makeForTest(id: 1, state: .completed)
+        let pendingApproval = HouseworkItem.makeForTest(id: 2, state: .pendingApproval)
+        let input: [HouseworkItem] = [completed, pendingApproval]
+
+        // Act
+
+        let actual = TodayHouseworkSummary(allItems: input)
+
+        // Assert
+
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [completed, pendingApproval],
+            incompleteItems: [pendingApproval],
+            progress: 0.5,
+            displayState: .hasIncomplete,
+            displayIncompleteItems: [pendingApproval],
+            hasMoreIncomplete: false
+        )
+        #expect(actual == expected)
     }
 
 }
@@ -163,36 +218,55 @@ extension TodayHouseworkSummaryTest.DisplayIncompleteItemsCase {
     func hasMoreIncomplete_falseWhenIncompleteCountIsLessThanOrEqualToLimit() {
         // Arrange
 
-        let incompleteItems: [HouseworkItem] = (1 ... 4).map {
-            .makeForTest(id: $0, state: .incomplete)
-        }
+        let item1 = HouseworkItem.makeForTest(id: 1, state: .incomplete)
+        let item2 = HouseworkItem.makeForTest(id: 2, state: .incomplete)
+        let item3 = HouseworkItem.makeForTest(id: 3, state: .incomplete)
+        let item4 = HouseworkItem.makeForTest(id: 4, state: .incomplete)
+        let input: [HouseworkItem] = [item1, item2, item3, item4]
 
         // Act
 
-        let summary = TodayHouseworkSummary(allItems: incompleteItems)
+        let actual = TodayHouseworkSummary(allItems: input)
 
         // Assert
 
-        #expect(summary.displayIncompleteItems == incompleteItems)
-        #expect(summary.hasMoreIncomplete == false)
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [item1, item2, item3, item4],
+            incompleteItems: [item1, item2, item3, item4],
+            progress: 0,
+            displayState: .hasIncomplete,
+            displayIncompleteItems: [item1, item2, item3, item4],
+            hasMoreIncomplete: false
+        )
+        #expect(actual == expected)
     }
 
     @Test("未完了が5件以上の場合はhasMoreIncompleteがtrueになり先頭4件のみ表示される")
     func hasMoreIncomplete_trueWhenIncompleteCountExceedsLimit() {
         // Arrange
 
-        let incompleteItems: [HouseworkItem] = (1 ... 5).map {
-            .makeForTest(id: $0, state: .incomplete)
-        }
+        let item1 = HouseworkItem.makeForTest(id: 1, state: .incomplete)
+        let item2 = HouseworkItem.makeForTest(id: 2, state: .incomplete)
+        let item3 = HouseworkItem.makeForTest(id: 3, state: .incomplete)
+        let item4 = HouseworkItem.makeForTest(id: 4, state: .incomplete)
+        let item5 = HouseworkItem.makeForTest(id: 5, state: .incomplete)
+        let input: [HouseworkItem] = [item1, item2, item3, item4, item5]
 
         // Act
 
-        let summary = TodayHouseworkSummary(allItems: incompleteItems)
+        let actual = TodayHouseworkSummary(allItems: input)
 
         // Assert
 
-        #expect(summary.displayIncompleteItems == Array(incompleteItems.prefix(4)))
-        #expect(summary.hasMoreIncomplete == true)
+        let expected = TodayHouseworkSummary.makeForTest(
+            allItems: [item1, item2, item3, item4, item5],
+            incompleteItems: [item1, item2, item3, item4, item5],
+            progress: 0,
+            displayState: .hasIncomplete,
+            displayIncompleteItems: [item1, item2, item3, item4],
+            hasMoreIncomplete: true
+        )
+        #expect(actual == expected)
     }
 
 }

--- a/LocalPackage/Tests/HouseworkFeatureTests/TodayHouseworkSummaryTest.swift
+++ b/LocalPackage/Tests/HouseworkFeatureTests/TodayHouseworkSummaryTest.swift
@@ -1,0 +1,198 @@
+//
+//  TodayHouseworkSummaryTest.swift
+//  hometeTests
+//
+//  Created by 佐藤汰一 on 2026/05/18.
+//
+
+import Foundation
+import HometeDomain
+@testable import HouseworkFeature
+import Testing
+
+enum TodayHouseworkSummaryTest {
+
+    struct EmptyCase {}
+    struct AllCompletedCase {}
+    struct HasIncompleteCase {}
+    struct ProgressCase {}
+    struct DisplayIncompleteItemsCase {}
+
+}
+
+extension TodayHouseworkSummaryTest.EmptyCase {
+
+    @Test("家事が0件の場合、displayStateは.empty・progressは0・未完了リストも空になる")
+    func empty_whenNoItems() {
+        // Arrange
+
+        let input: [HouseworkItem] = []
+
+        // Act
+
+        let summary = TodayHouseworkSummary(allItems: input)
+
+        // Assert
+
+        #expect(summary.displayState == .empty)
+        #expect(summary.progress == 0)
+        #expect(summary.allItems.isEmpty)
+        #expect(summary.incompleteItems.isEmpty)
+        #expect(summary.displayIncompleteItems.isEmpty)
+        #expect(summary.hasMoreIncomplete == false)
+    }
+
+}
+
+extension TodayHouseworkSummaryTest.AllCompletedCase {
+
+    @Test("全ての家事が完了の場合、displayStateは.allCompleted・progressは1.0になる")
+    func allCompleted_whenAllItemsCompleted() {
+        // Arrange
+
+        let input: [HouseworkItem] = [
+            .makeForTest(id: 1, state: .completed),
+            .makeForTest(id: 2, state: .completed),
+            .makeForTest(id: 3, state: .completed),
+        ]
+
+        // Act
+
+        let summary = TodayHouseworkSummary(allItems: input)
+
+        // Assert
+
+        #expect(summary.displayState == .allCompleted)
+        #expect(summary.progress == 1.0)
+        #expect(summary.incompleteItems.isEmpty)
+        #expect(summary.displayIncompleteItems.isEmpty)
+        #expect(summary.hasMoreIncomplete == false)
+    }
+
+}
+
+extension TodayHouseworkSummaryTest.HasIncompleteCase {
+
+    @Test("未完了の家事がある場合、displayStateは.hasIncompleteになる")
+    func hasIncomplete_whenIncompleteItemExists() {
+        // Arrange
+
+        let input: [HouseworkItem] = [
+            .makeForTest(id: 1, state: .incomplete),
+            .makeForTest(id: 2, state: .completed),
+        ]
+
+        // Act
+
+        let summary = TodayHouseworkSummary(allItems: input)
+
+        // Assert
+
+        #expect(summary.displayState == .hasIncomplete)
+    }
+
+    @Test("pendingApprovalのみの場合でもdisplayStateは.hasIncompleteになる")
+    func hasIncomplete_whenOnlyPendingApprovalExists() {
+        // Arrange
+
+        let input: [HouseworkItem] = [
+            .makeForTest(id: 1, state: .pendingApproval),
+        ]
+
+        // Act
+
+        let summary = TodayHouseworkSummary(allItems: input)
+
+        // Assert
+
+        #expect(summary.displayState == .hasIncomplete)
+    }
+
+    @Test("incompleteとpendingApprovalの両方を未完了として集計する")
+    func incompleteItems_includeIncompleteAndPendingApproval() {
+        // Arrange
+
+        let incomplete = HouseworkItem.makeForTest(id: 1, state: .incomplete)
+        let pendingApproval = HouseworkItem.makeForTest(id: 2, state: .pendingApproval)
+        let completed = HouseworkItem.makeForTest(id: 3, state: .completed)
+        let input: [HouseworkItem] = [incomplete, pendingApproval, completed]
+
+        // Act
+
+        let summary = TodayHouseworkSummary(allItems: input)
+
+        // Assert
+
+        #expect(summary.incompleteItems == [incomplete, pendingApproval])
+    }
+
+}
+
+extension TodayHouseworkSummaryTest.ProgressCase {
+
+    @Test(
+        "進捗率は 完了数 / 全数 で算出する",
+        arguments: [
+            (states: [HouseworkState.completed, .completed, .incomplete, .incomplete], expected: 0.5),
+            (states: [HouseworkState.completed, .incomplete, .incomplete, .incomplete], expected: 0.25),
+            (states: [HouseworkState.completed, .pendingApproval], expected: 0.5),
+            (states: [HouseworkState.incomplete, .pendingApproval], expected: 0.0),
+        ]
+    )
+    func progress_iscompletedCountDividedByAllCount(states: [HouseworkState], expected: Double) {
+        // Arrange
+
+        let input: [HouseworkItem] = states.enumerated().map { index, state in
+            .makeForTest(id: index + 1, state: state)
+        }
+
+        // Act
+
+        let summary = TodayHouseworkSummary(allItems: input)
+
+        // Assert
+
+        #expect(summary.progress == expected)
+    }
+
+}
+
+extension TodayHouseworkSummaryTest.DisplayIncompleteItemsCase {
+
+    @Test("未完了が4件以下の場合はhasMoreIncompleteがfalseになり全件表示される")
+    func hasMoreIncomplete_falseWhenIncompleteCountIsLessThanOrEqualToLimit() {
+        // Arrange
+
+        let incompleteItems: [HouseworkItem] = (1 ... 4).map {
+            .makeForTest(id: $0, state: .incomplete)
+        }
+
+        // Act
+
+        let summary = TodayHouseworkSummary(allItems: incompleteItems)
+
+        // Assert
+
+        #expect(summary.displayIncompleteItems == incompleteItems)
+        #expect(summary.hasMoreIncomplete == false)
+    }
+
+    @Test("未完了が5件以上の場合はhasMoreIncompleteがtrueになり先頭4件のみ表示される")
+    func hasMoreIncomplete_trueWhenIncompleteCountExceedsLimit() {
+        // Arrange
+
+        let incompleteItems: [HouseworkItem] = (1 ... 5).map {
+            .makeForTest(id: $0, state: .incomplete)
+        }
+
+        // Act
+
+        let summary = TodayHouseworkSummary(allItems: incompleteItems)
+
+        // Assert
+
+        #expect(summary.displayIncompleteItems == Array(incompleteItems.prefix(4)))
+        #expect(summary.hasMoreIncomplete == true)
+    }
+
+}

--- a/doc/strategy/today-housework-summary.md
+++ b/doc/strategy/today-housework-summary.md
@@ -114,13 +114,13 @@ TodayHouseworkSummary
 
 ### Phase 1: ドメインモデル
 
-- [ ] **T-1** `TodayHouseworkSummary` 値オブジェクトの実装
+- [x] **T-1** `TodayHouseworkSummary` 値オブジェクトの実装
   - 当日の `HouseworkItem` 配列から初期化
   - `incompleteItems`（incomplete + pendingApproval）の抽出
   - `progress`（達成率: completed / all）の算出
   - `displayState`（empty / allCompleted / hasIncomplete）の判定
   - `displayIncompleteItems`（最大4件）と `hasMoreIncomplete` フラグ
-- [ ] **T-2** `TodayHouseworkSummary` のユニットテスト
+- [x] **T-2** `TodayHouseworkSummary` のユニットテスト
   - 家事0件 → `.empty`
   - 全完了 → `.allCompleted`、progress = 1.0
   - 未完了あり → `.hasIncomplete`、progress 計算検証


### PR DESCRIPTION
## 経緯

ダッシュボード機能（#25）の実装にあたり、`doc/strategy/today-housework-summary.md` で定義した Phase 1（T-1 / T-2）の対応として、当日の家事サマリーを表現するドメインモデルを追加する。

UI 実装に先立ってドメイン層を独立に検証可能な値オブジェクトとして切り出し、進捗率・表示状態・未完了一覧の集計ロジックを単体テストで担保する。

## 実装内容

### `TodayHouseworkSummary` 値オブジェクトの追加

- 当日の `HouseworkItem` 配列を入力に、サマリー表示に必要な状態を一度に算出する `Equatable` な値オブジェクトとして実装した
  - View 側で複数のプロパティを個別に計算するとロジックが View に染み出すため、ドメイン層に集約してテスト可能にしている
- `incompleteItems` は `incomplete` と `pendingApproval` の両方を未完了として扱う
  - 「承認待ち」もユーザー視点では「まだ終わっていない家事」であり、ダッシュボード上は未完了として集計するのが仕様（doc 参照）
- `progress` は `完了数 / 全数` で算出し、0件のときは 0 を返す
  - 0件で 0除算 / NaN が UI に伝播するのを避けるため、ドメイン側で吸収している
- `displayState` を `empty` / `allCompleted` / `hasIncomplete` の 3 状態に分離した
  - View 側で `count` や `progress` から状態を導出させると分岐が散らかるため、enum で表現を一意化している
- `displayIncompleteItems` は先頭 `displayIncompleteLimit`(=4) 件に制限し、超過分は `hasMoreIncomplete` で表現する
  - サマリー UI は固定件数表示が要件で、件数判定のロジックも View ではなくドメインに置きたいため

### テスト実装

- `LocalPackage/Tests/HouseworkFeatureTests/TodayHouseworkSummaryTest.swift` にケース別の enum 構造でテストを実装
  - empty / allCompleted / hasIncomplete / progress / displayIncompleteItems の各観点をネストした struct でグループ化し、Xcode 上で見通しを良くしている
- Equatable 型はプロパティ毎ではなくインスタンス同士で比較する方針に統一した
  - プロパティ単位の `#expect` だと検証漏れに気付けないため
  - `TodayHouseworkSummary` には memberwise init がないので、テストヘルパー `makeForTest` を追加して expected を組み立てる
- 上記のアサーション方針を `.claude/skills/swift-test-implementation/SKILL.md` に追記し、後続のテスト実装で迷わないようにした

### ドキュメント更新

- `doc/strategy/today-housework-summary.md` の Phase 1 タスク（T-1 / T-2）を完了状態に更新

## 確認内容

- [x] `swift test --package-path LocalPackage` でユニットテストがすべてパスする
- [x] `TodayHouseworkSummary` を `HouseworkItem` 配列から生成した結果が、各 displayState / progress / hasMoreIncomplete の境界で期待通りになる
- [x] `HouseworkFeature` モジュールの公開 API のみで利用できる（`@testable import` はテスト側のヘルパーのみ）