### PR TITLE
Claude Codeの自律実行を成立させる（サンドボックス・許可モード・検証フック）

### DIFF
--- a/.claude/rules/claude-config-update.md
+++ b/.claude/rules/claude-config-update.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - ".claude/**"
+  - "CLAUDE.md"
+  - ".worktreeinclude"
+---
+
+# Claude Code設定の更新ルール
+
+Claude Code の設定（`settings.json` / `settings.local.json` / `.claude/rules/` / `.claude/skills/` / `.claude/agents/` / `.claude/commands/` / `CLAUDE.md`）を更新・追加する前に、必ず `improve-setting` スキルを参照すること。
+
+変更対象ごとにロードすべきデフォルトスキル（`update-config`、`example-skills:skill-creator`、`keybindings-help` など）と、マージ編集 → `jq` 検証 → 反映タイミングの伝達までの手順は当該スキルに集約されている。
+
+## このリポジトリ固有の事情
+
+### settings.local.json は worktree に引き継がれる
+
+`.worktreeinclude` に `.claude/settings.local.json` が登録されているため、gitignore 対象でありながら `wt step copy-ignored` で新規 worktree にコピーされる。
+
+つまり `settings.local.json` に入れた設定は**このリポジトリの全 worktree に伝播する**。マシン固有の絶対パスを含む許可ルールを足すときは、worktree 側（`../<branch-name>` 階層）でも成立するかを考えること。逆に、worktree でも効かせたい個人設定はここに置けばよい。
+
+### 書き分け
+
+- 個人用の `allow` 許可ルール → `.claude/settings.local.json`
+- チーム全員に効かせたい `deny`（秘匿ファイルの読み書き禁止など） → `.claude/settings.json`（コミット対象）
+
+`.claude/settings.json` には `Secret*.xcconfig`・`GoogleService-Info*.plist`・`private_keys/` などの deny が既にある。deny は allow より優先されるため、これらに一致する allow を足しても効かない。
+
+### ルール追加時の `paths:` は必須
+
+`.claude/rules/` に追加するファイルには必ず `paths:` frontmatter を付ける（詳細は CLAUDE.md「ルール（.claude/rules/）の運用」）。Swift実装に関するルールに `firebase/functions/**` を含めるような、対象の広げすぎをしない。
+
+### ADR の対象になる場合がある
+
+プラグイン導入・MCPサーバ追加・フックによるワークフロー自動化など、開発フローの技術選定に相当する設定変更を行った場合は `.claude/rules/adr.md` に従って `doc/adr/` に ADR を残す。単なる許可ルールの追加は対象外。

--- a/.claude/rules/prefire-canimport.md
+++ b/.claude/rules/prefire-canimport.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/*.swift"
+---
+
 # Prefireインポートのルール
 
 `LocalPackage/Package.swift` で `Prefire` プロダクトは `condition: .when(platforms: [.iOS])` でiOSプラットフォーム限定でリンクされている。そのため、`swift test --package-path LocalPackage`（`make test-packages`）が実行するホストmacOS向けビルドでは `Prefire` モジュールが存在せず、無条件の `import Prefire` は `error: no such module 'Prefire'` でビルド失敗する。

--- a/.claude/rules/swift-code-verification.md
+++ b/.claude/rules/swift-code-verification.md
@@ -1,5 +1,6 @@
 ---
-applyTo: "**/*.swift"
+paths:
+  - "**/*.swift"
 ---
 
 # Swiftコード変更後の検証ルール

--- a/.claude/rules/swift-code-verification.md
+++ b/.claude/rules/swift-code-verification.md
@@ -14,4 +14,5 @@ Swiftファイル（`*.swift`）を編集・作成・削除した後は、必ず
 
 許可ツール（プロジェクトの `.claude/settings.local.json` に登録済み）:
 - `Bash(swift build:*)`, `Bash(swift test:*)`, `Bash(xcodebuild:*)`, `Bash(ProjectTools/.build/arm64-apple-macosx/debug/swiftlint lint:*)`
-- **サンドボックスは有効**（`sandbox.enabled: true`）。SwiftPM系コマンドは `dangerouslyDisableSandbox: true` を付けて実行すること（理由はスキル参照）
+- **サンドボックスは有効**（`sandbox.enabled: true`）。SwiftPM系コマンドには **`--disable-sandbox` フラグ**を付けて、Claudeのサンドボックス**内**で実行すること。`dangerouslyDisableSandbox: true` は使わない（allowルールを迂回して必ず許可プロンプトが出るため、自律実行が止まる）。理由と許可済みキャッシュパスはスキル参照
+- `make build-local-package` / `make test-packages` / `make format` には `--disable-sandbox` が既に入っている

--- a/.claude/rules/swift-code-verification.md
+++ b/.claude/rules/swift-code-verification.md
@@ -16,3 +16,7 @@ Swiftファイル（`*.swift`）を編集・作成・削除した後は、必ず
 - `Bash(swift build:*)`, `Bash(swift test:*)`, `Bash(xcodebuild:*)`, `Bash(ProjectTools/.build/arm64-apple-macosx/debug/swiftlint lint:*)`
 - **サンドボックスは有効**（`sandbox.enabled: true`）。SwiftPM系コマンドには **`--disable-sandbox` フラグ**を付けて、Claudeのサンドボックス**内**で実行すること。`dangerouslyDisableSandbox: true` は使わない（allowルールを迂回して必ず許可プロンプトが出るため、自律実行が止まる）。理由と許可済みキャッシュパスはスキル参照
 - `make build-local-package` / `make test-packages` / `make format` には `--disable-sandbox` が既に入っている
+
+## 自動検証（Stopフック）
+
+ターン終了時に `scripts/claude-verify-swift.sh` が走り、Swiftに変更があれば `make test-packages` を実行する。失敗すると exit 2 で作業が差し戻されるので、**手順を飛ばしても最終的には検証される**。ただし差し戻しは遅く、3回連続失敗で自動検証は止まるため、フックに頼らず上記の手順を自分で実行すること。設計は [ADR-0006](../../doc/adr/0006-claude-code-autonomous-execution.md)。

