### PR TITLE
feat: ダッシュボードのテンプレートプロモーションバナーをテンプレート未設定時のみ表示

### DIFF
--- a/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/RegisteredContent.swift
+++ b/LocalPackage/Sources/Features/HomeFeature/HomeView/SubViews/RegisteredContent/RegisteredContent.swift
@@ -16,8 +16,9 @@ struct RegisteredContent: View {
     @Environment(\.adComponentResolver) var adComponentResolver
     @Environment(CohabitantStore.self) var cohabiantStore
     @Environment(ContributionStore.self) var contributionStore
-    @Environment(HouseworkListStore.self) var hoseworkListstore
+    @Environment(HouseworkListStore.self) var houseworkListstore
     @Environment(\.routeResolver) var router
+    @Environment(\.houseworkTemplateContext.hasTemplate) var hasTemplate
 
     @State var isShowHouseworkTemplate = false
 
@@ -33,9 +34,10 @@ struct RegisteredContent: View {
                     ContributionSummaryComponent.make()
                         .padding(.vertical, .space16)
                         .redacted(reason: loadingState.isLoading ? .placeholder : [])
-                    // TODO: テンプレート未設定の場合のみ表示する
-                    PromoteHouseworkTemplateBanner {
-                        isShowHouseworkTemplate = true
+                    if !hasTemplate {
+                        PromoteHouseworkTemplateBanner {
+                            isShowHouseworkTemplate = true
+                        }
                     }
                 }
                 .padding(.horizontal, .space16)
@@ -52,7 +54,7 @@ struct RegisteredContent: View {
         }
         .navigationDestination(for: RegisteredContentRoute.self) { route in
             navigationHandler(route)
-                .environment(hoseworkListstore)
+                .environment(houseworkListstore)
         }
         .fullScreenLoadingIndicator(loadingState)
     }


### PR DESCRIPTION
## 経緯

家事テンプレート機能の追加対応（#67）の一環で、ダッシュボードに `PromoteHouseworkTemplateBanner` を表示する処理は既に組み込まれていたが、TODOコメントとして「テンプレート未設定の場合のみ表示する」という出し分けが未対応のまま残っていた。本PRでこの分岐を実装する。

## 実装内容

- `RegisteredContent` から `@Environment(\.houseworkTemplateContext.hasTemplate)` でテンプレート設定有無を参照し、`hasTemplate == false` の場合のみ `PromoteHouseworkTemplateBanner` を表示するように修正。
  - すでに上位レイヤから `houseworkTemplateContext` が EnvironmentValue として供給されているため、Store を新規に注入するよりも Environment 経由でフラグだけを受け取る方が `RegisteredContent` の責務を増やさず最小差分で済むと判断した。
- あわせて、既存のタイポだった `hoseworkListstore` を `houseworkListstore` に修正。バナー表示の出し分け実装と同じファイル内のため、レビュー負荷を抑えるべく同一PRに含めた。

## 確認内容

- [x] テンプレート未設定の状態でダッシュボードを開いた際に `PromoteHouseworkTemplateBanner` が表示されること
- [x] テンプレート設定済みの状態でダッシュボードを開いた際に `PromoteHouseworkTemplateBanner` が表示されないこと
- [x] バナーをタップして `HouseworkTemplate` 画面が開けること（既存挙動のリグレッションがないこと）