### PR TITLE
fix: worktreeinclude で settings.local.json を引き継ぎ対象に追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -12,3 +12,6 @@ scripts/appstoreconnect.env
 scripts/revenuecat.env
 homete/Resouces/Secret.xcconfig
 homete/Resouces/Secret_dev.xcconfig
+
+# Claude Code設定（sandbox無効化・Bash許可ルールをworktreeにも引き継ぐ）
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- worktree作成時、`.claude/settings.local.json` がコピーされず、sandbox無効化設定やswift build/test等のBash許可ルールがworktree側で効かないままになっていた
- 結果として `feat/licence-view` worktreeでの実装検証時に、swift build / swift test / git commit / gh pr create のたびにサンドボックス起因の失敗が発生し、都度 `dangerouslyDisableSandbox` での再実行が必要になっていた
- `.worktreeinclude` に `.claude/settings.local.json` を追加し、今後作成するworktreeに自動的に引き継がれるようにした

## Test plan
- [ ] 新規worktreeを作成し、`.claude/settings.local.json` がコピーされることを確認
- [ ] 新規worktree上で `swift build` / `swift test` がサンドボックス許可プロンプトなしで実行できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)