--- a/.claude/rules/swift-code-verification.md
+++ b/.claude/rules/swift-code-verification.md
@@ -13,4 +13,4 @@ Swiftファイル（`*.swift`）を編集・作成・削除した後は、必ず
 
 許可ツール（プロジェクトの `.claude/settings.local.json` に登録済み）:
 - `Bash(swift build:*)`, `Bash(swift test:*)`, `Bash(xcodebuild:*)`, `Bash(ProjectTools/.build/arm64-apple-macosx/debug/swiftlint lint:*)`
-- サンドボックスは無効化済み（Swift PM の sandbox-exec ネスト問題のため）
+- **サンドボックスは有効**（`sandbox.enabled: true`）。SwiftPM系コマンドは `dangerouslyDisableSandbox: true` を付けて実行すること（理由はスキル参照）

--- a/.claude/rules/swift-test-implementation.md
+++ b/.claude/rules/swift-test-implementation.md
@@ -1,5 +1,6 @@
 ---
-applyTo: "**/*Test.swift,**/*Tests.swift,**/Tests/**/*.swift"
+paths:
+  - "LocalPackage/Tests/**/*.swift"
 ---
 
 # Swiftテスト実装ルール

--- a/.claude/rules/swiftui-push-navigation.md
+++ b/.claude/rules/swiftui-push-navigation.md
@@ -1,6 +1,6 @@
 ---
 paths:
-  - "LocalPackage/Sources/**/*.swift"
+  - "**/*.swift"
 ---
 
 # SwiftUI Push遷移の実装ルール

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,5 +24,15 @@
       "Edit(homete/Resouces/Secret.xcconfig)",
       "Edit(homete/Resouces/Secret_dev.xcconfig)"
     ]
