### PR TITLE
feat: テンプレート未設定時の初期テンプレート監視処理を実装

### DIFF
--- a/.github/workflows/ci_local_package.yml
+++ b/.github/workflows/ci_local_package.yml
@@ -17,9 +17,9 @@ permissions:
 
 jobs:
   test:
-    runs-on: macos-15
+    runs-on: macos-26
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.3.app
+      DEVELOPER_DIR: /Applications/Xcode_26.4.1.app
     steps:
       - uses: actions/checkout@v4.2.2
 

--- a/.github/workflows/ci_local_package.yml
+++ b/.github/workflows/ci_local_package.yml
@@ -19,7 +19,7 @@ jobs:
   test:
     runs-on: macos-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_26.1.1.app
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app
     steps:
       - uses: actions/checkout@v4.2.2
 

--- a/LocalPackage/Sources/AppRoot/Dependency/Impl/ImplHouseworkTemplateClient.swift
+++ b/LocalPackage/Sources/AppRoot/Dependency/Impl/ImplHouseworkTemplateClient.swift
@@ -69,6 +69,11 @@ extension HouseworkTemplateClient {
                 firestore.houseworkTemplateDaysRef(cohabitantId: cohabitantId, templateId: templateId)
             }
         },
+        addTemplatesSnapshotListener: { id, cohabitantId in
+            await FirestoreService.shared.addSnapshotListener(id: id) { firestore in
+                firestore.houseworkTemplatesRef(cohabitantId: cohabitantId)
+            }
+        },
         addEditorsSnapshotListener: { id, templateId, cohabitantId in
             await FirestoreService.shared.addSnapshotListener(id: id) { firestore in
                 firestore.houseworkTemplateEditorsRef(cohabitantId: cohabitantId, templateId: templateId)

--- a/LocalPackage/Sources/Features/HouseworkTemplateFeature/Template/HouseworkTemplateScreen.swift
+++ b/LocalPackage/Sources/Features/HouseworkTemplateFeature/Template/HouseworkTemplateScreen.swift
@@ -54,6 +54,11 @@ public struct HouseworkTemplateScreen: View {
                 await onChangeTemplateVersion()
             }
         }
+        .onChange(of: houseworkTemplateListStore.selectedTemplateId) { oldValue, newValue in
+            Task {
+                await onChangeSelectedTemplateId(oldValue: oldValue, newValue: newValue)
+            }
+        }
     }
 
 }
