### PR TITLE
ci: FunctionsのSTGデプロイをCIで自動化する

### DIFF
--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -1,0 +1,81 @@
+name: Deploy Functions
+
+# E2Eテストの成功を前提にデプロイしたいため、pushではなく
+# Firebase Functions E2E Test の完了を受けて発火する。
+# 発火元がpathsで firebase/functions/** に絞られているので、
+# このワークフロー側でpathsを指定しなくても対象変更時のみ動く。
+on:
+  workflow_run:
+    workflows: ["Firebase Functions E2E Test"]
+    types:
+      - completed
+  workflow_dispatch:
+
+# デプロイ同士が並走すると Cloud Functions 側で競合するため直列化する
+concurrency:
+  group: deploy-functions
+  cancel-in-progress: false
+
+env:
+  NODE_VERSION: "22"
+  FUNCTIONS_DIR: firebase/functions
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # workflow_dispatch（手動実行）か、mainへのpushで走ったE2Eが成功したときだけデプロイする。
+    # PR上のE2E成功で走らないよう event と head_branch も見る。
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main')
+
+    steps:
+      # workflow_run はデフォルトブランチのHEADをチェックアウトするため、
+      # 実際にテストが通ったコミットを明示的に指定する
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: "npm"
+          cache-dependency-path: ${{ env.FUNCTIONS_DIR }}/package-lock.json
+
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      # firebase.json の predeploy が npm run lint / build を実行するため、
+      # デプロイ前に functions 配下の依存を入れておく必要がある
+      - name: Install dependencies
+        working-directory: ${{ env.FUNCTIONS_DIR }}
+        run: npm ci
+
+      - name: Write Service Account JSON
+        run: |
+          if [ -z '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' ]; then
+            echo "::error::FIREBASE_SERVICE_ACCOUNT secret is not set"
+            exit 1
+          fi
+          echo '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}' > /tmp/service-account.json
+
+      - name: Deploy Functions
+        run: firebase deploy --only functions --non-interactive
+        working-directory: firebase
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: /tmp/service-account.json
+
+      - name: Create deploy summary
+        if: always()
+        run: |
+          {
+            echo "## Deploy Functions"
+            echo ""
+            echo "- **Result**: ${{ job.status }}"
+            echo "- **Commit**: \`${{ github.event.workflow_run.head_sha || github.sha }}\`"
+            echo "- **Triggered by**: ${{ github.event_name }}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -10,6 +10,13 @@ on:
     types:
       - completed
   workflow_dispatch:
+  # TODO: マージ前に削除する。
+  # workflow_run はデフォルトブランチ上の定義でしか発火しないため、
+  # このワークフロー自体をPR上で動作確認する手段がない。
+  # 検証のあいだだけ作業ブランチのpushで発火させる。
+  push:
+    branches:
+      - "ci/deploy-functions"
 
 # デプロイ同士が並走すると Cloud Functions 側で競合するため直列化する
 concurrency:
@@ -25,8 +32,10 @@ jobs:
     runs-on: ubuntu-latest
     # workflow_dispatch（手動実行）か、mainへのpushで走ったE2Eが成功したときだけデプロイする。
     # PR上のE2E成功で走らないよう event と head_branch も見る。
+    # `github.event_name == 'push'` は上のTODOと同じく検証用。マージ前に削除する。
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_branch == 'main')

--- a/.github/workflows/deploy-functions.yml
+++ b/.github/workflows/deploy-functions.yml
@@ -10,13 +10,6 @@ on:
     types:
       - completed
   workflow_dispatch:
-  # TODO: マージ前に削除する。
-  # workflow_run はデフォルトブランチ上の定義でしか発火しないため、
-  # このワークフロー自体をPR上で動作確認する手段がない。
-  # 検証のあいだだけ作業ブランチのpushで発火させる。
-  push:
-    branches:
-      - "ci/deploy-functions"
 
 # デプロイ同士が並走すると Cloud Functions 側で競合するため直列化する
 concurrency:
@@ -32,10 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     # workflow_dispatch（手動実行）か、mainへのpushで走ったE2Eが成功したときだけデプロイする。
     # PR上のE2E成功で走らないよう event と head_branch も見る。
-    # `github.event_name == 'push'` は上のTODOと同じく検証用。マージ前に削除する。
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'push' ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.event == 'push' &&
        github.event.workflow_run.head_branch == 'main')

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,10 +182,25 @@ launching → notLoggedIn → Sign In with Apple
 1. **`ci_danger.yml`** - PR作成時に実行
    - Danger実行（SwiftLint、カバレッジレポート）
 
-2. **`functions-e2e-test.yml`** - Firebase Functionsテスト
-   - `firebase/dev/functions/**`への変更でトリガー
+2. **`ci_local_package.yml`** - LocalPackageのユニットテスト
+   - `LocalPackage/**`への変更でトリガー（macos-26 / Xcode 26.4.1）
+
+3. **`functions-e2e-test.yml`** - Firebase Functionsテスト
+   - `firebase/functions/**`への変更でトリガー（PR / mainまたはrelease/*へのpush）
    - ESLintとE2Eテストを実行
    - Node.js 21とJava 21を使用
+
+4. **`deploy-functions.yml`** - Firebase FunctionsをSTGへデプロイ
+   - `functions-e2e-test.yml`の完了を`workflow_run`で受けて発火し、mainへのpushかつ成功時のみデプロイ
+   - `firebase deploy --only functions`（`firebase.json`のpredeployでlint+buildが走る）
+   - `workflow_dispatch`で手動デプロイも可能
+
+5. **`deploy-firestore-indexes.yml`** - Firestoreインデックスのデプロイ
+   - `firebase/firestore.indexes.json`のmainへのpushでトリガー
+
+6. **`create-release-note.yaml`** - リリースノート生成
+
+デプロイ先は`firebase/.firebaserc`のdefaultプロジェクト（`homete-ios-dev-e3ef7`）。認証は`FIREBASE_SERVICE_ACCOUNT` secretのサービスアカウントJSONを使う。
 
 **Xcode Cloudワークフロー:**
 

--- a/doc/adr/0008-deploy-functions-workflow.md
+++ b/doc/adr/0008-deploy-functions-workflow.md
@@ -42,7 +42,7 @@ Firestoreインデックスは `deploy-firestore-indexes.yml` で自動デプロ
 
 ### 決定にあたり考慮したデメリット
 
-* `workflow_run` はデフォルトブランチ上のワークフロー定義でしか動かないため、このワークフロー自体の変更はmainにマージするまで実際の挙動を検証できない。検証したい場合は作業ブランチの `push` を一時的にトリガーへ追加し、確認後にマージ前に外す運用とする
+* `workflow_run` はデフォルトブランチ上のワークフロー定義でしか動かないため、このワークフロー自体の変更はmainにマージするまで実際の挙動を検証できない
 * 発火元（`functions-e2e-test.yml`）の `name:` を変えると連鎖が黙って切れる。ワークフロー名が実質的な結合点になっている
 * デプロイのトリガーが間接的になり、GitHubのUI上で「このpushがデプロイした」という繋がりが追いにくい（サマリにcommit SHAを出して緩和する）
 * `FIREBASE_SERVICE_ACCOUNT` に Functions デプロイ相当の権限（Cloud Functions 管理者 / サービスアカウントユーザー / Cloud Build / Artifact Registry）が必要。インデックスデプロイ用の権限だけでは足りない可能性がある

--- a/doc/adr/0008-deploy-functions-workflow.md
+++ b/doc/adr/0008-deploy-functions-workflow.md
@@ -42,7 +42,7 @@ Firestoreインデックスは `deploy-firestore-indexes.yml` で自動デプロ
 
 ### 決定にあたり考慮したデメリット
 
-* `workflow_run` はデフォルトブランチ上のワークフロー定義でしか動かないため、このワークフロー自体の変更はmainにマージするまで実際の挙動を検証できない
+* `workflow_run` はデフォルトブランチ上のワークフロー定義でしか動かないため、このワークフロー自体の変更はmainにマージするまで実際の挙動を検証できない。検証したい場合は作業ブランチの `push` を一時的にトリガーへ追加し、確認後にマージ前に外す運用とする
 * 発火元（`functions-e2e-test.yml`）の `name:` を変えると連鎖が黙って切れる。ワークフロー名が実質的な結合点になっている
 * デプロイのトリガーが間接的になり、GitHubのUI上で「このpushがデプロイした」という繋がりが追いにくい（サマリにcommit SHAを出して緩和する）
 * `FIREBASE_SERVICE_ACCOUNT` に Functions デプロイ相当の権限（Cloud Functions 管理者 / サービスアカウントユーザー / Cloud Build / Artifact Registry）が必要。インデックスデプロイ用の権限だけでは足りない可能性がある

--- a/doc/adr/0008-deploy-functions-workflow.md
+++ b/doc/adr/0008-deploy-functions-workflow.md
@@ -1,0 +1,55 @@
+## Functionsの自動デプロイ: E2E成功を条件にworkflow_runで発火させる
+
+* **ステータス: 承認済**
+* 意思決定者: @stotic-dev
+* 日付: 2026-08-09
+* 技術的背景やその他関連チケット No: [#192](https://github.com/stotic-dev/homete_iOS/issues/192) / [#202](https://github.com/stotic-dev/homete_iOS/pull/202)
+
+## 文脈、背景や問題点の説明
+
+Cloud FunctionsのデプロイはCIに存在せず、`make deploy`（= `firebase deploy --only functions`）の手動実行のみだった。そのためmainにマージしてもSTGには反映されず、反映漏れや「誰がいつ何を入れたか」が追えない状態になっていた。実際 Issue #192 の修正も、マージだけでは実環境の挙動が変わらない。
+
+Firestoreインデックスは `deploy-firestore-indexes.yml` で自動デプロイされているので、Functionsも同様に自動化したい。ただしインデックスと違い、Functionsは壊れたコードがそのまま実行環境に載るため、デプロイ前の検証をどう担保するかを決める必要がある。
+
+## 決定事項
+
+* `deploy-functions.yml` を追加し、`firebase deploy --only functions --non-interactive` をCIから実行する
+* 発火条件は `push` ではなく `workflow_run`（`Firebase Functions E2E Test` の完了）とし、**E2Eが成功したときだけ**デプロイする
+* さらに `github.event.workflow_run.event == 'push'` と `head_branch == 'main'` を条件に加え、PR上のE2E成功では発火させない
+* チェックアウトは `github.event.workflow_run.head_sha` を明示指定し、テストが通ったコミットそのものをデプロイする
+* `concurrency: deploy-functions` でデプロイを直列化する
+* 緊急時のために `workflow_dispatch` による手動実行も残す
+
+## 考慮した選択肢
+
+* **選択肢1: `deploy-firestore-indexes.yml` と同じく、mainへのpush + pathsで直接発火する**
+  * 既存ワークフローと形が揃い、YAMLが最も単純
+  * ただしテストの成否と無関係にデプロイされる。PRの必須チェックに頼る前提になり、squash mergeの取り違えや管理者マージで簡単に穴が開く
+* **選択肢2: デプロイワークフロー内でE2Eも実行し、job間の `needs` で繋ぐ**
+  * 依存関係が1ファイルで完結して読みやすい
+  * `functions-e2e-test.yml` とジョブ定義がまるごと重複し、エミュレータ起動を含む数分のテストがmainへのpushで二重に走る
+* **選択肢3: `workflow_run` でE2Eの成功を受けて発火する（採用）**
+
+## 決定結果
+
+### 決定にあたり考慮したメリット
+
+* テストが緑のコミットしかSTGに出ないことをCIレベルで保証できる。ブランチ保護の設定に依存しない
+* E2Eワークフローが `firebase/functions/**` のpathsで既に絞られているため、デプロイ側でpathsを二重管理しなくても対象変更時のみ動く
+* テストの重複実行がなく、mainへのpush1回あたりのCI時間が増えない
+* `head_sha` を明示チェックアウトするので、テスト実行後にmainが進んでも「検証していないコード」をデプロイしない
+* `firebase.json` の predeploy がlintとbuildを実行するため、デプロイ直前にもう一段の検証が入る
+
+### 決定にあたり考慮したデメリット
+
+* `workflow_run` はデフォルトブランチ上のワークフロー定義でしか動かないため、このワークフロー自体の変更はmainにマージするまで実際の挙動を検証できない
+* 発火元（`functions-e2e-test.yml`）の `name:` を変えると連鎖が黙って切れる。ワークフロー名が実質的な結合点になっている
+* デプロイのトリガーが間接的になり、GitHubのUI上で「このpushがデプロイした」という繋がりが追いにくい（サマリにcommit SHAを出して緩和する）
+* `FIREBASE_SERVICE_ACCOUNT` に Functions デプロイ相当の権限（Cloud Functions 管理者 / サービスアカウントユーザー / Cloud Build / Artifact Registry）が必要。インデックスデプロイ用の権限だけでは足りない可能性がある
+
+## 参考
+
+* [GitHub Actions: workflow_run](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_run)
+* `.github/workflows/deploy-functions.yml`
+* `.github/workflows/functions-e2e-test.yml`
+* `.github/workflows/deploy-firestore-indexes.yml`

--- a/doc/adr/0008-deploy-functions-workflow.md
+++ b/doc/adr/0008-deploy-functions-workflow.md
@@ -42,10 +42,23 @@ Firestoreインデックスは `deploy-firestore-indexes.yml` で自動デプロ
 
 ### 決定にあたり考慮したデメリット
 
-* `workflow_run` はデフォルトブランチ上のワークフロー定義でしか動かないため、このワークフロー自体の変更はmainにマージするまで実際の挙動を検証できない
+* `workflow_run` はデフォルトブランチ上のワークフロー定義でしか動かないため、このワークフロー自体の変更はmainにマージするまで実際の挙動を検証できない。検証したい場合は作業ブランチの `push` を一時的にトリガーへ追加し、確認後にマージ前へrevertする運用とする
 * 発火元（`functions-e2e-test.yml`）の `name:` を変えると連鎖が黙って切れる。ワークフロー名が実質的な結合点になっている
 * デプロイのトリガーが間接的になり、GitHubのUI上で「このpushがデプロイした」という繋がりが追いにくい（サマリにcommit SHAを出して緩和する）
-* `FIREBASE_SERVICE_ACCOUNT` に Functions デプロイ相当の権限（Cloud Functions 管理者 / サービスアカウントユーザー / Cloud Build / Artifact Registry）が必要。インデックスデプロイ用の権限だけでは足りない可能性がある
+* `FIREBASE_SERVICE_ACCOUNT` にインデックスデプロイ用の権限だけでは足りず、GCP側の設定追加が必要だった（下記）
+
+## GCP側の前提設定
+
+`FIREBASE_SERVICE_ACCOUNT` のサービスアカウントに対し、`homete-ios-dev-e3ef7` で以下が必要（動作確認時に実際に不足していたもの）。
+
+* **サービス アカウント ユーザー**（`roles/iam.serviceAccountUser`）
+  * Functionsのデプロイは実行SA `homete-ios-dev-e3ef7@appspot.gserviceaccount.com` として振る舞う（`iam.serviceAccounts.actAs`）操作を含むため必須
+  * 「サービス アカウント トークン作成者」は別ロールで、`actAs` を含まないので代替にならない
+* **Cloud Billing API の有効化**
+  * firebase-toolsがデプロイ前に必要APIの有効化を試み、無効だと `Permissions denied enabling cloudbilling.googleapis.com` で落ちる
+  * SAに `roles/serviceusage.serviceUsageAdmin` を与えて自動有効化させる手もあるが、権限が広いためAPIを手動で有効化する方を選んだ
+
+Cloud Functions管理者・ストレージ管理者は付与済みだった。Cloud Build / Artifact Registry の権限は呼び出し側SAには不要で、Cloud Functionsのサービスエージェントが実行する。
 
 ## 参考
 


### PR DESCRIPTION
## 経緯

Cloud Functions のデプロイが CI に存在せず、`make deploy`（= `firebase deploy --only functions`）の手動実行のみでした。そのため main にマージしても STG には反映されず、反映漏れや「誰がいつ何を入れたか」が追えない状態になっていました。

実際、#192 の修正（#202 でマージ済み）も、マージだけでは STG の挙動が変わりません。

Firestore インデックスは `deploy-firestore-indexes.yml` で自動デプロイされているので、Functions も同様に自動化します。

## 実装内容

`.github/workflows/deploy-functions.yml` を追加しました。判断の経緯は [ADR-0008](doc/adr/0008-deploy-functions-workflow.md) に記載しています。

### なぜ push ではなく `workflow_run` で発火させるか

インデックスと違い Functions は壊れたコードがそのまま実行環境に載るため、デプロイ前の検証を CI レベルで担保したいためです。

`deploy-firestore-indexes.yml` と同じく main への push で直接発火させると、テストの成否と無関係にデプロイされます。PR の必須チェックに頼る前提になり、管理者マージなどで簡単に穴が開きます。

かといってデプロイワークフロー内で E2E も実行すると、`functions-e2e-test.yml` とジョブ定義がまるごと重複し、エミュレータ起動を含む数分のテストが main への push で二重に走ります。

そこで `Firebase Functions E2E Test` の完了を `workflow_run` で受け、**E2E が成功したときだけ**デプロイする形にしました。発火元が `firebase/functions/**` の paths で絞られているため、デプロイ側で paths を二重管理しなくても対象変更時のみ動きます。

### その他の判断

- **`event == 'push'` と `head_branch == 'main'` を条件に追加**: `workflow_run` は PR 上の E2E 成功でも発火するため、それを除外する
- **`head_sha` を明示チェックアウト**: `workflow_run` はデフォルトブランチの HEAD を見るため、指定しないと「テストしていないコード」をデプロイしうる
- **`concurrency: deploy-functions`**: デプロイ同士が並走すると Cloud Functions 側で競合するため直列化
- **デプロイ前に `npm ci`**: `firebase.json` の predeploy が `npm run lint` / `npm run build` を実行するため、functions 配下の依存が必要
- **`workflow_dispatch` を残す**: 緊急時の手動デプロイ経路

### 付随修正

`CLAUDE.md` の CI 一覧を実態に合わせました。`functions-e2e-test.yml` の発火パスが `firebase/dev/functions/**` のままだった（#202 で直したのに記述が追随していなかった）ほか、`ci_local_package.yml` / `deploy-firestore-indexes.yml` / `create-release-note.yaml` が未記載でした。

## 確認内容

- [x] actionlint 1.7.7 で構文・式ともに指摘なし
- [x] predeploy で走る `npm run lint` / `npm run build` がローカルで成功（既存の warning 3 件のみ、error なし）
- [ ] このブランチへの push で Deploy Functions が実際に成功すること

### ⚠️ マージ前に必ず revert するコミット

`workflow_run` はデフォルトブランチ上のワークフロー定義でしか発火しないため、このワークフロー自体を PR 上で動作確認する手段がありません。検証のためだけに `ci/deploy-functions` への push をトリガーへ追加しています。

- 対象コミット: `7d835ac` ci: 動作確認のため作業ブランチのpushで暫定的に発火させる
- 動作確認後、マージ前に revert すること

### 注意

- このブランチの push により、**#192 の修正が STG に実デプロイされます**（functions のソースは main と同一）
- `FIREBASE_SERVICE_ACCOUNT` に Functions デプロイ相当の権限（Cloud Functions 管理者 / サービスアカウントユーザー / Cloud Build / Artifact Registry）が必要です。インデックスデプロイ用の権限しか付いていない場合は失敗します

🤖 Generated with [Claude Code](https://claude.com/claude-code)