+  },
+  "sandbox": {
+    "filesystem": {
+      "allowWrite": [
+        "~/Library/org.swift.swiftpm",
+        "~/Library/Caches/org.swift.swiftpm",
+        "~/Library/Caches/SwiftLint",
+        "~/Library/Developer/Xcode/DerivedData"
+      ]
+    }
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,21 @@
       "Edit(homete/Resouces/Secret_dev.xcconfig)"
     ]
   },
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PROJECT_DIR:-.}/scripts/claude-verify-swift.sh\"",
+            "asyncRewake": true,
+            "timeout": 1200,
+            "statusMessage": "Swift検証中（ビルド・SwiftLint・テスト）"
+          }
+        ]
+      }
+    ]
+  },
   "sandbox": {
     "filesystem": {
       "allowWrite": [

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -41,6 +41,17 @@
     ]
   },
   "sandbox": {
+    "network": {
+      "allowedDomains": [
+        "github.com",
+        "api.github.com",
+        "raw.githubusercontent.com",
+        "objects.githubusercontent.com",
+        "codeload.github.com",
+        "code.claude.com",
+        "docs.claude.com"
+      ]
+    },
     "filesystem": {
       "allowWrite": [
         "~/Library/org.swift.swiftpm",

--- a/.claude/skills/swift-code-verification/SKILL.md
+++ b/.claude/skills/swift-code-verification/SKILL.md
@@ -13,7 +13,20 @@ Swiftファイル（`*.swift`）を編集・作成・削除した後は、必ず
 このスキルは Bash コマンドを以下の許可ルール下で実行する想定（プロジェクトの `.claude/settings.local.json` に登録済み）:
 - `Bash(swift build:*)`, `Bash(swift test:*)`, `Bash(xcodebuild:*)`, `Bash(ProjectTools/.build/arm64-apple-macosx/debug/swiftlint lint:*)`
 
-サンドボックスはプロジェクト設定で無効化済み（Swift PM の sandbox-exec ネスト問題回避のため）。`dangerouslyDisableSandbox` を明示する必要はない。
+### サンドボックスの扱い（重要）
+
+プロジェクトの `.claude/settings.local.json` では**サンドボックスが有効**（`sandbox.enabled: true`、`autoAllowBashIfSandboxed: true`）。
+
+SwiftPM は Package.swift のマニフェスト評価を自前の `sandbox-exec` で行うため、Claude のサンドボックス内で実行するとネストになり失敗する:
+
+```
+sandbox-exec: sandbox_apply: Operation not permitted
+error: invalid manifests at [...]
+```
+
+そのため **`swift build` / `swift test` / `swift package` は `dangerouslyDisableSandbox: true` を付けて実行する**。付けずに失敗した場合は、上記メッセージを確認したうえで即座に付け直して再実行してよい。
+
+他のコマンド（swiftlint など）はサンドボックス内で動くので、原則そのまま実行し、`Operation not permitted` 系の失敗が出たときだけ同様に切り替える。
 
 ---
 

--- a/.claude/skills/swift-code-verification/SKILL.md
+++ b/.claude/skills/swift-code-verification/SKILL.md
@@ -57,7 +57,7 @@ SwiftPM と SwiftLint はホームディレクトリ配下のキャッシュに�
 
 **worktreeで並列作業している場合、他worktreeのプロセスを誤って kill しないよう、`--package-path` は必ず現在のworktreeの絶対パスで指定する**（相対パス `LocalPackage` だとどのworktreeでもコマンドライン文字列が同じになり、`pkill -f` が他worktreeのプロセスまで巻き込んでしまう）。以降の手順1・3のコマンドも同様に絶対パスを使うこと。
 
-検証フローを始める前に、必ず以下を実行して掃除する:
+**`make test-packages` / `make build-local-package` は `$(CURDIR)` 基準で同じ掃除を先頭で実行するので、make 経由なら手順0は不要。** `swift` を直接叩く場合のみ以下を実行する:
 
 ```bash
 # 現在のworktreeのLocalPackage絶対パスを基準にする

--- a/.claude/skills/swift-code-verification/SKILL.md
+++ b/.claude/skills/swift-code-verification/SKILL.md
@@ -24,9 +24,28 @@ sandbox-exec: sandbox_apply: Operation not permitted
 error: invalid manifests at [...]
 ```
 
-そのため **`swift build` / `swift test` / `swift package` は `dangerouslyDisableSandbox: true` を付けて実行する**。付けずに失敗した場合は、上記メッセージを確認したうえで即座に付け直して再実行してよい。
+**解決策は SwiftPM 側のサンドボックスを切ること（`--disable-sandbox`）であって、Claude 側のサンドボックスを切ること（`dangerouslyDisableSandbox: true`）ではない。**
 
-他のコマンド（swiftlint など）はサンドボックス内で動くので、原則そのまま実行し、`Operation not permitted` 系の失敗が出たときだけ同様に切り替える。
+理由が重要で、`dangerouslyDisableSandbox: true` は allow ルールの有無に関係なく**必ず許可ゲートを通る**。`Bash(swift *)` が許可済みでも、この引数を付けた瞬間に毎回ユーザーへの確認（auto mode なら分類器）が走る。つまりこれを使い続ける限り、許可ルールをいくら足しても自律実行にならない。
+
+一方 `--disable-sandbox` は SwiftPM に渡す普通のフラグなので、コマンドは Claude のサンドボックス**内**で完結し、`autoAllowBashIfSandboxed: true` によって無確認で実行される。ネットワーク・ファイルシステムの隔離もそのまま効いたままになる。
+
+```bash
+swift build --package-path "$(pwd)/LocalPackage" --disable-sandbox ...
+swift test  --package-path "$(pwd)/LocalPackage" --disable-sandbox ...
+```
+
+`make build-local-package` / `make test-packages` / `make format` には既に `--disable-sandbox` が入っているので、これらを使う場合は何も足さなくてよい。
+
+SwiftPM と SwiftLint はホームディレクトリ配下のキャッシュに書き込む。以下は `settings.local.json` の `sandbox.filesystem.allowWrite` で許可済み:
+
+- `~/Library/org.swift.swiftpm`、`~/Library/Caches/org.swift.swiftpm`（マニフェストキャッシュ。無いとビルドが毎回遅くなる）
+- `~/Library/Caches/SwiftLint`（SwiftLintプラグインのキャッシュ。無いとビルドが失敗する）
+- `~/Library/Developer/Xcode/DerivedData`（xcodebuild用）
+
+`attempt to write a readonly database` や `You don't have permission to save the file ...` が出たら、書き込み先を特定して `allowWrite` に足す。**この設定はセッション開始時にしか読まれない**ので、追加後は再起動が必要。
+
+他のコマンド（swiftlint 単体実行など）はサンドボックス内でそのまま動く。`dangerouslyDisableSandbox: true` は最後の手段であり、まず「サンドボックス内で動かすには何を許可すればよいか」を考えること。
 
 ---
 
@@ -57,7 +76,7 @@ ps aux | grep -E "swift-test|swiftpm-testing-helper" | grep "${LOCAL_PACKAGE_PAT
 **LocalPackage配下のファイルを変更した場合（通常）:**
 
 ```bash
-swift build --package-path "$(pwd)/LocalPackage" --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios26.2-simulator
+swift build --package-path "$(pwd)/LocalPackage" --disable-sandbox --sdk $(xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios26.2-simulator
 ```
 
 **メインターゲット（`homete/`配下）を変更した場合のみ:**
@@ -81,7 +100,7 @@ ProjectTools/.build/arm64-apple-macosx/debug/swiftlint lint
 ### 3. ユニットテスト実行（省略不可）
 
 ```bash
-swift test --package-path "$(pwd)/LocalPackage" --enable-code-coverage
+swift test --package-path "$(pwd)/LocalPackage" --disable-sandbox --enable-code-coverage
 ```
 
 特定のテストだけ流したいときは `--filter "TestSuite名"` を追加する。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,13 +16,23 @@ hometeは同居人（ルームメイト/家族）間で家事を管理するた�
 ### iOS開発
 
 ```bash
-# SwiftLint（CIでDanger経由で実行、スタンドアロンでは実行しない）
-swift run --package-path ProjectTools swiftlint lint --config .swiftlint.yml
+# LocalPackageのユニットテスト（最も使う。xcodebuildは使わない）
+make test-packages
 
-# ProjectToolsのセットアップ（Danger、SwiftLint）
+# LocalPackageをiOSシミュレーター向けにビルド
+make build-local-package
+
+# SwiftFormatを全体にかける
+make format
+
+# SwiftLint（ビルド時にSPMプラグインとして自動実行される。単体で流す場合）
+ProjectTools/.build/arm64-apple-macosx/debug/swiftlint lint
+
+# プロジェクトのセットアップ（ProjectToolsビルド、証明書、git hooks）
 make setup-project
-# または: swift build --package-path ProjectTools --scratch-path ProjectTools/.build
 ```
+
+`make` の各ターゲットには `--disable-sandbox` が付いている。理由は `.claude/skills/swift-code-verification/SKILL.md` を参照。
 
 ### Firebase Functions
 
@@ -81,17 +91,20 @@ Services（Firestore、SignInWithApple、P2P、NotificationCenter）
 Domain Models（Codable構造体）
 ```
 
+**マルチモジュール構成**（SPM）: 実装コードはメインターゲットではなく `LocalPackage/` に置かれている。モジュールの一覧・責務・依存関係は **[doc/multimodules_structure.md](doc/multimodules_structure.md)** が正。採用経緯は [ADR-0001](doc/adr/0001-spm-multimodule-structure.md)。
+
 **主要ディレクトリ:**
-- `homete/Views/` - 機能別に整理されたSwiftUIビュー（Auth、HomeView、HouseworkBoardViewなど）
-- `homete/Model/Domain/` - ビジネスロジックモデル（Account、Housework、Cohabitant）
-- `homete/Model/Dependencies/` - Dependency Injection用のクライアントプロトコル
-- `homete/Model/Store/` - Observableな状態管理クラス（@Observableクラス）
-- `homete/Model/Service/` - インフラ層の実装（Firestore、SignInWithApple、P2P）
+- `LocalPackage/Sources/HometeDomain/` - ドメインモデル・Clientプロトコル・Store・UseCase（最下層、依存なし）
+- `LocalPackage/Sources/Features/` - 機能別SwiftUIビュー（Auth / Home / Housework / HouseworkTemplate / Setting / Contribution）
+- `LocalPackage/Sources/HometeUI/` - デザインシステム・共通コンポーネント・Viewユーティリティ
+- `LocalPackage/Sources/HometeInfrastructure/` - Clientの`liveValue`実装とService（Firestore、SignInWithApple、Purchase、Advertisement）
+- `LocalPackage/Sources/HometeResources/` - アセットとSwiftGen生成コード
+- `LocalPackage/Sources/AppRoot/` - RootView・AppTabView・依存注入レイヤ
 
 **エントリーポイント:**
-- `homete/Views/HometeApp.swift` - アプリのエントリーポイント、Firebaseの初期化
-- `homete/Views/RootView/RootView.swift` - 起動状態マシン（launching → login → logged in）
-- `homete/Model/AppDependencies.swift` - Dependency Injectionコンテナ
+- `homete/Views/HometeApp.swift` - アプリのエントリーポイント、Firebaseの初期化（メインターゲットにある実装コードはこれだけ）
+- `LocalPackage/Sources/AppRoot/RootView.swift` - 起動状態マシン（launching → login → logged in）
+- `LocalPackage/Sources/HometeDomain/Dependencies/AppDependencies.swift` - Dependency Injectionコンテナ
 
 ### Dependency Injectionパターン
 
@@ -112,7 +125,7 @@ View → Store（AppDependenciesを受け取る）
 
 ### Firebase連携
 
-**Firestoreサービス** (`homete/Model/Service/Firestore/FirestoreService.swift`):
+**Firestoreサービス** (`LocalPackage/Sources/HometeInfrastructure/Firestore/FirestoreService.swift`):
 - スレッドセーフのためにactorベース
 - 汎用CRUD: `fetch()`, `insertOrUpdate()`, `delete()`
 - `AsyncStream`を使ったリアルタイムリスナー
@@ -123,7 +136,7 @@ View → Store（AppDependenciesを受け取る）
 - `deleteuserdata` - アカウント削除時のユーザーデータクリーンアップ（v1 authトリガー）
 
 **認証:**
-- `homete/Model/Service/SignInWithApple/`経由でSign in with Apple
+- `LocalPackage/Sources/HometeInfrastructure/SignInWithApple/`経由でSign in with Apple（プロトコルは`HometeDomain/SignInWithApple/`）
 - `AccountAuthClient`がFirebase Auth操作をラップ
 
 ### 状態管理
@@ -133,7 +146,7 @@ View → Store（AppDependenciesを受け取る）
 - Swift 6のstrict concurrencyでアクター分離と`@Sendable`
 - 全体的にasync/await、completion handlerは使わない
 
-**起動状態マシン** （RootViewの`LaunchState` enum）:
+**起動状態マシン** （`HometeDomain/AppLaunch/LaunchState.swift` の enum を `AppRoot/RootView.swift` が分岐）:
 ```
 launching → notLoggedIn → Sign In with Apple
          ↓
@@ -144,15 +157,17 @@ launching → notLoggedIn → Sign In with Apple
 
 ### テスト戦略
 
-**ユニットテスト** (`hometeTests/`):
-- テストプラン: `CI.xctestplan`
-- ロケール: 日本語（ja/JP）、タイムゾーン: 東京
-- プラットフォーム: iOSシミュレーター（iPhone 16、iOS 18.6）
+**ユニットテスト** (`LocalPackage/Tests/`):
+- テストターゲット: `HometeDomainTests`、`HouseworkFeatureTests`、`ContributionFeatureTests`、`HouseworkTemplateFeatureTests`
+- 実行: `make test-packages`（`swift test`。xcodebuildは使わない）
+- Xcode経由で流す場合のテストプラン: `homete.xctestplan`（上記4ターゲットを含む）
+- CI: `.github/workflows/ci_local_package.yml`（`LocalPackage/**` の変更でトリガー、macos-26 / Xcode 26.4.1）
 
 **スナップショットテスト** (`hometeSnapshotTests/`):
 - ライブラリ: PointFreeのswift-snapshot-testing 1.18.7
-- テストプラン: `snapshotTesting.xctestplan`
-- Prefire連携（`.prefire.yml`）でプレビュースナップショット
+- テストプラン: `snapshotTesting.xctestplan`（言語は`-AppleLanguages (ja)`で日本語固定）
+- Prefire連携（`.prefire.yml`）でプレビューからテストを生成。対象ソースは `homete/Views` と `LocalPackage/Sources`
+- 収録デバイス: iPhone 16 / iPhone SE (2nd generation)、必要OS: 27
 - CI上で失敗時は`Build/VRT/SnapshotsFailures`にアップロード
 
 **Firebase Functions E2Eテスト** (`firebase/functions/test/`):
@@ -199,7 +214,7 @@ launching → notLoggedIn → Sign In with Apple
 - `.swiftlint.yml`で設定
 - `force_unwrapping`、`multiline_arguments`、`trailing_closure`などのopt-inルールを有効化
 - `identifier_name`、`statement_position`などのルールを無効化
-- `homete/`と`hometeTests/`ディレクトリのみをlint（ProjectToolsは除外）
+- `ProjectTools`・`DangerTools`・`LocalPackage/.build`・`LocalPackage/Package.swift`・`vendor`を除外し、それ以外をlint
 
 ### Xcode 26対応
 
@@ -222,17 +237,22 @@ Fastlaneのアップロードで`--use-old-altool`を使用。Xcode 26の新し�
 
 ### カスタムビルドツール（ProjectTools）
 
-開発ツールを含むSwift Package:
-- **SwiftLint 0.59.1**: コードスタイル強制
-- **Danger Swift 3.22.0**: PR自動化
-- **danger-swift-coverage**: コードカバレッジレポート
+開発ツールは2つのSwift Packageに分かれている。
 
-**Dangerfile** (`ProjectTools/Dangerfile.swift`):
-- PRの変更が500行を超えると警告
-- `homete/`の変更ファイルでSwiftLintを実行
-- `Build/test.xcresult`からコードカバレッジをレポート
+**`ProjectTools/`** - ビルド時に走るツール:
+- **SwiftLint 0.59.1**: バイナリをSPMプラグイン（`SwiftLintPlugin`）としてビルドに組み込み、`swift build` / `swift test` 実行時に自動でlintされる
+- **SwiftFormat 0.61.1**: `make format` から呼ぶ
+- ビルド: `swift build --package-path ProjectTools --scratch-path ProjectTools/.build`
 
-ビルド: `swift build --package-path ProjectTools --scratch-path ProjectTools/.build`
+**`DangerTools/`** - PR自動化（CIのみ）:
+- **Danger Swift 3.22.0** + **danger-swift-coverage**
+- **Dangerfile** (`DangerTools/Dangerfile.swift`):
+  - PRの変更が500行を超えると警告
+  - `homete/`の変更ファイルでSwiftLintを実行
+  - `Build/test.xcresult`からコードカバレッジをレポート
+  - VRTスナップショット（`hometeSnapshotTests/__Snapshots__/PreviewTests.generated`）の差分を報告
+
+> 注意: Dangerの`lintTargets`は`homete`のみで、実装コードの大半がある`LocalPackage/`はPR時のDanger lint対象外。ローカルではSPMプラグインが同じlintを実行するため検知はできる。
 
 ## エージェント
 
@@ -290,12 +310,15 @@ Swiftコードの実装完了後に使用する専用のコードレビューエ
 
 新機能を追加する際:
 
-1. **Views**: `homete/Views/`の適切な機能フォルダに追加（例: `HomeView/`、`SettingView/`）
-2. **ドメインモデル**: ドメイン領域別に`homete/Model/Domain/`のサブフォルダに追加
-3. **Clients**: `homete/Model/Dependencies/`でプロトコル定義、`.liveValue`と`.previewValue`を実装
-4. **Services**: `homete/Model/Service/`のサブフォルダにインフラコードを追加
-5. **Stores**: `homete/Model/Store/`にObservable状態管理クラスを追加
-6. **Tests**: `hometeTests/`でメインアプリの構造をミラー
+1. **Views**: `LocalPackage/Sources/Features/<機能名>Feature/` に追加
+2. **ドメインモデル**: ドメイン領域別に `LocalPackage/Sources/HometeDomain/` のサブフォルダに追加
+3. **Clients**: `LocalPackage/Sources/HometeDomain/Dependencies/` でプロトコルと`.previewValue`を定義し、`.liveValue`は `LocalPackage/Sources/HometeInfrastructure/` に実装
+4. **Services**: `LocalPackage/Sources/HometeInfrastructure/` のサブフォルダにインフラコードを追加
+5. **Stores**: `LocalPackage/Sources/HometeDomain/` の該当ドメインフォルダにObservable状態管理クラスを追加（機能固有のものは Feature 配下の `Model/` でもよい）
+6. **共通UI**: `LocalPackage/Sources/HometeUI/` に追加
+7. **Tests**: `LocalPackage/Tests/<対象モジュール>Tests/` に対象モジュールの構造をミラー
+
+新しいモジュールを足す場合は `LocalPackage/Package.swift` と [doc/multimodules_structure.md](doc/multimodules_structure.md) の両方を更新する。
 
 常にDependency Injectionパターンを使用 - ViewからServiceに直接アクセスしない。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,11 @@ Swiftコードの実装完了後に使用する専用のコードレビューエ
 
 - 対象を無闇に広げない。実際にそのルールが関係するディレクトリ・拡張子のみを`paths:`に指定する（例: Swift実装のみに関係するルールに`firebase/functions/**`を含めない）
 - プレーンテキストで「対象範囲: 〜のときのみ参照」のように書くだけでは自動スコープにならないため使わない。必ず`paths:`フロントマターで機能として制限する
-- 既存ルールも`paths:`を持つ: `swiftui-push-navigation.md`（`LocalPackage/Sources/**/*.swift`）
+- 既存ルールの`paths:`は以下の通り。`applyTo:`はスコープ機能として認識されないため使わないこと
+  - `**/*.swift`: `swift-code-verification.md`、`swiftui-push-navigation.md`、`prefire-canimport.md`
+  - `LocalPackage/Tests/**/*.swift`: `swift-test-implementation.md`
+  - `.claude/**` / `CLAUDE.md` / `.worktreeinclude`: `claude-config-update.md`
+  - `adr.md`のみ`paths:`を持たない（技術選定はファイル種別に紐づかないため意図的に常時ロード）
 
 ## ファイル整理の規約
 

--- a/Makefile
+++ b/Makefile
@@ -19,19 +19,19 @@ test-e2e: ## E2Eテストを実行
 
 build-local-package: ## LocalPackageをiOSシミュレーター向けにビルド
 	-pkill -f "$(CURDIR)/LocalPackage/.build" 2>/dev/null
-	swift build --package-path $(CURDIR)/LocalPackage --sdk $(shell xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios26.2-simulator
+	swift build --package-path $(CURDIR)/LocalPackage --disable-sandbox --sdk $(shell xcrun --sdk iphonesimulator --show-sdk-path) --triple arm64-apple-ios26.2-simulator
 
 test-packages: ## LocalPackageのテストを実行（自worktreeのstaleプロセスのみ掃除してから実行、他worktreeには影響しない）
 	-pkill -f "swift-test --package-path $(CURDIR)/LocalPackage" 2>/dev/null
 	-pkill -f "$(CURDIR)/LocalPackage/.build" 2>/dev/null
-	swift test --package-path $(CURDIR)/LocalPackage --enable-code-coverage
+	swift test --package-path $(CURDIR)/LocalPackage --disable-sandbox --enable-code-coverage
 
 install-hooks: ## git hooks（pre-commitでSwiftFormat実行）を有効化
 	git config core.hooksPath scripts/git-hooks
 	@echo "✅ git hooksを scripts/git-hooks に設定しました"
 
 format: ## プロダクション+テストコード全体にSwiftFormatを実行
-	swift package --package-path ProjectTools plugin \
+	swift package --package-path ProjectTools --disable-sandbox plugin \
 		--allow-writing-to-package-directory \
 		--allow-writing-to-directory $(CURDIR) \
 		swiftformat --config .swiftformat \

--- a/doc/adr/0006-claude-code-autonomous-execution.md
+++ b/doc/adr/0006-claude-code-autonomous-execution.md
@@ -1,0 +1,55 @@
+## タイトル: Claude Codeの自律実行を成立させる（サンドボックス・許可モード・検証フック）
+
+* **ステータス: 承認済**
+* 意思決定者: @stotic-dev
+* 日付: 2026-08-09
+* 技術的背景: Claude Code v2.1.226 / [permission modes](https://code.claude.com/docs/en/permission-modes) / [sandboxing](https://code.claude.com/docs/en/sandboxing)
+
+## 文脈、背景や問題点の説明
+
+Claude Code に実装を任せても、`swift build` / `swift test` のたびに許可プロンプトが出て停止するため、開発者が張り付いていないと作業が進まなかった。許可ルール（`permissions.allow`）を追加し続けた結果 190 件超まで肥大したが、プロンプトは減らなかった。
+
+原因は許可ルールの不足ではなく、**プロンプトの発生源が許可ルールの管轄外だったこと**にある。あわせて、検証手順がスキル・ルール上の「お願い」でしかなく、Claude が読み飛ばせばビルドが壊れたままターンが終わる構造も残っていた。
+
+## 決定事項
+
+* **SwiftPM は `--disable-sandbox`（SwiftPM 自身のフラグ）で Claude のサンドボックス内で実行する**。`dangerouslyDisableSandbox: true` は使わない
+* **`permissions.defaultMode` を `auto` にする**（`~/.claude/settings.json`。project / local 設定では仕様上無視されるため）
+* **`Stop` フックで `make test-packages` を実行し、失敗時は exit 2 で Claude を起こす**（`scripts/claude-verify-swift.sh`）
+* SwiftPM / SwiftLint のキャッシュ書き込み先を `sandbox.filesystem.allowWrite` で許可し、コミット対象の `.claude/settings.json` に置いてチームで共有する
+
+### なぜ `dangerouslyDisableSandbox` が問題だったか
+
+SwiftPM はマニフェスト評価を自前の `sandbox-exec` で行うため、Claude のサンドボックス内ではネストして失敗する。これを回避するため `dangerouslyDisableSandbox: true` を使う運用にしていたが、この引数は**サンドボックス外実行なので通常の許可フローに戻り、allow ルールの有無に関係なく毎回ゲートを通る**。`Bash(swift *)` を許可済みでも無意味だった。
+
+`--disable-sandbox` は SwiftPM 側のサンドボックスだけを切るので、コマンドは Claude のサンドボックス内で完結し、`autoAllowBashIfSandboxed: true` により無確認で走る。ネットワーク・ファイルシステムの隔離は維持される。
+
+## 考慮した選択肢
+
+* **`sandbox.excludedCommands` に `swift` を追加** — SwiftPM をサンドボックス外で動かす。隔離が丸ごと外れるうえ、公式も「ツールに書き込みが必要なだけなら `allowWrite` を使うほうが望ましい」としているため不採用
+* **`sandbox.enabled: false`** — 隔離を全廃。ネットワーク経由の情報漏洩に対する防御が消えるため不採用
+* **`permissions.defaultMode: "bypassPermissions"`** — 全チェックを飛ばす。公式が隔離環境専用としており、ローカル開発機には不適切なため不採用
+* **`defaultMode: "acceptEdits"` のまま許可ルールを足し続ける** — 現状維持。保護パス（`.claude/`）・未許可ドメイン・サンドボックス外実行のいずれも allow ルールでは消せないため、根本解決にならない
+* **検証を `PostToolUse` フックで走らせる** — Swift ファイル編集のたびにテスト全体が走り遅すぎる。`Stop` なら1ターンに1回で済むため不採用
+
+## 決定結果
+
+### 決定にあたり考慮したメリット
+
+* 開発者が張り付かなくても実装〜検証が進む
+* 検証がスキルの記述ではなく harness の実行に変わり、確実に走る。ビルドが壊れたままターンが終わらなくなる
+* サンドボックスの隔離境界を維持したまま実現できる（プロンプト削減と安全性のトレードオフを最小化）
+* SwiftPM / SwiftLint のキャッシュが効くようになり、ビルド自体も速くなる
+
+### 決定にあたり考慮したデメリット
+
+* auto mode は分類器がリスクを判定するもので、安全を保証しない。公式も「方向性を信頼できる作業に使い、機微な操作のレビュー代替にはするな」としている
+* 分類器の判定に往復のレイテンシとトークンコストがかかる
+* `--disable-sandbox` により、人間が `make` を叩くときも SwiftPM のマニフェストサンドボックスが無効になる。CI・ローカルとも同じ挙動に揃える方を優先した
+* `Stop` フックの分だけターン終了が遅くなる（Swift 変更が無ければスキップ、前回検証から変化が無ければスキップ、で軽減）
+* 3回連続失敗で自動検証を止める設計のため、それ以降は人間の確認が要る
+
+## 参考
+
+* 手順とトラブルシュートは `.claude/skills/swift-code-verification/SKILL.md` と `~/.claude/skills/improve-setting/SKILL.md`
+* [LoopsBench (arXiv:2608.00267)](https://arxiv.org/abs/2608.00267) — 長時間の自律ループでは最強構成でも解決率25%にとどまり、全構成でリグレッションが継続的に発生する。検証を決定論的に閉じる根拠

--- a/scripts/claude-verify-swift.sh
+++ b/scripts/claude-verify-swift.sh
@@ -21,13 +21,26 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT" || exit 0
 
-STATE_DIR="$REPO_ROOT/.git/claude-verify"
+# 状態の置き場は git 経由で解決する。リンクされた worktree では $REPO_ROOT/.git が
+# ディレクトリではなくファイル（実体へのポインタ）なので、直に .git/ を掘ると失敗する。
+# --absolute-git-dir は worktree ごとの metadata ディレクトリを返すため、fingerprint と
+# 失敗カウントが worktree 間で混ざることもない。
+GIT_DIR="$(git rev-parse --absolute-git-dir 2>/dev/null)"
+if [[ -z "$GIT_DIR" ]]; then
+    printf '{"systemMessage":"Swift検証: git ディレクトリを解決できないため検証をスキップしました。"}\n'
+    exit 0
+fi
+
+STATE_DIR="$GIT_DIR/claude-verify"
 STAMP_FILE="$STATE_DIR/last-verified"
 FAIL_COUNT_FILE="$STATE_DIR/consecutive-failures"
 LOG_FILE="$STATE_DIR/last-run.log"
 MAX_CONSECUTIVE_FAILURES=3
 
-mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+if ! mkdir -p "$STATE_DIR" 2>/dev/null; then
+    printf '{"systemMessage":"Swift検証: 状態ディレクトリ %s を作成できないため検証をスキップしました。"}\n' "$STATE_DIR"
+    exit 0
+fi
 
 # --- 変更された Swift ファイルがあるか判定 --------------------------------
 

--- a/scripts/claude-verify-swift.sh
+++ b/scripts/claude-verify-swift.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Claude Code の Stop フックから呼ばれる Swift 検証スクリプト。
+#
+# 目的:
+#   検証手順をスキル/ルールに「お願い」として書くだけだと、Claude が読み飛ばした
+#   場合にビルドが壊れたままターンが終わる。フックは harness が実行するので確実に
+#   走り、失敗時は exit 2 で Claude を叩き起こして修正させられる。
+#
+# 挙動:
+#   - Swift ファイルに変更が無ければ何もしない（exit 0）
+#   - 前回検証が通った時点から変化が無ければ何もしない（exit 0）
+#   - make test-packages を実行（SwiftPMビルド + SwiftLintプラグイン + ユニットテスト）
+#   - 失敗したら要約を stdout に出して exit 2（Claude が起こされる）
+#   - 3回連続で失敗したら諦めて exit 0（無限ループ防止）
+#
+# 手動実行してデバッグする場合:
+#   echo '{}' | scripts/claude-verify-swift.sh; echo "exit=$?"
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT" || exit 0
+
+STATE_DIR="$REPO_ROOT/.git/claude-verify"
+STAMP_FILE="$STATE_DIR/last-verified"
+FAIL_COUNT_FILE="$STATE_DIR/consecutive-failures"
+LOG_FILE="$STATE_DIR/last-run.log"
+MAX_CONSECUTIVE_FAILURES=3
+
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+
+# --- 変更された Swift ファイルがあるか判定 --------------------------------
+
+# 未コミットの変更（追跡外の新規ファイルも含む）
+uncommitted="$(git status --porcelain -uall -- '*.swift' 2>/dev/null)"
+
+# ブランチ上でコミット済みの変更（main から分岐して以降）
+committed=""
+if base="$(git merge-base HEAD main 2>/dev/null)"; then
+    committed="$(git diff --name-only "$base"...HEAD -- '*.swift' 2>/dev/null)"
+fi
+
+if [[ -z "$uncommitted" && -z "$committed" ]]; then
+    exit 0
+fi
+
+# --- 前回検証時から変化があるか判定 ----------------------------------------
+
+fingerprint="$(
+    {
+        git rev-parse HEAD 2>/dev/null
+        printf '%s\n' "$uncommitted"
+        git diff HEAD -- '*.swift' 2>/dev/null
+        # 追跡外ファイルは内容も含める（git diff に出てこないため）
+        git ls-files --others --exclude-standard -- '*.swift' 2>/dev/null \
+            | while IFS= read -r f; do [[ -f "$f" ]] && shasum -a 256 "$f"; done
+    } | shasum -a 256 | cut -d' ' -f1
+)"
+
+if [[ -f "$STAMP_FILE" && "$(cat "$STAMP_FILE" 2>/dev/null)" == "$fingerprint" ]]; then
+    exit 0
+fi
+
+# --- 連続失敗のガード -------------------------------------------------------
+
+fail_count=0
+[[ -f "$FAIL_COUNT_FILE" ]] && fail_count="$(cat "$FAIL_COUNT_FILE" 2>/dev/null || echo 0)"
+[[ "$fail_count" =~ ^[0-9]+$ ]] || fail_count=0
+
+if (( fail_count >= MAX_CONSECUTIVE_FAILURES )); then
+    echo 0 > "$FAIL_COUNT_FILE"
+    printf '{"systemMessage":"Swift検証が%d回連続で失敗したため自動検証を停止しました。%s を確認してください。"}\n' \
+        "$MAX_CONSECUTIVE_FAILURES" "${LOG_FILE#"$REPO_ROOT"/}"
+    exit 0
+fi
+
+# --- 検証実行 ---------------------------------------------------------------
+
+if make test-packages > "$LOG_FILE" 2>&1; then
+    echo "$fingerprint" > "$STAMP_FILE"
+    echo 0 > "$FAIL_COUNT_FILE"
+    exit 0
+fi
+
+attempt=$((fail_count + 1))
+echo "$attempt" > "$FAIL_COUNT_FILE"
+
+echo "make test-packages が失敗しました（${attempt}回目 / 上限${MAX_CONSECUTIVE_FAILURES}回）。以下を修正してから終了してください。"
+echo
+echo "--- エラー抜粋 ---"
+grep -E "error:|error :|failed|✘|Fatal error|Test .* failed" "$LOG_FILE" | tail -40
+echo
+echo "--- 末尾 ---"
+tail -25 "$LOG_FILE"
+echo
+echo "全文: ${LOG_FILE#"$REPO_ROOT"/}"
+
+exit 2


### PR DESCRIPTION
## 経緯

Claude Code に実装を任せても `swift build` / `swift test` のたびに許可プロンプトが出て停止するため、開発者が張り付いていないと作業が進まない状態だった。許可ルールを追加し続けた結果 190 件超まで肥大したが、プロンプトは減らなかった。

調べたところ、原因は許可ルールの不足ではなく**プロンプトの発生源が許可ルールの管轄外だったこと**にある。あわせて、検証手順がスキル・ルール上の「お願い」でしかなく、Claude が読み飛ばせばビルドが壊れたままターンが終わる構造も残っていた。

関連 Issue なし。設計判断の経緯は ADR-0006 に記載。

## 実装内容

### 1. SwiftPM を Claude のサンドボックス内で実行する（`d83e0c4`）

SwiftPM はマニフェスト評価を自前の `sandbox-exec` で行うため、Claude のサンドボックス内ではネストして失敗する。これを回避するため `dangerouslyDisableSandbox: true` を使う運用にしていたが、**この引数はサンドボックス外実行なので通常の許可フローに戻り、allow ルールの有無に関係なく毎回ゲートを通る**。`Bash(swift *)` を許可済みでも無意味だった。

SwiftPM 側のサンドボックスだけを切る `--disable-sandbox` に置き換えることで、コマンドが Claude のサンドボックス内で完結し、`autoAllowBashIfSandboxed` により無確認で走るようになる。ネットワーク・ファイルシステムの隔離は維持される。Makefile の `build-local-package` / `test-packages` / `format` に付与し、人間・CI・Claude で分岐が生まれないようにした。

### 2. キャッシュ書き込み許可をチーム共有設定へ（`e7703c9`）

このプロジェクトで SwiftPM ビルドを回すと、SwiftLint プラグインが `~/Library/Caches/SwiftLint` への書き込みで必ず失敗し、SwiftPM 自身もマニフェストキャッシュを書けず毎回フルパースになる。環境ではなくプロジェクトの性質に由来する要件なので、開発者ごとにローカル設定を書かせず `.claude/settings.json` で共有する。ツールをサンドボックスから除外する `excludedCommands` ではなく `filesystem.allowWrite` を使うのは、隔離境界を保ったまま必要な書き込みだけを開けるため（公式も推奨）。

### 3. Stop フックで検証ループを閉じる（`cd497a4`）

検証手順の遵守を Claude の判断に委ねている限り、読み飛ばされる経路が残る。フックは harness が実行するので確実に走る。

`scripts/claude-verify-swift.sh` がターン終了時に動き、Swift に変更があれば `make test-packages` を実行、失敗時は exit 2 で Claude を起こして修正させる（`asyncRewake`）。無駄打ちと無限ループを避けるため、Swift 変更が無ければスキップ、前回検証時から fingerprint が変わっていなければスキップ、3 回連続失敗で自動検証を停止する設計にした。

`PostToolUse` ではなく `Stop` を選んだのは、ファイル編集のたびにテスト全体が走ると遅すぎるため。

### 4. CLAUDE.md を実際のコード構成に合わせる（`03b0ed5`）

マルチモジュール化（ADR-0001）以降、CLAUDE.md の記述が実態と乖離したままだった。`homete/Model/` は既に存在せず、`hometeTests/` も `CI.xctestplan` も無い。CLAUDE.md は毎ターン読み込まれるため、古いパスはエージェントを存在しない場所へ直接誘導する。

実構造に修正したうえで、詳細は `doc/multimodules_structure.md` へのリンクに寄せて重複を持たせないようにした。最頻出の `make test-packages` / `build-local-package` / `format` が「よく使うコマンド」に載っていなかったので追加。Dangerfile が `DangerTools/` 配下である点と、その `lintTargets` が `homete` のみで `LocalPackage/` をカバーしていない点も注記した。

### 5. パッケージ取得先の事前許可（`4dc3f95`）

サンドボックスはドメインを 1 つも事前許可しないため、未許可ホストへの通信が必要になった時点でコマンドがサンドボックス外へ落ち、プロンプトが出る。`swift build` のパッケージ解決は tarball を `codeload` / `objects.githubusercontent.com` から取得するので、これらを `allowedDomains` に登録して通信をサンドボックス内で完結させる。

### 6. ルールの `paths:` スコープ修正（`ef3a09f` ほか）

`.claude/rules/` の 4 ファイルが `applyTo:` を使っていたか frontmatter を持たず、Claude Code のスコープ機能として認識されずに常時ロードされていた。`paths:` に統一し、Swift を触らないセッションでコンテキストを浪費しないようにした。

## 確認内容

- [x] `swift package --disable-sandbox dump-package` がサンドボックス内で exit 0 になること（素の実行は `sandbox-exec: sandbox_apply: Operation not permitted` で失敗することを対照確認）
- [x] `make -n build-local-package` / `test-packages` / `format` の 3 ターゲットで `--disable-sandbox` のフラグ位置が正しいこと
- [x] Stop フックが Swift 変更なしのとき exit 0 で即スキップすること
- [x] Stop フックが、意図的にコンパイルエラーを含む Swift ファイルを置いた状態で exit 2 を返し、エラー抜粋を出力すること（確認後クリーンアップ済み）
- [x] `.claude/settings.json` / `settings.local.json` / `~/.claude/settings.json` の 3 ファイルが JSON として妥当で、意図したキーが入っていること（`jq -e`）
- [x] `.claude/rules/` 全ファイルに `applyTo:` が残っておらず、`paths:` が YAML として解釈できること
- [ ] **レビュアー向け**: Claude Code を再起動し、Swift を編集してターンを終えたときに「Swift検証中（ビルド・SwiftLint・テスト）」が表示されること（`hooks` / `sandbox.*` はセッション開始時にのみ読まれるため再起動が必要）

## 補足

`permissions.defaultMode: "auto"` への変更も同時に行っているが、これは `~/.claude/settings.json`（コミット対象外）にある。`auto` はリポジトリが自分自身に auto mode を与えられないよう project / local 設定では無視される仕様のため、ユーザー設定に置くしかない。各自で設定する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)