@@ -118,6 +123,20 @@ private extension HouseworkTemplateScreen {
               let templateId = houseworkTemplateListStore.selectedTemplateId,
               let cohabitantId = account.cohabitantId else { return }
 
+        await loadCurrentTemplate(templateId: templateId, cohabitantId: cohabitantId)
+    }
+
+    func onChangeSelectedTemplateId(oldValue: String?, newValue: String?) async {
+        // テンプレート画面内でテンプレートがない状態からテンプレートが作成されたことを検知したら、
+        // 現在のテンプレートの内容をロードする
+        guard oldValue == nil,
+              let newValue,
+              let cohabitantId = account.cohabitantId else { return }
+
+        await loadCurrentTemplate(templateId: newValue, cohabitantId: cohabitantId)
+    }
+
+    func loadCurrentTemplate(templateId: String, cohabitantId: String) async {
         do {
             // バージョンが変わったらテンプレートの内容を再ロードする
             try await houseworkTemplateListStore.loadDays(templateId: templateId, cohabitantId: cohabitantId)

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
@@ -72,10 +72,6 @@ public final class HouseworkTemplateListStore {
             name: name
         )
         try await houseworkTemplateClient.upsertTemplate(newMeta, cohabitantId)
-        templates.append(newMeta)
-        // 選択中のテンプレートを作成したテンプレートに更新
-        selectedDays = []
-        selectedTemplateId = templateId
     }
 
     /// 指定テンプレートの Days SnapshotListener を開始する

--- a/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
+++ b/LocalPackage/Sources/HometeDomain/Cohabitant/HouseworkTemplate/HouseworkTemplateListStore.swift
@@ -16,9 +16,11 @@ public final class HouseworkTemplateListStore {
     public private(set) var selectedTemplateId: String?
 
     private var daysObserveTask: Task<Void, Never>?
+    private var templatesObserveTask: Task<Void, Never>?
 
     private let houseworkTemplateClient: HouseworkTemplateClient
     private let daysListenerKey = "houseworkTemplateDaysListener"
+    private let templatesListenerKey = "houseworkTemplatesListener"
 
     public var context: HouseworkTemplateContext {
         .init(metadata: templates.first, houseworkTemplate: selectedDays)
@@ -45,7 +47,7 @@ public final class HouseworkTemplateListStore {
             try await loadDays(templateId: selectedTemplateId, cohabitantId: cohabitantId)
             await startObservingDays(templateId: selectedTemplateId, cohabitantId: cohabitantId)
         } else {
-            // TODO: テンプレートリストを監視して、作成されたらテンプレートを選択してテンプレートの内容を監視する
+            await startObservingTemplates(cohabitantId)
         }
     }
 
@@ -122,6 +124,35 @@ public final class HouseworkTemplateListStore {
                 selectedDays.append(day)
             }
         }
+    }
+
+}
+
+private extension HouseworkTemplateListStore {
+
+    func startObservingTemplates(_ cohabitantId: String) async {
+        let stream = await houseworkTemplateClient.addTemplatesSnapshotListener(
+            templatesListenerKey,
+            cohabitantId
+        )
+
+        templatesObserveTask = Task {
+            for await templates in stream {
+                // テンプレートが空の場合は何もしない
+                guard let selectedTemplate = templates.first else { continue }
+
+                // テンプレートが設定されたことを検知したら選択テンプレートを更新して、テンプレートの監視を終了する
+                self.templates = templates
+                self.selectedTemplateId = selectedTemplate.templateId
+                await stopObservingTemplates()
+            }
+        }
+    }
+
+    func stopObservingTemplates() async {
+        templatesObserveTask?.cancel()
+        templatesObserveTask = nil
+        await houseworkTemplateClient.removeListener(templatesListenerKey)
     }
 
 }

--- a/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkTemplateClient.swift
+++ b/LocalPackage/Sources/HometeDomain/Dependencies/HouseworkTemplateClient.swift
@@ -44,6 +44,12 @@ public struct HouseworkTemplateClient: Sendable {
         _ cohabitantId: String
     ) async -> AsyncStream<[HouseworkTemplateDay]>
 
