### PR TITLE
chore: wt worktree作成時に秘密情報ファイルをコピーできるようにする

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,8 @@
+# wt (worktrunk) プロジェクト設定
+# https://worktrunk.dev
+
+[pre-start]
+# GoogleService-Info*.plist / .env / private_keys など、git管理外の秘密情報を
+# 新規worktreeへコピーする。対象は .worktreeinclude で限定している。
+# ビルド・実行に必要なため pre-start（worktree作成をブロックしてでも先に完了させる）で実行する。
+copy-secrets = "wt step copy-ignored"

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ GoogleService-Info-dev.plist
 .env
 scripts/appstoreconnect.env
 scripts/revenuecat.env
+homete/Resouces/Secret.xcconfig
+homete/Resouces/Secret_dev.xcconfig
 
 # other
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ xcuserdata/
 *.dSYM.zip
 *.dSYM
 
+## Xcode Cloud
+homete.xcodeproj/xcshareddata/xcodecloud/
+
 ## Playgrounds
 timeline.xctimeline
 playground.xcworkspace

--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,8 @@ private_keys/
 GoogleService-Info.plist
 GoogleService-Info-dev.plist
 .env
+scripts/appstoreconnect.env
+scripts/revenuecat.env
 
 # other
 

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -10,3 +10,5 @@ GoogleService-Info-dev.plist
 fastlane/.env
 scripts/appstoreconnect.env
 scripts/revenuecat.env
+homete/Resouces/Secret.xcconfig
+homete/Resouces/Secret_dev.xcconfig

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -8,3 +8,5 @@ GoogleService-Info.plist
 GoogleService-Info-dev.plist
 .env
 fastlane/.env
+scripts/appstoreconnect.env
+scripts/revenuecat.env

--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,10 @@
+# wt step copy-ignored でコピーする対象を限定するファイル
+# gitignore対象 かつ ここに記載されたパターンに一致するファイルのみコピーされる
+# （Build/ などの巨大なビルド成果物を誤ってコピーしないため）
+
+# secret（.gitignoreの「# secret」セクションと対応）
+private_keys/
+GoogleService-Info.plist
+GoogleService-Info-dev.plist
+.env
+fastlane/.env


### PR DESCRIPTION
## Summary
- `wt` (worktrunk) でworktreeを作成した際、git管理外の秘密情報ファイル（GoogleService-Info*.plist、.env等）が引き継がれず手動コピーが必要だった問題を解消
- `pre-start`フックで`wt step copy-ignored`を実行し、`.worktreeinclude`でコピー対象を秘密情報ファイルに限定
- `scripts/appstoreconnect.env`と`scripts/revenuecat.env`をgit管理対象外に追加し、同様にworktreeへ引き継げるようにした

## Test plan
- [ ] `wt hook show` でproject hookとして`pre-start copy-secrets`が認識されることを確認済み
- [ ] `wt switch --create <branch>` で新規worktree作成時に秘密情報ファイルがコピーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)