+    /// Tesmplates の SnapshotListener
+    public let addTemplatesSnapshotListener: @Sendable (
+        _ id: String,
+        _ cohabitantId: String
+    ) async -> AsyncStream<[HouseworkTemplateMeta]>
+
     /// Editors の SnapshotListener（編集中のみ使用）
     public let addEditorsSnapshotListener: @Sendable (
         _ id: String,
@@ -94,6 +100,10 @@ public struct HouseworkTemplateClient: Sendable {
             _ templateId: String,
             _ cohabitantId: String
         ) async -> AsyncStream<[HouseworkTemplateDay]> = { _, _, _ in .makeStream().stream },
+        addTemplatesSnapshotListener: @Sendable @escaping (
+            _ id: String,
+            _ cohabitantId: String
+        ) async -> AsyncStream<[HouseworkTemplateMeta]> = { _, _ in .makeStream().stream },
         addEditorsSnapshotListener: @Sendable @escaping (
             _ id: String,
             _ templateId: String,
@@ -113,6 +123,7 @@ public struct HouseworkTemplateClient: Sendable {
         self.upsertEditor = upsertEditor
         self.removeEditor = removeEditor
         self.addDaysSnapshotListener = addDaysSnapshotListener
+        self.addTemplatesSnapshotListener = addTemplatesSnapshotListener
         self.addEditorsSnapshotListener = addEditorsSnapshotListener
         self.addMetaVersionSnapshotListener = addMetaVersionSnapshotListener
         self.removeListener = removeListener

--- a/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
@@ -5,6 +5,8 @@
 //  Created by Taichi Sato on 2026/05/09.
 //
 
+// swiftlint:disable file_length
+
 import Foundation
 @testable import HometeDomain
 import Testing
@@ -388,6 +390,78 @@ extension HouseworkTemplateListStoreTest {
         #expect(store.templates == [])
         #expect(store.selectedTemplateId == nil)
         #expect(store.selectedDays == [])
+    }
+
+    @Test("configureを呼んでテンプレートが0件の場合、テンプレートの監視リスナーが登録される")
+    func configureStartsTemplatesObservingWhenEmpty() async throws {
+        // Arrange
+
+        let (templatesStream, templatesContinuation) = AsyncStream<[HouseworkTemplateMeta]>.makeStream()
+        let listenerStartedKeys = TestLockedArray<String>()
+
+        let store = HouseworkTemplateListStore(
+            houseworkTemplateClient: .init(
+                fetchTemplates: { _ in [] },
+                addTemplatesSnapshotListener: { id, cohabitantId in
+                    await listenerStartedKeys.append(id)
+                    #expect(cohabitantId == Self.inputCohabitantId)
+                    return templatesStream
+                }
+            )
+        )
+
+        // Act
+
+        try await store.configure(cohabitantId: Self.inputCohabitantId)
+
+        // Assert
+
+        let startedKeys = await listenerStartedKeys.values
+        #expect(startedKeys == ["houseworkTemplatesListener"])
+
+        // Cleanup
+
+        templatesContinuation.finish()
+    }
+
+    @Test("configureでテンプレートが0件の状態でTemplatesリスナーから値を受信すると、templatesとselectedTemplateIdが反映される")
+    func configureReflectsTemplatesReceivedWhileEmpty() async throws {
+        // Arrange
+
+        let receivedTemplates: [HouseworkTemplateMeta] = [
+            .init(templateId: "newTemplate", name: "新規テンプレ"),
+        ]
+        let (templatesStream, templatesContinuation) = AsyncStream<[HouseworkTemplateMeta]>.makeStream()
+        let store = HouseworkTemplateListStore(
+            houseworkTemplateClient: .init(
+                fetchTemplates: { _ in [] },
+                addTemplatesSnapshotListener: { _, _ in templatesStream }
+            )
+        )
+        try await store.configure(cohabitantId: Self.inputCohabitantId)
+
+        // Act
+
+        let waiter = Task {
+            await withCheckedContinuation { continuation in
+                ObservationHelper.continuousObservationTracking {
+                    store.selectedTemplateId
+                } onChange: {
+                    continuation.resume(returning: ())
+                }
+            }
+        }
+        templatesContinuation.yield(receivedTemplates)
+        await waiter.value
+
+        // Assert
+
+        #expect(store.templates == receivedTemplates)
+        #expect(store.selectedTemplateId == "newTemplate")
+
+        // Cleanup
+
+        templatesContinuation.finish()
     }
 
 }

--- a/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
+++ b/LocalPackage/Tests/HometeDomainTests/HouseworkTemplate/HouseworkTemplateListStoreTest.swift
@@ -101,10 +101,6 @@ struct HouseworkTemplateListStoreTest {
                 name: inputName,
                 cohabitantId: Self.inputCohabitantId
             )
-
-            // Assert
-
-            #expect(store.templates == [expectedMeta])
         }
     }
 
@@ -309,38 +305,6 @@ struct HouseworkTemplateListStoreTest {
 }
 
 extension HouseworkTemplateListStoreTest {
-
-    @Test("テンプレートを新規作成すると、selectedTemplateIdが新規IDに更新されselectedDaysは空になる")
-    func createTemplateUpdatesSelection() async throws {
-        // Arrange
-
-        let inputTemplateId = "newTemplateId"
-        let inputName = "新しいテンプレ"
-        let initialDays: [HouseworkTemplateDay] = [
-            .init(
-                dayOfWeek: .monday,
-                items: [.init(id: .init(id: "old"), title: "古い家事", point: 1, updatedAt: .now)]
-            ),
-        ]
-        let store = HouseworkTemplateListStore(
-            houseworkTemplateClient: .init(),
-            selectedDays: initialDays,
-            selectedTemplateId: "previousTemplateId"
-        )
-
-        // Act
-
-        try await store.createTemplate(
-            templateId: inputTemplateId,
-            name: inputName,
-            cohabitantId: Self.inputCohabitantId
-        )
-
-        // Assert
-
-        #expect(store.selectedTemplateId == inputTemplateId)
-        #expect(store.selectedDays == [])
-    }
 
     @Test("configureを呼ぶと、テンプレート一覧の取得・先頭テンプレートのDays取得・監視開始が行われる")
     func configureLoadsTemplatesAndSelectsFirst() async throws {


### PR DESCRIPTION
## 経緯

#67 のテンプレート機能において、起動時にテンプレートが未設定だった場合に、その後テンプレートが新規作成されてもアプリ側で検知して反映する仕組みが未実装だった（`HouseworkTemplateListStore.configure` 内に TODO として残っていた）。

また、ダッシュボードに表示している「テンプレートを作ろう」プロモーションバナーが常に表示される実装になっていたため、テンプレート未設定時のみ表示する条件分岐も合わせて実装する必要があった。

## 実装内容

### `HouseworkTemplateListStore.configure` のテンプレート監視

- テンプレート一覧が空のときに `addTemplatesSnapshotListener` を開始するよう変更。テンプレートが作成されたら最初の1件を `selectedTemplateId` に設定し、その時点で監視を停止する。
  - 監視を停止する理由: テンプレートが1件でも存在すれば以降は通常の Days 監視ルートに合流するため、Templates の監視を続ける必要がない。リスナーを残し続けると Firestore の通信コストとリソースが無駄になる。
- `createTemplate` 内で `templates` / `selectedTemplateId` / `selectedDays` をローカル更新していた処理を削除。SnapshotListener 側で反映されるため、二重更新を避けて状態の一元管理に寄せた。
- `HouseworkTemplateClient` に `addTemplatesSnapshotListener` を追加し、`ImplHouseworkTemplateClient` で `FirestoreService.shared.addSnapshotListener` を使った実装を提供。

### `HouseworkTemplateScreen` での反映処理

- テンプレート画面を開いた状態のままテンプレートが新規作成されるケースに対応するため、`selectedTemplateId` が `nil` から値ありに変わったことを `onChange` で検知して、当該テンプレートの Days を読み込む処理を追加。
- 既存の `onChangeTemplateVersion` と処理が重複していたため、共通処理を `loadCurrentTemplate` として private 関数に切り出して再利用。

### ダッシュボードのテンプレートプロモーションバナー

- `RegisteredContent` で `houseworkTemplateContext.hasTemplate` を Environment から受け取り、`!hasTemplate` のときのみ `PromoteHouseworkTemplateBanner` を表示する条件分岐を追加。
- ついでにタイポしていた `hoseworkListstore` → `houseworkListstore` を修正。

### テスト

- `createTemplate` のローカル更新を削除したため、関連する既存テスト（`createTemplate` 直後に `templates` / `selectedTemplateId` を検証するテスト）を削除。
- 新規追加: `configure` 時にテンプレートが0件だと監視リスナーが登録されること、リスナー経由でテンプレートを受信したら `templates` / `selectedTemplateId` に反映されることのテストケースを追加。

## 確認内容

- [x] テンプレート未作成状態でアプリを起動 → ダッシュボードにテンプレート促進バナーが表示される
- [x] ダッシュボードのバナーからテンプレート作成画面を開き、テンプレートを新規作成 → ダッシュボードに戻るとバナーが非表示になる
- [x] テンプレート画面を開いた状態のまま、別画面（または同じ画面のフロー）でテンプレートを作成 → 画面内に作成したテンプレートの内容が反映される
- [x] `swift test` がパスすること